### PR TITLE
Add WSDL Browser and SOAP body template generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,20 @@ The Config screen now offers a **Find & Convert** panel. It scans a directory un
 
 ---
 
-## WSDL Browser
+### WSDL Browser
 
-After entering the endpoint and authentication details, press **Load WSDL** on the Config tab to retrieve the service description.
-The app lists available operations; clicking one stores the corresponding `SOAPAction` and seeds a minimal request body. If the
-WSDL cannot be fetched or contains no operations, an error message is shown.
+Use **WSDL Browser** to discover operations and auto-fill the Send page.
+
+1. Open **WSDL Browser** tab.
+2. Click **Load & List Operations** (uses `?wsdl` first; falls back to `?singleWsdl`).
+3. Filter or scroll the list; click **Use in Send** on an operation.
+   - This sets **SOAPAction** in Config and prepares a **SOAP 1.2** envelope with a minimal body template.
+   - You are taken to **Send**, where the request body is prefilled. Replace `<value>` placeholders with actual data.
+4. If there are issues, the **Config → WSDL → Debug WSDL** panel can diagnose TLS/URL/format problems.
+
+> Notes:
+> - For WSDL fetching, the app uses the **system CA** (public trust) and still presents your **client cert/key** for mTLS.
+> - Do **not** point the CA bundle to your **client chain** when loading WSDL (see “Known Issue”).
 
 ---
 

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -5,6 +5,7 @@
       <ul class="navbar-nav nav-tabs ms-auto">
         <li class="nav-item"><a class="nav-link text-white" href="/cert">Generate Certificate</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="/">Config</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="/wsdlui">WSDL Browser</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="/invoice">Invoice</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="/schema">Schema</a></li>
         <li class="nav-item"><a class="nav-link text-white" href="/send">Send</a></li>

--- a/app/templates/send.html
+++ b/app/templates/send.html
@@ -1,16 +1,34 @@
 {% extends "base.html" %}{% block content %}
 <h2>Send & Debug</h2>
-<p>Endpoint: <code>{{ cfg.endpoint }}</code></p>
+<div class="mb-3">
+  <label>SOAPAction
+    <input id="soap_action" class="form-control" value="{{ cfg.soap_action }}">
+  </label>
+</div>
+<div class="mb-3">
+  <textarea id="body_xml" rows="18" class="form-control">{{ xml }}</textarea>
+</div>
 <button id="send" class="btn btn-primary mb-3">Validate & Send</button>
 <pre id="dbg" class="mt-3"></pre>
 <script>
