### PR TITLE
feat: add WSDL loader and SOAP options

### DIFF
--- a/app/storage.py
+++ b/app/storage.py
@@ -5,6 +5,9 @@ CONFIG_PATH = "/data/config.json"
 DEFAULTS = {
     "endpoint": "https://divtest.vraa.gov.lv/Vraa.Div.WebService.UnifiedInterface/UnifiedService.svc",
     "soap_action": "",
+    "soap_version": "1.2",
+    "use_ws_addressing": True,
+    "wsse_mode": "username",
     "username": "",
     "password": "",
     "client_cert": "/data/certs/client_full.pem",

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -81,6 +81,25 @@ document.getElementById('fix').addEventListener('click', async ()=>{
     <input id="soap_action" name="soap_action" value="{{cfg.soap_action}}" class="form-control">
   </div>
   <div class="mb-3">
+    <label for="soap_version" class="form-label">SOAP Version</label>
+    <select id="soap_version" name="soap_version" class="form-select">
+      <option value="1.1" {% if cfg.soap_version == "1.1" %}selected{% endif %}>1.1</option>
+      <option value="1.2" {% if cfg.soap_version != "1.1" %}selected{% endif %}>1.2</option>
+    </select>
+  </div>
+  <div class="form-check mb-3">
+    <input id="use_ws_addressing" type="checkbox" name="use_ws_addressing" class="form-check-input" {% if cfg.use_ws_addressing %}checked{% endif %}>
+    <label for="use_ws_addressing" class="form-check-label">Use WS-Addressing</label>
+  </div>
+  <div class="mb-3">
+    <label for="wsse_mode" class="form-label">WS-Security</label>
+    <select id="wsse_mode" name="wsse_mode" class="form-select">
+      <option value="none" {% if cfg.wsse_mode == "none" %}selected{% endif %}>None</option>
+      <option value="username" {% if cfg.wsse_mode == "username" %}selected{% endif %}>UsernameToken</option>
+      <option value="x509" {% if cfg.wsse_mode == "x509" %}selected{% endif %}>X.509</option>
+    </select>
+  </div>
+  <div class="mb-3">
     <label for="username" class="form-label">Username</label>
     <input id="username" name="username" value="{{cfg.username}}" class="form-control">
   </div>

--- a/app/templates/send.html
+++ b/app/templates/send.html
@@ -1,9 +1,38 @@
 {% extends "base.html" %}{% block content %}
 <h2>Send & Debug</h2>
 <p>Endpoint: <code>{{ cfg.endpoint }}</code></p>
+<button id="load_wsdl" class="btn btn-secondary mb-3">Load WSDL</button>
+<ul id="wsdl_ops" class="list-group mb-3"></ul>
 <button id="send" class="btn btn-primary mb-3">Validate & Send</button>
 <pre id="dbg" class="mt-3"></pre>
 <script>
+const cfg = {{ cfg | tojson | safe }};
+
+document.getElementById('load_wsdl').addEventListener('click', async ()=>{
+  const fd = new FormData();
+  const res = await fetch('/wsdl/load', { method:'POST', body: fd });
+  const js = await res.json();
+  const ops = document.getElementById('wsdl_ops');
+  ops.innerHTML = '';
+  js.operations.forEach(op => {
+    const li = document.createElement('li');
+    li.textContent = `${op.name} (${op.soap_action})`;
+    li.className = 'list-group-item list-group-item-action';
+    li.style.cursor = 'pointer';
+    li.addEventListener('click', async ()=>{
+      const fd = new FormData();
+      Object.entries(cfg).forEach(([k,v]) => fd.append(k, v));
+      fd.set('soap_action', op.soap_action || '');
+      await fetch('/save-config', { method:'POST', body: fd });
+      cfg.soap_action = op.soap_action || '';
+      const body = `<${op.name}></${op.name}>`;
+      await fetch('/invoice/set', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({xml: body})});
+      alert(`Selected operation ${op.name}`);
+    });
+    ops.appendChild(li);
+  });
+});
+
 document.getElementById('send').addEventListener('click', async ()=>{
   // Optional: call /validate first and block on failure
   const v = await fetch('/validate', { method:'POST' }).then(r=>r.json());

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssl ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 COPY app /app
-RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 requests lxml python-dotenv python-multipart
+RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 requests lxml python-dotenv python-multipart zeep
 EXPOSE 9595
 ENV PYTHONUNBUFFERED=1
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9595"]


### PR DESCRIPTION
## Summary
- add configuration for SOAP version, WS-Addressing and WS-Security options
- implement WSDL loader endpoint with zeep and UI to select operations
- support SOAP 1.1/1.2 headers and optional WS-Security X.509, update Dockerfile

## Testing
- `python3 -m py_compile app/*.py`
- `python3 -c "import zeep, sys; sys.stdout.write('ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68b7386cc254832bbfbdad85800844ee