### PR TITLE
Improve navbar and Bootstrap styling; add schema fetch helper

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-import os, logging, base64, uuid, time, json
+import os, logging, base64, uuid, time, json, subprocess
 from datetime import datetime
 from fastapi import FastAPI, Request, Form, Query
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
@@ -407,6 +407,16 @@ def invoices_page():
                     "mtime": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(stat.st_mtime)),
                 })
     return env.get_template("invoices.html").render(files=files)
+
+
+@app.post("/fetch-schemas")
+def fetch_schemas():
+    try:
+        script = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "tools", "fetch_schemas.py"))
+        subprocess.run(["python", script], check=True)
+        return {"ok": True}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
 
 @app.get("/invoice/download")
 def invoice_download(path: str):

--- a/app/templates/certgen.html
+++ b/app/templates/certgen.html
@@ -6,49 +6,49 @@
 <form id="gen">
   <div class="grid">
     <label>Output directory
-      <input name="out_dir" value="{{ defaults.out_dir }}">
+      <input name="out_dir" value="{{ defaults.out_dir }}" class="form-control">
     </label>
     <label>Base name (files: base.key / base.csr)
-      <input name="base_name" value="{{ defaults.base_name }}">
+      <input name="base_name" value="{{ defaults.base_name }}" class="form-control">
     </label>
   </div>
 
   <h3>Subject (DN)</h3>
   <div class="grid">
     <label>Country (C)
-      <input name="country" value="{{ defaults.country }}">
+      <input name="country" value="{{ defaults.country }}" class="form-control">
     </label>
     <label>State (ST)
-      <input name="state" value="{{ defaults.state }}">
+      <input name="state" value="{{ defaults.state }}" class="form-control">
     </label>
     <label>Locality (L)
-      <input name="locality" value="{{ defaults.locality }}">
+      <input name="locality" value="{{ defaults.locality }}" class="form-control">
     </label>
     <label>Organization (O)
-      <input name="org" value="{{ defaults.org }}">
+      <input name="org" value="{{ defaults.org }}" class="form-control">
     </label>
     <label>Org Unit (OU)
-      <input name="org_unit" value="{{ defaults.org_unit }}">
+      <input name="org_unit" value="{{ defaults.org_unit }}" class="form-control">
     </label>
     <label>Common Name (CN)
-      <input name="common_name" value="{{ defaults.common_name }}">
+      <input name="common_name" value="{{ defaults.common_name }}" class="form-control">
     </label>
     <label>Email
-      <input name="email" value="{{ defaults.email }}">
+      <input name="email" value="{{ defaults.email }}" class="form-control">
     </label>
   </div>
 
   <h3>Key options</h3>
   <div class="grid">
     <label>Key size (RSA)
-      <input name="bits" type="number" value="{{ defaults.bits }}">
+      <input name="bits" type="number" value="{{ defaults.bits }}" class="form-control">
     </label>
     <label>Key passphrase (optional)
-      <input name="key_passphrase" type="password" value="{{ defaults.key_passphrase }}">
+      <input name="key_passphrase" type="password" value="{{ defaults.key_passphrase }}" class="form-control">
     </label>
   </div>
 
-  <button type="submit">Generate Key & CSR</button>
+  <button type="submit" class="btn btn-primary">Generate Key & CSR</button>
 </form>
 
 <pre id="out"></pre>

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -4,13 +4,16 @@
 <h3>WSDL</h3>
 <div class="grid">
   <label>Service URL (endpoint)
-    <input id="wsdl_url" value="{{cfg.endpoint}}">
+    <input id="wsdl_url" value="{{cfg.endpoint}}" class="form-control">
   </label>
-  <label><input type="checkbox" id="prefer_multi" checked> Prefer ?wsdl (recommended)</label>
+  <label class="form-check">
+    <input type="checkbox" id="prefer_multi" class="form-check-input" checked>
+    <span class="form-check-label">Prefer ?wsdl (recommended)</span>
+  </label>
 </div>
