### PR TITLE
Add certificate generation tab with RSA key and CSR creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,36 @@ README.md
 - **Custom CA bundles**:
   If the endpoint uses a private CA, place it under `data/trust/ca.pem` and set the path in Config.
 
+## Generate Certificate (Key + CSR)
+
+Use the **Generate Certificate** tab to create your private key and certificate signing request:
+
+1. Open **Generate Certificate** (first tab).
+2. Fill Subject (DN) fields (C, ST, L, O, OU, CN, email).
+3. (Optional) Enter a key passphrase.  \
+   - If you use a passphrase, the key will be encrypted (AES-256) and you must provide this passphrase later in Config (for the TLS probe and sending).
+4. Click **Generate Key & CSR**.
+
+The app writes files to `/data/certs/`:
+- `client.key` (or `{base}.key`) — your private key, **keep it safe**.
+- `client.csr` (or `{base}.csr`) — send this to **VDAA** for issuance.
+
+**After issuance**
+- VDAA returns `client.cer` (your cert) and optionally `chain.p7b` (CA chain).
+- Go to **Config → Find & Convert**, choose `/data/certs` and click **Find and convert**.  \
+  This will produce:
+  - `client.pem`, `chain.pem`, `client_full.pem` (cert + chain)
+- Ensure **Config** paths:
+  - Client cert (PEM): `/data/certs/client_full.pem`
+  - Client key (PEM):  `/data/certs/client.key`
+  - CA bundle:         `/data/certs/chain.pem`
+- Click **Verify chain & TLS probe** to confirm connectivity.
+
+> Requirements (per VDAA/VISS guidance):
+> - RSA **2048-bit** key
+> - SHA-256 for CSR
+> - Keep the **private key** private. Do not email/upload it.
+
 ## Find & Convert (OpenSSL)
 
 The Config screen now offers a **Find & Convert** panel. It scans a directory under `/data` for a private key (`*.key`), client certificate (`*.cer`/`*.crt`/`*.pem`), and chain file (`*.p7b`/`*.p7c`). The tool assembles `client.pem`, `chain.pem`, `client_full.pem`, and optionally `client.p12`, then applies these paths to the configuration.

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,2 +1,3 @@
 body{font-family:system-ui,Arial,sans-serif;margin:0}
 pre{background:#0b1020;color:#e7eaf6;padding:12px;overflow:auto;white-space:pre-wrap}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}

--- a/app/templates/certgen.html
+++ b/app/templates/certgen.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Generate Certificate (Key + CSR)</h2>
+<p>This will create a private key (<code>.key</code>) and a certificate signing request (<code>.csr</code>) in <code>/data/certs</code>. Keep the private key secure.</p>
+
+<form id="gen">
+  <div class="grid">
+    <label>Output directory
+      <input name="out_dir" value="{{ defaults.out_dir }}">
+    </label>
+    <label>Base name (files: base.key / base.csr)
+      <input name="base_name" value="{{ defaults.base_name }}">
+    </label>
+  </div>
+
+  <h3>Subject (DN)</h3>
+  <div class="grid">
+    <label>Country (C)
+      <input name="country" value="{{ defaults.country }}">
+    </label>
+    <label>State (ST)
+      <input name="state" value="{{ defaults.state }}">
+    </label>
+    <label>Locality (L)
+      <input name="locality" value="{{ defaults.locality }}">
+    </label>
+    <label>Organization (O)
+      <input name="org" value="{{ defaults.org }}">
+    </label>
+    <label>Org Unit (OU)
+      <input name="org_unit" value="{{ defaults.org_unit }}">
+    </label>
+    <label>Common Name (CN)
+      <input name="common_name" value="{{ defaults.common_name }}">
+    </label>
+    <label>Email
+      <input name="email" value="{{ defaults.email }}">
+    </label>
+  </div>
+
+  <h3>Key options</h3>
+  <div class="grid">
+    <label>Key size (RSA)
+      <input name="bits" type="number" value="{{ defaults.bits }}">
+    </label>
+    <label>Key passphrase (optional)
+      <input name="key_passphrase" type="password" value="{{ defaults.key_passphrase }}">
+    </label>
+  </div>
+
+  <button type="submit">Generate Key & CSR</button>
+</form>
+
+<pre id="out"></pre>
+
+<div id="after" style="display:none">
+  <h3>Next steps (VDAA)</h3>
+  <ol>
+    <li>Submit the <strong>.csr</strong> file to VDAA according to their enrollment instructions.</li>
+    <li>When you receive <strong>.cer</strong> (issued certificate) and optionally <strong>.p7b</strong> (chain), go to <em>Config → Find & Convert</em> to create <code>client.pem</code>, <code>chain.pem</code>, and <code>client_full.pem</code>.</li>
+    <li>Ensure Config paths point to <code>/data/certs/client_full.pem</code> and <code>/data/certs/client.key</code>, then run <em>Verify chain & TLS probe</em>.</li>
+  </ol>
+</div>
+
+<script>
+document.getElementById('gen').addEventListener('submit', async (e)=>{
+  e.preventDefault();
+  const fd = new FormData(e.target);
+  const res = await fetch('/cert/generate', { method:'POST', body: fd });
+  const js = await res.json();
+  const out = document.getElementById('out');
+  const after = document.getElementById('after');
+
+  if (js.ok) {
+    const csrLink = `/cert/download?path=${encodeURIComponent(js.csr_path)}`;
+    out.textContent = [
+      "✔ Generated successfully",
+      `Key: ${js.key_path}`,
+      `CSR: ${js.csr_path}`,
+      "",
+      "CSR preview:",
+      js.csr_text
+    ].join("\n");
+    after.style.display = 'block';
+
+    const a = document.createElement('a');
+    a.href = csrLink;
+    a.textContent = "Download CSR";
+    a.style.display = 'inline-block';
+    a.style.marginTop = '8px';
+    out.parentNode.insertBefore(a, out.nextSibling);
+  } else {
+    out.textContent = "✖ " + (js.error || "Generation failed");
+  }
+});
+</script>
+{% endblock %}

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -3,6 +3,7 @@
     <div class="container">
       <a class="navbar-brand" href="/">e-Rēķini Tester</a>
       <ul class="navbar-nav nav-tabs ms-auto">
+        <li class="nav-item"><a class="nav-link text-white" href="/cert">Generate Certificate</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="/">Config</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="/invoice">Invoice</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="/schema">Schema</a></li>


### PR DESCRIPTION
## Summary
- add backend helpers to generate RSA key and CSR with OpenSSL and provide safe downloads
- expose `/cert` UI and routes for creating key/CSR and retrieving the CSR
- document certificate generation workflow and update navigation

## Testing
- `PYTHONPATH=app python - <<'PY' from tools import gen_rsa_key_and_csr
res = gen_rsa_key_and_csr('/tmp', 'testkey', 'LV','Riga','Riga','Org','IT','example.com','it@example.com')
print(res['ok'], res['key_path'], res['csr_path'])
print('csr exists', open(res['csr_path']).read().splitlines()[0])
PY`
- `python -m py_compile app/main.py app/tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7404e0df8832b8b5bbea8389ae7f9