### PR TITLE
Add OpenSSL-based certificate finder and verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,25 @@ README.md
   openssl pkcs12 -in client.p12 -nocerts -nodes -out client.key
   ```
 
-- **Custom CA bundles**:  
+- **Custom CA bundles**:
   If the endpoint uses a private CA, place it under `data/trust/ca.pem` and set the path in Config.
+
+## Find & Convert (OpenSSL)
+
+The Config screen now offers a **Find & Convert** panel. It scans a directory under `/data` for a private key (`*.key`), client certificate (`*.cer`/`*.crt`/`*.pem`), and chain file (`*.p7b`/`*.p7c`). The tool assembles `client.pem`, `chain.pem`, `client_full.pem`, and optionally `client.p12`, then applies these paths to the configuration.
+
+**Security notes**
+
+- Reads and writes private keys inside `/data`; keep this directory local and protected.
+- Key passwords are untouched. If your key is encrypted, OpenSSL may prompt for its passphrase.
+- The TLS probe uses `curl -v` and prints the handshake log. Redact sensitive data before sharing.
+
+**Typical flow**
+
+1. Place raw files in `/data/certs` (`client.key`, `client.cer`, `chain.p7b`).
+2. Open **Config → Find & Convert**.
+3. Adjust directories if needed and run **Find and convert** (enable PKCS#12 to create `client.p12`).
+4. Run **Verify chain & TLS probe** to check the assembled certificates.
 
 ---
 

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,15 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from dotenv import load_dotenv
 
 from storage import load_config, save_config
+from tools import (
+    scan_for_materials,
+    convert_cer_to_pem,
+    extract_chain_from_p7b,
+    concat_cert_chain,
+    make_p12,
+    verify_chain,
+    tls_probe,
+)
 from validation import validate_xsd
 from soap_client import send_invoice
 
@@ -69,6 +78,118 @@ def save_config_route(
     })
     save_config(cfg)
     return JSONResponse({"status": "ok"})
+
+@app.post("/tools/find-convert")
+async def find_convert(
+    dir: str = Form("/data/certs"),
+    out: str = Form("/data/certs"),
+    mkp12: bool = Form(False),
+    p12pass: str = Form(""),
+):
+    os.makedirs(out, exist_ok=True)
+    found = scan_for_materials(dir)
+
+    key = next((p for p in found["keys"] if p.lower().endswith(".key")), "")
+    cer = next((p for p in found["certs"] if p.lower().endswith((".cer", ".crt"))), "")
+    pem = next((p for p in found["certs"] if p.lower().endswith(".pem")), "")
+    p7b = next((p for p in found["p7b"]), "")
+
+    outputs = {}
+    client_pem = os.path.join(out, "client.pem")
+    chain_pem = os.path.join(out, "chain.pem")
+    client_full = os.path.join(out, "client_full.pem")
+    client_p12 = os.path.join(out, "client.p12")
+
+    steps = []
+
+    if cer:
+        steps.append({"step": "cer->pem", "in": cer})
+        r = convert_cer_to_pem(cer, client_pem)
+        outputs["cer_to_pem"] = r
+    elif pem:
+        open(client_pem, "w", encoding="utf-8").write(
+            open(pem, "r", encoding="utf-8").read()
+        )
+        outputs["pem_copy"] = {"ok": True, "out": client_pem}
+    else:
+        return JSONResponse({
+            "ok": False,
+            "error": "No client certificate (.cer/.crt/.pem) found",
+            "found": found,
+        })
+
+    if p7b:
+        steps.append({"step": "p7b->chain.pem", "in": p7b})
+        r = extract_chain_from_p7b(p7b, chain_pem)
+        outputs["p7b_to_chain"] = r
+
+    steps.append({"step": "concat", "in": [client_pem, chain_pem]})
+    r = concat_cert_chain(
+        client_pem, chain_pem if os.path.exists(chain_pem) else "", client_full
+    )
+    outputs["concat"] = r
+
+    if mkp12 and key and os.path.exists(client_pem):
+        steps.append({"step": "p12_export", "in": [key, client_pem, chain_pem]})
+        r = make_p12(
+            key,
+            client_pem,
+            chain_pem if os.path.exists(chain_pem) else "",
+            client_p12,
+            p12pass,
+        )
+        outputs["p12"] = r
+
+    cfg = load_config()
+    config_applied = False
+    if key and os.path.exists(client_full):
+        cfg["client_cert"] = client_full
+        cfg["client_key"] = key
+        if os.path.exists(chain_pem):
+            cfg["ca_bundle"] = chain_pem
+        save_config(cfg)
+        config_applied = True
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "found": found,
+            "outputs": outputs,
+            "steps": steps,
+            "applied_paths": {
+                "client_cert": cfg.get("client_cert", ""),
+                "client_key": cfg.get("client_key", ""),
+                "ca_bundle": cfg.get("ca_bundle", ""),
+            },
+            "config_applied": config_applied,
+        }
+    )
+
+
+@app.post("/tools/verify")
+async def tools_verify():
+    cfg = load_config()
+    client_full = cfg.get("client_cert", "")
+    key = cfg.get("client_key", "")
+    ca = cfg.get("ca_bundle", "")
+    endpoint = cfg.get("endpoint", "")
+
+    res = {"chain_verify": None, "tls_probe": None}
+
+    if client_full and os.path.exists(client_full):
+        res["chain_verify"] = verify_chain(client_full, ca)
+    else:
+        res["chain_verify"] = {"ok": False, "err": "client_full.pem not set or missing"}
+
+    if endpoint and client_full and key:
+        try:
+            res["tls_probe"] = tls_probe(endpoint, client_full, key, ca)
+        except Exception as e:
+            res["tls_probe"] = {"ok": False, "err": str(e)}
+    else:
+        res["tls_probe"] = {"ok": False, "err": "endpoint or cert/key missing in config"}
+
+    return JSONResponse(res)
 
 @app.get("/invoice", response_class=HTMLResponse)
 def invoice_page():

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -1,5 +1,47 @@
 {% extends "base.html" %}{% block content %}
 <h2>Configuration</h2>
+<h3>Find & Convert (OpenSSL)</h3>
+<p>Choose a directory under <code>/data</code> that contains your certificate files.
+I will look for: <code>.key</code> (private key), <code>.cer</code>/<code>.pem</code> (client cert), and <code>.p7b</code>/<code>.p7c</code> (chain).</p>
+<p><strong>Security:</strong> This tool reads and writes private keys inside <code>/data</code>. Keep that directory local &amp; protected. We don't change key passwords; if your key is encrypted, OpenSSL may prompt for passphrases. The TLS probe uses <code>curl -v</code>; redact logs before sharing.</p>
+
+<form id="finder">
+  <label>Search directory (inside /data):
+    <input name="dir" value="/data/certs">
+  </label>
+  <label>Output directory:
+    <input name="out" value="/data/certs">
+  </label>
+  <label>Create PKCS#12 (.p12)
+    <input type="checkbox" name="mkp12" checked>
+  </label>
+  <label>PKCS#12 password (optional)
+    <input type="password" name="p12pass" value="">
+  </label>
+  <div>
+    <button type="submit">Find and convert</button>
+    <button id="verify" type="button">Verify chain &amp; TLS probe</button>
+  </div>
+</form>
+<pre id="finder_out"></pre>
+
+<script>
+document.getElementById('finder').addEventListener('submit', async (e)=>{
+  e.preventDefault();
+  const fd = new FormData(e.target);
+  const res = await fetch('/tools/find-convert', { method:'POST', body: fd });
+  const js = await res.json();
+  document.getElementById('finder_out').textContent = JSON.stringify(js, null, 2);
+  if (js.config_applied) alert('Converted and applied to config.');
+});
+
+document.getElementById('verify').addEventListener('click', async ()=>{
+  const res = await fetch('/tools/verify', { method:'POST' });
+  const js = await res.json();
+  document.getElementById('finder_out').textContent = JSON.stringify(js, null, 2);
+});
+</script>
+<hr>
 <form id="cfg">
   <div class="mb-3">
     <label for="endpoint" class="form-label">Endpoint</label>

--- a/app/tools.py
+++ b/app/tools.py
@@ -1,0 +1,88 @@
+import os, re, subprocess, shlex, glob, shutil
+from typing import Dict, List, Tuple
+
+OPENSSL = "openssl"
+
+
+def _run(cmd: str) -> Tuple[int, str, str]:
+    p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    out, err = p.communicate()
+    return p.returncode, out.strip(), err.strip()
+
+
+def scan_for_materials(search_dir: str) -> Dict[str, List[str]]:
+    patterns = {
+        "keys": ["*.key", "*.pem"],
+        "certs": ["*.cer", "*.crt", "*.pem"],
+        "p7b": ["*.p7b", "*.p7c"],
+    }
+    found = {k: [] for k in patterns}
+    for k, pats in patterns.items():
+        for pat in pats:
+            found[k].extend(glob.glob(os.path.join(search_dir, pat)))
+    for k in found:
+        found[k] = sorted(list(dict.fromkeys(found[k])))
+    return found
+
+
+def convert_cer_to_pem(cer_path: str, out_pem: str) -> Dict:
+    try:
+        with open(cer_path, "r", encoding="utf-8", errors="ignore") as f:
+            txt = f.read()
+            if "BEGIN CERTIFICATE" in txt:
+                open(out_pem, "w", encoding="utf-8").write(txt)
+                return {"ok": True, "note": "input already PEM", "out": out_pem}
+    except Exception:
+        pass
+    code, out, err = _run(f"{OPENSSL} x509 -inform DER -in {shlex.quote(cer_path)} -out {shlex.quote(out_pem)}")
+    return {"ok": code == 0, "out": out_pem, "err": err}
+
+
+def extract_chain_from_p7b(p7b_path: str, out_pem: str) -> Dict:
+    code, out, err = _run(f"{OPENSSL} pkcs7 -print_certs -in {shlex.quote(p7b_path)} -out {shlex.quote(out_pem)}")
+    return {"ok": code == 0, "out": out_pem, "err": err}
+
+
+def concat_cert_chain(cert_pem: str, chain_pem: str, out_full: str) -> Dict:
+    try:
+        with open(out_full, "w", encoding="utf-8") as f_out:
+            f_out.write(open(cert_pem, "r", encoding="utf-8").read())
+            if os.path.exists(chain_pem):
+                f_out.write("\n")
+                f_out.write(open(chain_pem, "r", encoding="utf-8").read())
+        return {"ok": True, "out": out_full}
+    except Exception as e:
+        return {"ok": False, "err": str(e)}
+
+
+def make_p12(key_path: str, cert_pem: str, chain_pem: str, out_p12: str, password: str = "") -> Dict:
+    cmd = f"{OPENSSL} pkcs12 -export -inkey {shlex.quote(key_path)} -in {shlex.quote(cert_pem)} -out {shlex.quote(out_p12)}"
+    if chain_pem and os.path.exists(chain_pem):
+        cmd += f" -certfile {shlex.quote(chain_pem)}"
+    if password:
+        cmd += f" -passout pass:{shlex.quote(password)}"
+    else:
+        cmd += " -passout pass:"
+    code, out, err = _run(cmd)
+    return {"ok": code == 0, "out": out_p12, "err": err}
+
+
+def verify_chain(cert_full_pem: str, ca_bundle: str = "") -> Dict:
+    if ca_bundle and os.path.exists(ca_bundle):
+        cmd = f"{OPENSSL} verify -CAfile {shlex.quote(ca_bundle)} {shlex.quote(cert_full_pem)}"
+    else:
+        cmd = f"{OPENSSL} verify {shlex.quote(cert_full_pem)}"
+    code, out, err = _run(cmd)
+    return {"ok": code == 0, "out": out, "err": err}
+
+
+def tls_probe(url: str, cert_full_pem: str, key_path: str, ca_bundle: str = "") -> Dict:
+    curl = "curl"
+    if not shutil.which(curl):
+        return {"ok": False, "err": "curl not present in container"}
+    cmd = f'{curl} -v --cert {shlex.quote(cert_full_pem)} --key {shlex.quote(key_path)} '
+    if ca_bundle and os.path.exists(ca_bundle):
+        cmd += f'--cacert {shlex.quote(ca_bundle)} '
+    cmd += shlex.quote(url)
+    code, out, err = _run(cmd)
+    return {"ok": code == 0, "http": out, "tls_log": err}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.12-slim
 WORKDIR /app
+# OS tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssl ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
 COPY app /app
 RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 requests lxml python-dotenv python-multipart
 EXPOSE 9595


### PR DESCRIPTION
## Summary
- install OpenSSL, CA certificates and curl in Docker image
- add Find & Convert panel to config UI for scanning and converting cert files
- implement backend tooling for conversion and TLS verification
- document new workflow and security notes

## Testing
- `python -m py_compile app/main.py app/tools.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b72a5d8eb4832ba39a8d97dd28c718