-<div>
-  <button id="wsdl_load">Load WSDL</button>
-  <button id="wsdl_debug">Debug WSDL</button>
+<div class="mb-3">
+  <button id="wsdl_load" class="btn btn-primary me-2">Load WSDL</button>
+  <button id="wsdl_debug" class="btn btn-secondary">Debug WSDL</button>
 </div>
 <pre id="wsdl_out"></pre>
 <div id="wsdl_suggest"></div>
@@ -49,20 +52,20 @@ I will look for: <code>.key</code> (private key), <code>.cer</code>/<code>.pem</
 
 <form id="finder">
   <label>Search directory (inside /data):
-    <input name="dir" value="/data/certs">
+    <input name="dir" value="/data/certs" class="form-control">
   </label>
   <label>Output directory:
-    <input name="out" value="/data/certs">
+    <input name="out" value="/data/certs" class="form-control">
   </label>
-  <label>Create PKCS#12 (.p12)
-    <input type="checkbox" name="mkp12" checked>
+  <label class="form-check mt-2">Create PKCS#12 (.p12)
+    <input type="checkbox" name="mkp12" class="form-check-input" checked>
   </label>
   <label>PKCS#12 password (optional)
-    <input type="password" name="p12pass" value="">
+    <input type="password" name="p12pass" value="" class="form-control">
   </label>
-  <div>
-    <button type="submit">Find and convert</button>
-    <button id="verify" type="button">Verify chain &amp; TLS probe</button>
+  <div class="mt-2">
+    <button type="submit" class="btn btn-primary me-2">Find and convert</button>
+    <button id="verify" type="button" class="btn btn-secondary">Verify chain &amp; TLS probe</button>
   </div>
 </form>
 <pre id="finder_out"></pre>
