### PR TITLE
Add python-multipart dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ README.md
 1. Install dependencies:
 
    ```bash
-   pip install fastapi uvicorn jinja2 requests lxml python-dotenv
+   pip install fastapi uvicorn jinja2 requests lxml python-dotenv python-multipart
    ```
 
 2. Export environment variables:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY app /app
-RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 requests lxml python-dotenv
+RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 requests lxml python-dotenv python-multipart
 EXPOSE 9595
 ENV PYTHONUNBUFFERED=1
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9595"]


### PR DESCRIPTION
## Summary
- Install `python-multipart` in Docker image to enable form data parsing.
- Document `python-multipart` requirement for bare-metal installations.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b71aec8e88832b9f1b689a57a428de