### PR TITLE
Fix Docker CMD path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,4 +8,4 @@ COPY app /app
 RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 requests lxml python-dotenv
 EXPOSE 9595
 ENV PYTHONUNBUFFERED=1
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "9595"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9595"]


### PR DESCRIPTION
## Summary
- fix Dockerfile CMD so uvicorn loads the main module directly

## Testing
- `python -m py_compile app/main.py`
- `docker compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b733178008832b841b26254a31ebb4