@@ -88,11 +91,11 @@ document.getElementById('verify').addEventListener('click', async ()=>{
 <p>This will inspect your certs/keys, verify the chain, and test TLS handshake to the endpoint.</p>
 
 <form id="diag">
-  <label>Allow creating a decrypted test key (client.key.decrypted.pem)?
-    <input type="checkbox" name="allow_decrypt" />
+  <label class="form-check">Allow creating a decrypted test key (client.key.decrypted.pem)?
+    <input type="checkbox" name="allow_decrypt" class="form-check-input" />
   </label>
-  <button type="submit">Run Diagnostics</button>
-  <button id="fix" type="button">One-click Fix</button>
+  <button type="submit" class="btn btn-primary me-2">Run Diagnostics</button>
+  <button id="fix" type="button" class="btn btn-secondary">One-click Fix</button>
 </form>
 <pre id="diag_out"></pre>
 

--- a/app/templates/invoice_unified.html
+++ b/app/templates/invoice_unified.html
@@ -8,29 +8,29 @@
   <fieldset>
     <legend>Header</legend>
     <div class="grid">
-      <label>Invoice ID <input name="id" value="{{ prefill.id }}"></label>
-      <label>Issue Date <input name="issue_date" value="{{ prefill.issue_date }}"></label>
-      <label>Due Date <input name="due_date" value="{{ prefill.due_date }}"></label>
-      <label>Type Code <input name="type_code" value="{{ prefill.type_code or '380' }}"></label>
-      <label>Currency <input name="currency" value="{{ prefill.currency or 'EUR' }}"></label>
+      <label>Invoice ID <input name="id" value="{{ prefill.id }}" class="form-control"></label>
+      <label>Issue Date <input name="issue_date" value="{{ prefill.issue_date }}" class="form-control"></label>
+      <label>Due Date <input name="due_date" value="{{ prefill.due_date }}" class="form-control"></label>
+      <label>Type Code <input name="type_code" value="{{ prefill.type_code or '380' }}" class="form-control"></label>
+      <label>Currency <input name="currency" value="{{ prefill.currency or 'EUR' }}" class="form-control"></label>
     </div>
   </fieldset>
 
   <fieldset>
     <legend>Supplier</legend>
     <div class="grid">
-      <label>Name <input name="supplier_name" value="{{ prefill.supplier_name }}"></label>
-      <label>Company ID <input name="supplier_company_id" value="{{ prefill.supplier_company_id }}"></label>
-      <label>VAT Number <input name="supplier_vat" value="{{ prefill.supplier_vat }}"></label>
+      <label>Name <input name="supplier_name" value="{{ prefill.supplier_name }}" class="form-control"></label>
+      <label>Company ID <input name="supplier_company_id" value="{{ prefill.supplier_company_id }}" class="form-control"></label>
+      <label>VAT Number <input name="supplier_vat" value="{{ prefill.supplier_vat }}" class="form-control"></label>
     </div>
   </fieldset>
 
   <fieldset>
     <legend>Customer</legend>
     <div class="grid">
-      <label>Name <input name="customer_name" value="{{ prefill.customer_name }}"></label>
-      <label>Company ID <input name="customer_company_id" value="{{ prefill.customer_company_id }}"></label>
-      <label>VAT Number <input name="customer_vat" value="{{ prefill.customer_vat }}"></label>
+      <label>Name <input name="customer_name" value="{{ prefill.customer_name }}" class="form-control"></label>
+      <label>Company ID <input name="customer_company_id" value="{{ prefill.customer_company_id }}" class="form-control"></label>
+      <label>VAT Number <input name="customer_vat" value="{{ prefill.customer_vat }}" class="form-control"></label>
     </div>
   </fieldset>
 
@@ -39,53 +39,53 @@
     <div id="lines">
       {% for ln in prefill.lines %}
       <div class="line">
-        <label>Line ID <input name="lines[{{ loop.index0 }}][id]" value="{{ ln.id }}"></label>
-        <label>Name <input name="lines[{{ loop.index0 }}][name]" value="{{ ln.name }}"></label>
-        <label>Qty <input name="lines[{{ loop.index0 }}][qty]" value="{{ ln.qty }}"></label>
-        <label>Price <input name="lines[{{ loop.index0 }}][price]" value="{{ ln.price }}"></label>
-        <label>Line Ext. <input name="lines[{{ loop.index0 }}][line_ext]" value="{{ ln.line_ext }}"></label>
-        <button type="button" class="rm">Remove</button>
+        <label>Line ID <input name="lines[{{ loop.index0 }}][id]" value="{{ ln.id }}" class="form-control"></label>
+        <label>Name <input name="lines[{{ loop.index0 }}][name]" value="{{ ln.name }}" class="form-control"></label>
+        <label>Qty <input name="lines[{{ loop.index0 }}][qty]" value="{{ ln.qty }}" class="form-control"></label>
+        <label>Price <input name="lines[{{ loop.index0 }}][price]" value="{{ ln.price }}" class="form-control"></label>
+        <label>Line Ext. <input name="lines[{{ loop.index0 }}][line_ext]" value="{{ ln.line_ext }}" class="form-control"></label>
+        <button type="button" class="btn btn-danger btn-sm rm">Remove</button>
       </div>
       {% endfor %}
       {% if prefill.lines|length == 0 %}
       <div class="line">
-        <label>Line ID <input name="lines[0][id]" value="1"></label>
-        <label>Name <input name="lines[0][name]" value="Service"></label>
-        <label>Qty <input name="lines[0][qty]" value="1"></label>
-        <label>Price <input name="lines[0][price]" value="100.00"></label>
-        <label>Line Ext. <input name="lines[0][line_ext]" value="100.00"></label>
-        <button type="button" class="rm">Remove</button>
+        <label>Line ID <input name="lines[0][id]" value="1" class="form-control"></label>
+        <label>Name <input name="lines[0][name]" value="Service" class="form-control"></label>
+        <label>Qty <input name="lines[0][qty]" value="1" class="form-control"></label>
+        <label>Price <input name="lines[0][price]" value="100.00" class="form-control"></label>
+        <label>Line Ext. <input name="lines[0][line_ext]" value="100.00" class="form-control"></label>
+        <button type="button" class="btn btn-danger btn-sm rm">Remove</button>
       </div>
       {% endif %}
     </div>
-    <button type="button" id="addLine">Add line</button>
+    <button type="button" id="addLine" class="btn btn-secondary">Add line</button>
   </fieldset>
 
   <fieldset>
     <legend>Totals</legend>
     <div class="grid">
-      <label>Tax Amount <input name="tax_amount" value="{{ prefill.tax_amount }}"></label>
-      <label>Payable Amount <input name="payable_amount" value="{{ prefill.payable_amount or '100.00' }}"></label>
+      <label>Tax Amount <input name="tax_amount" value="{{ prefill.tax_amount }}" class="form-control"></label>
+      <label>Payable Amount <input name="payable_amount" value="{{ prefill.payable_amount or '100.00' }}" class="form-control"></label>
     </div>
   </fieldset>
 
   <div class="grid">
-    <label>File name (optional) <input name="filename" placeholder="invoice-YYYYMMDD-HHMMSS.xml"></label>
+    <label>File name (optional) <input name="filename" placeholder="invoice-YYYYMMDD-HHMMSS.xml" class="form-control"></label>
   </div>
 
   <div class="actions">
-    <button type="button" id="gen">Generate XML</button>
-    <button type="button" id="genSave">Generate & Save</button>
+    <button type="button" id="gen" class="btn btn-primary">Generate XML</button>
+    <button type="button" id="genSave" class="btn btn-secondary">Generate & Save</button>
   </div>
 </form>
 
 <h3>XML Preview</h3>
-<textarea id="xml" rows="16" style="width:100%"></textarea>
+<textarea id="xml" rows="16" style="width:100%" class="form-control"></textarea>
 
 <h3>Validate against XSD</h3>
 <div class="grid">
   <label>Schema entrypoint
-    <select id="xsd">
+    <select id="xsd" class="form-select">
       {% for p in xsds %}
       <option value="{{ p }}">{{ p }}</option>
       {% endfor %}
@@ -93,7 +93,7 @@
   </label>
 </div>
 <div class="actions">
-  <button type="button" id="validate">Validate XML</button>
+  <button type="button" id="validate" class="btn btn-primary">Validate XML</button>
 </div>
 <pre id="valout"></pre>
 
@@ -133,12 +133,12 @@ document.getElementById('addLine').addEventListener('click', ()=>{
   const wrapper = document.createElement('div');
   wrapper.className = 'line';
   wrapper.innerHTML = `
-    <label>Line ID <input name="lines[${idx}][id]" value="${idx+1}"></label>
-    <label>Name <input name="lines[${idx}][name]" value=""></label>
-    <label>Qty <input name="lines[${idx}][qty]" value="1"></label>
-    <label>Price <input name="lines[${idx}][price]" value="0.00"></label>
-    <label>Line Ext. <input name="lines[${idx}][line_ext]" value="0.00"></label>
-    <button type="button" class="rm">Remove</button>
+    <label>Line ID <input name="lines[${idx}][id]" value="${idx+1}" class="form-control"></label>
+    <label>Name <input name="lines[${idx}][name]" value="" class="form-control"></label>
+    <label>Qty <input name="lines[${idx}][qty]" value="1" class="form-control"></label>
+    <label>Price <input name="lines[${idx}][price]" value="0.00" class="form-control"></label>
+    <label>Line Ext. <input name="lines[${idx}][line_ext]" value="0.00" class="form-control"></label>
+    <button type="button" class="btn btn-danger btn-sm rm">Remove</button>
   `;
   linesDiv.appendChild(wrapper);
   wrapper.querySelector('.rm').addEventListener('click', ()=> wrapper.remove());

--- a/app/templates/invoices.html
+++ b/app/templates/invoices.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Invoices</h2>
-<table>
+<div class="mb-3">
+  <button id="fetchSchemas" class="btn btn-primary">Fetch Schemes</button>
+</div>
+<table class="table table-striped">
   <thead><tr><th>Name</th><th>Size</th><th>Modified</th><th>Actions</th></tr></thead>
   <tbody>
     {% for f in files %}
@@ -10,7 +13,7 @@
       <td>{{ f.size }}</td>
       <td>{{ f.mtime }}</td>
       <td>
-        <a href="/invoice/download?path={{ f.path }}">Download</a>
+        <a href="/invoice/download?path={{ f.path }}" class="btn btn-sm btn-secondary">Download</a>
       </td>
     </tr>
     {% endfor %}
@@ -19,9 +22,14 @@
     {% endif %}
   </tbody>
 </table>
-<style>
-table{width:100%;border-collapse:collapse}
-th,td{border:1px solid #ddd;padding:8px}
-th{background:#f5f5f5;text-align:left}
-</style>
+<script>
+document.getElementById('fetchSchemas').addEventListener('click', async ()=>{
+  const res = await fetch('/fetch-schemas', {method:'POST'}).then(r=>r.json());
+  if(res.ok){
+    alert('Schemas fetched');
+  } else {
+    alert('Failed: ' + (res.error || ''));
+  }
+});
+</script>
 {% endblock %}

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -1,8 +1,13 @@
-<nav class="nav">
-  <a href="/cert">Generate Certificate</a>
-  <a href="/">Config</a>
-  <a href="/wsdlui">WSDL Browser</a>
-  <a href="/invoice">Invoice</a>
-  <a href="/invoices">Invoices</a>
-  <a href="/send">Send</a>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">e-Rēķini Tester</a>
+    <div class="navbar-nav">
+      <a class="nav-link" href="/cert">Generate Certificate</a>
+      <a class="nav-link" href="/">Config</a>
+      <a class="nav-link" href="/wsdlui">WSDL Browser</a>
+      <a class="nav-link" href="/invoice">Invoice</a>
+      <a class="nav-link" href="/invoices">Invoices</a>
+      <a class="nav-link" href="/send">Send</a>
+    </div>
+  </div>
 </nav>

--- a/app/templates/wsdlui.html
+++ b/app/templates/wsdlui.html
@@ -6,13 +6,16 @@
 
 <div class="grid">
   <label>Endpoint (service URL)
-    <input id="wb_url" value="{{cfg.endpoint}}">
+    <input id="wb_url" value="{{cfg.endpoint}}" class="form-control">
   </label>
-  <label><input type="checkbox" id="wb_prefer" checked> Prefer ?wsdl (recommended)</label>
+  <label class="form-check">
+    <input type="checkbox" id="wb_prefer" class="form-check-input" checked>
+    <span class="form-check-label">Prefer ?wsdl (recommended)</span>
+  </label>
 </div>
-<div>
-  <button id="wb_load">Load & List Operations</button>
-  <input id="wb_filter" placeholder="Filter operations by name...">
+<div class="mb-3">
+  <button id="wb_load" class="btn btn-primary me-2">Load & List Operations</button>
+  <input id="wb_filter" class="form-control" placeholder="Filter operations by name...">
 </div>
 
 <pre id="wb_msg"></pre>
@@ -37,9 +40,9 @@ function renderList(){
       <div>Operation: <code>${o.operation}</code></div>
       <div>SOAPAction: <code>${o.soap_action || '(none)'}</code></div>
       <div>Signature: <code>${o.input_signature}</code></div>
-      <button data-svc="${o.service}" data-port="${o.port}" data-op="${o.operation}" class="wb_use">Use in Send</button>
-    </div>
-  `).join('');
+      <button data-svc="${o.service}" data-port="${o.port}" data-op="${o.operation}" class="btn btn-secondary wb_use mt-2">Use in Send</button>
+      </div>
+    `).join('');
   document.querySelectorAll('.wb_use').forEach(btn=>{
     btn.addEventListener('click', async ()=>{
       const fd = new FormData();


### PR DESCRIPTION
## Summary
- restore Bootstrap navbar with app name and links
- apply Bootstrap classes to buttons and inputs across templates
- add "Fetch Schemes" button and backend endpoint to download XSD schemas

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b765e09824832b83a7f0c07c0c20ea