### PR TITLE
Improve WSDL loading and debugging

### DIFF
--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -1,10 +1,47 @@
 {% extends "base.html" %}{% block content %}
 <h2>Configuration</h2>
-<div class="mb-3">
-  <button id="load_wsdl" class="btn btn-secondary mb-3">Load WSDL</button>
-  <ul id="wsdl_ops" class="list-group"></ul>
-  <div id="wsdl_err" class="text-danger"></div>
+
+<h3>WSDL</h3>
+<div class="grid">
+  <label>Service URL (endpoint)
+    <input id="wsdl_url" value="{{cfg.endpoint}}">
+  </label>
+  <label><input type="checkbox" id="prefer_multi" checked> Prefer ?wsdl (recommended)</label>
 </div>
+<div>
+  <button id="wsdl_load">Load WSDL</button>
+  <button id="wsdl_debug">Debug WSDL</button>
+</div>
+<pre id="wsdl_out"></pre>
+<div id="wsdl_suggest"></div>
+
+<script>
+document.getElementById('wsdl_load').addEventListener('click', async ()=>{
+  const url = document.getElementById('wsdl_url').value;
+  const prefer_multi = document.getElementById('prefer_multi').checked ? 'true' : 'false';
+  const fd = new FormData();
+  fd.append('url', url);
+  fd.append('prefer_multi', prefer_multi);
+  const res = await fetch('/wsdl/load', { method:'POST', body: fd });
+  const js = await res.json();
+  document.getElementById('wsdl_out').textContent = JSON.stringify(js, null, 2);
+  document.getElementById('wsdl_suggest').textContent = '';
+});
+
+document.getElementById('wsdl_debug').addEventListener('click', async ()=>{
+  const url = document.getElementById('wsdl_url').value;
+  const fd = new FormData();
+  fd.append('url', url);
+  fd.append('try_both', 'true');
+  fd.append('use_curl_fallback', 'true');
+  const res = await fetch('/wsdl/debug', { method:'POST', body: fd });
+  const js = await res.json();
+  document.getElementById('wsdl_out').textContent = JSON.stringify(js, null, 2);
+  const sug = (js.suggestions || []).map(s => `- ${s}`).join('\n');
+  document.getElementById('wsdl_suggest').textContent = sug ? ("Suggestions:\n" + sug) : "";
+});
+</script>
+
 <h3>Find & Convert (OpenSSL)</h3>
 <p>Choose a directory under <code>/data</code> that contains your certificate files.
 I will look for: <code>.key</code> (private key), <code>.cer</code>/<code>.pem</code> (client cert), and <code>.p7b</code>/<code>.p7c</code> (chain).</p>