+document.addEventListener('DOMContentLoaded', ()=>{
+  const stored = localStorage.getItem('send_body_template');
+  if (stored) {
+    const ta = document.getElementById('body_xml');
+    if (ta && !ta.value.trim()) {
+      ta.value = stored;
+    }
+    localStorage.removeItem('send_body_template');
+  }
+});
+
 const cfg = {{ cfg | tojson | safe }};
 
 document.getElementById('send').addEventListener('click', async ()=>{
-  // Optional: call /validate first and block on failure
+  const body = document.getElementById('body_xml').value;
+  await fetch('/invoice/set', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({xml: body})});
   const v = await fetch('/validate', { method:'POST' }).then(r=>r.json());
   if (!v.ok) { alert("XSD validation failed — see Schema tab"); return; }
-
   const res = await fetch('/send', { method:'POST' });
   const json = await res.json();
   const d = json.debug;

--- a/app/templates/wsdlui.html
+++ b/app/templates/wsdlui.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>WSDL Browser</h2>
+<p>Inspect services, ports, and operations from the endpoint WSDL and insert an operation into the Send page.</p>
+
+<div class="grid">
+  <label>Endpoint (service URL)
+    <input id="wb_url" value="{{cfg.endpoint}}">
+  </label>
+  <label><input type="checkbox" id="wb_prefer" checked> Prefer ?wsdl (recommended)</label>
+</div>
+<div>
+  <button id="wb_load">Load & List Operations</button>
+  <input id="wb_filter" placeholder="Filter operations by name...">
+</div>
+
+<pre id="wb_msg"></pre>
+<div id="wb_list"></div>
+
+<script>
+const listDiv = document.getElementById('wb_list');
+const msg = document.getElementById('wb_msg');
+let ops = [];
+
+function renderList(){
+  const q = (document.getElementById('wb_filter').value || '').toLowerCase();
+  const filtered = ops.filter(o => (
+    o.operation.toLowerCase().includes(q) ||
+    o.service.toLowerCase().includes(q) ||
+    o.port.toLowerCase().includes(q)
+  ));
+  if (!filtered.length) { listDiv.innerHTML = '<p>No operations.</p>'; return; }
+  listDiv.innerHTML = filtered.map(o => `
+    <div class="card">
+      <div><b>${o.service}</b> / <code>${o.port}</code></div>
+      <div>Operation: <code>${o.operation}</code></div>
+      <div>SOAPAction: <code>${o.soap_action || '(none)'}</code></div>
+      <div>Signature: <code>${o.input_signature}</code></div>
+      <button data-svc="${o.service}" data-port="${o.port}" data-op="${o.operation}" class="wb_use">Use in Send</button>
+    </div>
+  `).join('');
+  document.querySelectorAll('.wb_use').forEach(btn=>{
+    btn.addEventListener('click', async ()=>{
+      const fd = new FormData();
+      fd.append('service', btn.dataset.svc);
+      fd.append('port', btn.dataset.port);
+      fd.append('operation', btn.dataset.op);
+      fd.append('url', document.getElementById('wb_url').value);
+      fd.append('prefer_multi', document.getElementById('wb_prefer').checked ? 'true':'false');
+      fd.append('apply_to_config', 'true');
+      const res = await fetch('/wsdl/op-template', { method:'POST', body: fd });
+      const js = await res.json();
+      if (!js.ok) { msg.textContent = JSON.stringify(js, null, 2); return; }
+      localStorage.setItem('send_body_template', js.body_template || '');
+      window.location.href = '/send';
+    });
+  });
+}
+
+document.getElementById('wb_load').addEventListener('click', async ()=>{
+  const url = document.getElementById('wb_url').value;
+  const prefer = document.getElementById('wb_prefer').checked ? 'true' : 'false';
+  const fd = new FormData();
+  fd.append('url', url);
+  fd.append('prefer_multi', prefer);
+  const res = await fetch('/wsdl/inspect', { method: 'POST', body: fd });
+  const js = await res.json();
+  msg.textContent = JSON.stringify(js, null, 2);
+  ops = js.operations || [];
+  renderList();
+});
+
+document.getElementById('wb_filter').addEventListener('input', renderList);
+</script>
+
+<style>
+.card{border:1px solid #ddd;padding:12px;margin:8px 0;border-radius:10px}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}
+</style>
+{% endblock %}

--- a/app/wsdl_body.py
+++ b/app/wsdl_body.py
@@ -1,0 +1,48 @@
+from lxml import etree
+
+
+def _el(tag, nsmap=None, text=None):
+    el = etree.Element(tag, nsmap=nsmap) if nsmap else etree.Element(tag)
+    if text is not None:
+        el.text = text
+    return el
+
+
+def _safe_tag(ns_prefix, local):
+    return f"{{{ns_prefix}}}{local}" if ns_prefix and local else local
+
+
+def _walk_part(el, xsd_type, depth=0, max_depth=4):
+    """Very simple recursive skeleton: sequences/elements -> empty tags, simple types -> placeholder text."""
+    if depth > max_depth or xsd_type is None:
+        return
+    if hasattr(xsd_type, "elements"):
+        for name, sub in xsd_type.elements:
+            child = etree.SubElement(el, name.text if hasattr(name, "text") else name)
+            sub_type = getattr(sub, "type", None)
+            if sub_type is not None and getattr(sub_type, "elements", None):
+                _walk_part(child, sub_type, depth + 1, max_depth)
+            else:
+                child.text = "<value>"
+    else:
+        el.text = "<value>"
+
+
+def build_body_template(client, service_name, port_name, operation_name):
+    """Return <ns:Operation>...</ns:Operation> skeleton based on input body type."""
+    svc = client.wsdl.services[service_name]
+    port = svc.ports[port_name]
+    op = port.binding._operations[operation_name]
+
+    target_ns = port.binding.wsdl.port_type._name.namespace
+    nsmap = {"tns": target_ns}
+
+    root = _el(_safe_tag(target_ns, operation_name), nsmap=nsmap)
+
+    body = getattr(op.input, "body", None)
+    if body is not None and getattr(body, "type", None) is not None:
+        _walk_part(root, body.type)
+    else:
+        etree.SubElement(root, "payload").text = "<value>"
+
+    return etree.tostring(root, encoding="utf-8", pretty_print=True).decode("utf-8")


### PR DESCRIPTION
## Summary
- Implement WSDL inspection and SOAP body template endpoints with system CA trust
- Add WSDL Browser UI to list operations and prefill Send page
- Preload Send page with templates and document workflow in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b74c57f7c8832b98d5379c77d3eb07