### PR TITLE
Switch Docker base Java to OpenJDK 21

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
 # Add Java runtime for Schematron (Saxon-HE)
-RUN apt-get update && apt-get install -y --no-install-recommends openjdk-17-jre-headless curl unzip openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-21-jre-headless curl unzip openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Put Saxon-HE under /opt/saxon
 RUN mkdir -p /opt/saxon


### PR DESCRIPTION
## Summary
- replace unavailable OpenJDK 17 with OpenJDK 21 JRE headless in Docker build

## Testing
- `pytest`
- `docker build -t testimage -f docker/Dockerfile .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b76f42ae4c832bbf3d261805e524e6