### PR TITLE
Install python-multipart for FastAPI form handling

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssl ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 COPY app /app
-RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 requests lxml python-dotenv
+RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 requests lxml python-dotenv python-multipart
 EXPOSE 9595
 ENV PYTHONUNBUFFERED=1
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9595"]


### PR DESCRIPTION
## Summary
- Include `python-multipart` in Docker image dependencies to enable FastAPI form parsing

## Testing
- `docker compose up --build -d` *(fails: command not found)*
- `timeout 3 uvicorn main:app --host 0.0.0.0 --port 8000`


------
https://chatgpt.com/codex/tasks/task_e_68b735361ae0832bb3faba9289ca3f17