### PR TITLE
docs: embed application screenshot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # e-Rēķini Tester
 
+![Screenshot of the application interface](e_invoice.PNG)
+
 A minimal **FastAPI** web application to **edit**, **validate**, and **send** e-invoices via **SOAP** with **WS-Security UsernameToken (digest)** and optional **mutual TLS**.
 
 This tool is intended as a **local integration tester** for the Latvian VDAA *e-Rēķini* system.  


### PR DESCRIPTION
## Summary
- show application screenshot near top of README for quick visual reference

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7cbf6abb0832bbd78b7e0d3098276