@@ -150,43 +187,6 @@ document.getElementById('fix').addEventListener('click', async ()=>{
   </div>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
-<script>
-const cfg = {{ cfg | tojson | safe }};
-document.getElementById('load_wsdl').addEventListener('click', async ()=>{
-  const fd = new FormData();
-  const res = await fetch('/wsdl/load', { method:'POST', body: fd });
-  const ops = document.getElementById('wsdl_ops');
-  const err = document.getElementById('wsdl_err');
-  ops.innerHTML = '';
-  err.textContent = '';
-  if (!res.ok) {
-    err.textContent = 'Failed to load WSDL';
-    return;
-  }
-  const js = await res.json();
-  if (!js.operations || !js.operations.length) {
-    err.textContent = 'No operations found';
-    return;
-  }
-  js.operations.forEach(op => {
-    const li = document.createElement('li');
-    li.textContent = `${op.name} (${op.soap_action})`;
-    li.className = 'list-group-item list-group-item-action';
-    li.style.cursor = 'pointer';
-    li.addEventListener('click', async ()=>{
-      const fd = new FormData();
-      Object.entries(cfg).forEach(([k,v]) => fd.append(k, v));
-      fd.set('soap_action', op.soap_action || '');
-      await fetch('/save-config', { method:'POST', body: fd });
-      cfg.soap_action = op.soap_action || '';
-      const body = `<${op.name}></${op.name}>`;
-      await fetch('/invoice/set', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({xml: body})});
-      alert(`Selected operation ${op.name}`);
-    });
-    ops.appendChild(li);
-  });
-});
-</script>
 <script>
 document.getElementById('cfg').addEventListener('submit', async (e) => {
   e.preventDefault();

--- a/app/wsdl_utils.py
+++ b/app/wsdl_utils.py
@@ -1,0 +1,77 @@
+import os, ssl, requests, shlex, subprocess, tempfile
+from typing import Tuple
+from requests.adapters import HTTPAdapter
+from urllib3.poolmanager import PoolManager
+from lxml import etree
+
+CURL = "curl"
+
+class SSLContextAdapter(HTTPAdapter):
+    def __init__(self, ssl_context=None, **kwargs):
+        self.ssl_context = ssl_context
+        super().__init__(**kwargs)
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+        self.poolmanager = PoolManager(num_pools=connections, maxsize=maxsize, block=block, ssl_context=self.ssl_context)
+
+def build_session_with_sslcontext(endpoint: str, client_cert: str, client_key: str, key_pass: str):
+    """
+    Build requests.Session using system CAs (public trust) + mTLS (client cert/key).
+    IMPORTANT: We *do not* load custom CA bundle here to avoid replacing system roots.
+    """
+    ctx = ssl.create_default_context()  # system CAs
+    pwd = key_pass or None
+    if client_cert and client_key:
+        ctx.load_cert_chain(certfile=client_cert, keyfile=client_key, password=pwd)
+
+    s = requests.Session()
+    s.mount("https://", SSLContextAdapter(ctx))
+    s.mount("http://", HTTPAdapter())
+    s.headers.update({"User-Agent": "e-rekini-tester/1.0"})
+    return s
+
+def http_get(session: requests.Session, url: str) -> Tuple[int, dict, bytes, str]:
+    try:
+        r = session.get(url, timeout=30)
+        return r.status_code, dict(r.headers), r.content, ""
+    except Exception as e:
+        return -1, {}, b"", str(e)
+
+def try_parse_wsdl(content: bytes) -> Tuple[bool, str]:
+    try:
+        doc = etree.fromstring(content)
+        if b"definitions" in content or doc.tag.endswith("definitions"):
+            return True, "WSDL/definitions element found"
+        return False, "XML parsed but no <definitions> found"
+    except Exception as e:
+        return False, f"XML parse error: {e}"
+
+def curl_fetch_wsdl(url: str, client_cert: str, client_key: str, key_pass: str = "") -> Tuple[int, str, str, bytes]:
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+        out_file = tf.name
+    cmd = f'{CURL} -sS -D - '
+    if client_cert:
+        cmd += f' --cert {shlex.quote(client_cert)}'
+    if client_key:
+        cmd += f' --key {shlex.quote(client_key)}'
+    if key_pass:
+        cmd += f' --pass "pass:{shlex.quote(key_pass)}"'
+    cmd += f' -o {shlex.quote(out_file)} {shlex.quote(url)}'
+
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    raw_headers, err = p.communicate()
+    code = p.returncode
+    body = b""
+    try:
+        with open(out_file, "rb") as f:
+            body = f.read()
+    finally:
+        try: os.remove(out_file)
+        except Exception: pass
+
+    status = 0
+    if raw_headers:
+        for line in raw_headers.splitlines():
+            if line.startswith("HTTP/"):
+                try: status = int(line.split()[1])
+                except Exception: status = 0
+    return status, raw_headers, err, body


### PR DESCRIPTION
## Summary
- Use system CA trust with mTLS via new `wsdl_utils` helpers
- Robust `/wsdl/load` route preferring `?wsdl` and structured error reporting
- Added `/wsdl/debug` endpoint with curl fallback and UI for troubleshooting; documented CA bundle pitfalls

## Testing
- `pytest`
- `python -m py_compile app/wsdl_utils.py app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b745e00770832b9512ca317ffac66b