### PR TITLE
feat: move WSDL loader to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ It helps integrators, developers, and support teams validate invoice XMLs, test 
   - Builds WS-Security UsernameToken (digest)
   - Optional mutual TLS with PEM keypair
   - PKCS#12 supported via manual conversion to PEM/KEY
+- **WSDL browser**:
+  - Fetches available SOAP operations after authentication
+  - Clicking an operation fills SOAPAction and seeds the invoice body
 
 - **Debug panel**:
   - Shows raw SOAP request & response
@@ -157,10 +160,19 @@ The Config screen now offers a **Find & Convert** panel. It scans a directory un
 
 ---
 
+## WSDL Browser
+
+After entering the endpoint and authentication details, press **Load WSDL** on the Config tab to retrieve the service description.
+The app lists available operations; clicking one stores the corresponding `SOAPAction` and seeds a minimal request body. If the
+WSDL cannot be fetched or contains no operations, an error message is shown.
+
+---
+
 ## Usage Workflow
 
-1. **Open Config tab**  
-   - Enter endpoint, SOAPAction, credentials, and cert paths  
+1. **Open Config tab**
+   - Enter endpoint, credentials, and cert paths
+   - Use **Load WSDL** to list available operations; selecting one fills `SOAPAction` and seeds a minimal request body
    - Save configuration
 
 2. **Load Invoice**  

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}{% block content %}
 <h2>Configuration</h2>
+<div class="mb-3">
+  <button id="load_wsdl" class="btn btn-secondary mb-3">Load WSDL</button>
+  <ul id="wsdl_ops" class="list-group"></ul>
+  <div id="wsdl_err" class="text-danger"></div>
+</div>
 <h3>Find & Convert (OpenSSL)</h3>
 <p>Choose a directory under <code>/data</code> that contains your certificate files.
 I will look for: <code>.key</code> (private key), <code>.cer</code>/<code>.pem</code> (client cert), and <code>.p7b</code>/<code>.p7c</code> (chain).</p>
@@ -145,6 +150,43 @@ document.getElementById('fix').addEventListener('click', async ()=>{
   </div>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
+<script>
+const cfg = {{ cfg | tojson | safe }};
+document.getElementById('load_wsdl').addEventListener('click', async ()=>{
+  const fd = new FormData();
+  const res = await fetch('/wsdl/load', { method:'POST', body: fd });
+  const ops = document.getElementById('wsdl_ops');
+  const err = document.getElementById('wsdl_err');
+  ops.innerHTML = '';
+  err.textContent = '';
+  if (!res.ok) {
+    err.textContent = 'Failed to load WSDL';
+    return;
+  }
+  const js = await res.json();
+  if (!js.operations || !js.operations.length) {
+    err.textContent = 'No operations found';
+    return;
+  }
+  js.operations.forEach(op => {
+    const li = document.createElement('li');
+    li.textContent = `${op.name} (${op.soap_action})`;
+    li.className = 'list-group-item list-group-item-action';
+    li.style.cursor = 'pointer';
+    li.addEventListener('click', async ()=>{
+      const fd = new FormData();
+      Object.entries(cfg).forEach(([k,v]) => fd.append(k, v));
+      fd.set('soap_action', op.soap_action || '');
+      await fetch('/save-config', { method:'POST', body: fd });
+      cfg.soap_action = op.soap_action || '';
+      const body = `<${op.name}></${op.name}>`;
+      await fetch('/invoice/set', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({xml: body})});
+      alert(`Selected operation ${op.name}`);
+    });
+    ops.appendChild(li);
+  });
+});
+</script>
 <script>
 document.getElementById('cfg').addEventListener('submit', async (e) => {
   e.preventDefault();

--- a/app/templates/send.html
+++ b/app/templates/send.html
@@ -1,37 +1,10 @@
 {% extends "base.html" %}{% block content %}
 <h2>Send & Debug</h2>
 <p>Endpoint: <code>{{ cfg.endpoint }}</code></p>
-<button id="load_wsdl" class="btn btn-secondary mb-3">Load WSDL</button>
-<ul id="wsdl_ops" class="list-group mb-3"></ul>
 <button id="send" class="btn btn-primary mb-3">Validate & Send</button>
 <pre id="dbg" class="mt-3"></pre>
 <script>
 const cfg = {{ cfg | tojson | safe }};
-
-document.getElementById('load_wsdl').addEventListener('click', async ()=>{
-  const fd = new FormData();
-  const res = await fetch('/wsdl/load', { method:'POST', body: fd });
-  const js = await res.json();
-  const ops = document.getElementById('wsdl_ops');
-  ops.innerHTML = '';
-  js.operations.forEach(op => {
-    const li = document.createElement('li');
-    li.textContent = `${op.name} (${op.soap_action})`;
-    li.className = 'list-group-item list-group-item-action';
-    li.style.cursor = 'pointer';
-    li.addEventListener('click', async ()=>{
-      const fd = new FormData();
-      Object.entries(cfg).forEach(([k,v]) => fd.append(k, v));
-      fd.set('soap_action', op.soap_action || '');
-      await fetch('/save-config', { method:'POST', body: fd });
-      cfg.soap_action = op.soap_action || '';
-      const body = `<${op.name}></${op.name}>`;
-      await fetch('/invoice/set', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({xml: body})});
-      alert(`Selected operation ${op.name}`);
-    });
-    ops.appendChild(li);
-  });
-});
 
 document.getElementById('send').addEventListener('click', async ()=>{
   // Optional: call /validate first and block on failure


### PR DESCRIPTION
## Summary
- move WSDL loader to the Config tab and show operations or an error message
- simplify Send & Debug page
- document WSDL browser functionality in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b73b9a29ec832bb8f36eaeb49a933f