### PR TITLE
Add KoSIT Peppol BIS validator integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,3 +451,44 @@ data/schematron/peppol/.xslt
 
 This project is licensed for non-commercial use only. Commercial use requires a separate license. See [LICENSE](LICENSE).
 
+
+## KoSIT Validator (Peppol BIS)
+
+This app integrates the **KoSIT XML Validator** to validate invoices against **Peppol BIS** scenarios (XSD + Schematron combined).
+
+### What is it (legally & technically)?
+
+- **KoSIT** (Koordinierungsstelle für IT-Standards) is the German public body behind the **XRechnung** standard. They publish an open validator which can execute **XSD** and **Schematron** based on a **scenario** configuration. For Peppol BIS, KoSIT provides a dedicated **validator configuration** (scenarios + resources). KoSIT is **authoritative for XRechnung**; for **Peppol BIS**, the authoritative specs live at **OpenPeppol**, while KoSIT’s Peppol package is a convenient runtime configuration of those rules. 
+
+### CLI reference (for troubleshooting)
+
+```
+java -jar validator-<version>-standalone.jar -s <path>/scenarios.xml -r <repo-dir> -h -o <outdir> <invoice.xml>
+```
+
+- `-s` scenario config file  
+- `-r` repository folder (contains `scenarios.xml` and `resources/`)  
+- `-o` output directory  
+- `-h` also produce HTML report  
+- Since **v1.5.1** jar is named `validator-<ver>-standalone.jar`.   
+- Typical usage writes `*-report.xml` and (with `-h`) `*-report.html`. 
+
+### Setup
+
+1. Ensure Java is in the container (`default-jre-headless` installed).  
+2. Provide the **KoSIT validator jar** (e.g. `validator-1.5.2-standalone.jar`) under `/opt/kosit/bin/`. You can:
+   - Download in Dockerfile, or
+   - Mount via volume and set `KOSIT_JAR=/opt/kosit/bin/validator-1.5.2-standalone.jar`.
+3. Populate `data/kosit/bis/` with the **Peppol validator configuration** (contains `scenarios.xml` and `resources/**`).  
+   - Point `KOSIT_CONF_DIR` to that folder if you change the path.
+
+### Using in the GUI
+
+- Open **KoSIT Validator** tab.  
+- Pick an **invoice** (from `/data/invoices`).  
+- Click **Validate by KoSIT**.  
+- The app runs the validator and shows:
+  - Status, exit code, and runtime  
+  - Paths to **XML** and **HTML** reports under `/data/logs/kosit/<timestamp>/`
+
+> Tip: Keep your **XSD** and **Schematron (Saxon)** checks in the **Invoice** tab for developer-friendly iteration. Use **KoSIT** for a Peppol-aligned final check and HTML report.

--- a/app/kosit_runner.py
+++ b/app/kosit_runner.py
@@ -1,0 +1,51 @@
+import os, subprocess, time, pathlib, shlex
+from typing import Dict
+
+KOSIT_JAR = os.environ.get("KOSIT_JAR") or "/opt/kosit/bin/validator-1.5.2-standalone.jar"
+KOSIT_CONF_DIR = os.environ.get("KOSIT_CONF_DIR") or "/data/kosit/bis"
+
+def run_kosit(invoice_path: str, out_dir: str, html_report: bool = True) -> Dict:
+    invoice_path = os.path.abspath(invoice_path)
+    out_dir = os.path.abspath(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+
+    scenarios = os.path.join(KOSIT_CONF_DIR, "scenarios.xml")
+    repo_dir  = KOSIT_CONF_DIR  # contains scenarios.xml and resources/
+
+    if not os.path.exists(KOSIT_JAR):
+        return {"ok": False, "error": f"KoSIT jar not found: {KOSIT_JAR}"}
+    if not os.path.exists(scenarios):
+        return {"ok": False, "error": f"scenarios.xml not found at: {scenarios}"}
+    if not os.path.exists(invoice_path):
+        return {"ok": False, "error": f"Invoice not found: {invoice_path}"}
+
+    cmd = [
+        "java", "-jar", KOSIT_JAR,
+        "-s", scenarios,
+        "-r", repo_dir,
+        "-o", out_dir
+    ]
+    if html_report:
+        cmd.append("-h")
+    cmd.append(invoice_path)
+
+    t0 = time.time()
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    dt = round((time.time() - t0) * 1000)
+
+    # KoSIT writes <file>-report.xml (+ html)
+    stem = pathlib.Path(invoice_path).name
+    xml_report = os.path.join(out_dir, f"{stem}-report.xml")
+    html_report_path = os.path.join(out_dir, f"{stem}-report.html") if html_report else None
+
+    result = {
+        "ok": p.returncode == 0 and os.path.exists(xml_report),
+        "took_ms": dt,
+        "cmd": " ".join(shlex.quote(x) for x in cmd),
+        "exit_code": p.returncode,
+        "stdout": p.stdout,
+        "stderr": p.stderr,
+        "xml_report": xml_report if os.path.exists(xml_report) else "",
+        "html_report": html_report_path if (html_report and os.path.exists(html_report_path)) else ""
+    }
+    return result

--- a/app/templates/kosit.html
+++ b/app/templates/kosit.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>KoSIT Validator (Peppol BIS)</h2>
+
+<p class="muted">Jar: <code>{{ conf.jar }}</code> &nbsp;|&nbsp; Config dir: <code>{{ conf.conf_dir }}</code></p>
+
+<form id="kform">
+  <div class="grid">
+    <label>Invoice XML
+      <select name="invoice_path" id="invoice_path">
+        {% for p in invoices %}
+        <option value="{{ p }}">{{ p }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Generate HTML report (-h)
+      <select name="html_report" id="html_report">
+        <option value="true" selected>Yes</option>
+        <option value="false">No</option>
+      </select>
+    </label>
+  </div>
+
+  <div class="actions">
+    <button type="button" id="run">Validate by KoSIT</button>
+  </div>
+</form>
+
+<h3>Result</h3>
+<pre id="out"></pre>
+
+<style>
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:10px}
+.actions{display:flex;gap:10px;margin:10px 0}
+.muted{opacity:.75}
+</style>
+
+<script>
+document.getElementById('run').addEventListener('click', async ()=>{
+  const fd = new FormData(document.getElementById('kform'));
+  const res = await fetch('/kosit/validate', { method:'POST', body: fd });
+  const js = await res.json();
+  const lines = [];
+  lines.push("OK: " + js.ok);
+  lines.push("Exit code: " + js.exit_code);
+  lines.push("Took (ms): " + js.took_ms);
+  if (js.xml_report) lines.push("XML report: " + js.xml_report);
+  if (js.html_report) lines.push("HTML report: " + js.html_report);
+  if (js.stdout) lines.push("\nSTDOUT:\n" + js.stdout.trim());
+  if (js.stderr) lines.push("\nSTDERR:\n" + js.stderr.trim());
+  document.getElementById('out').textContent = lines.join("\n");
+});
+</script>
+{% endblock %}

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -7,6 +7,7 @@
       <a class="nav-link" href="/wsdlui">WSDL Browser</a>
       <a class="nav-link" href="/invoice">Invoice</a>
       <a class="nav-link" href="/invoices">Invoices</a>
+      <a class="nav-link" href="/kosit">KoSIT Validator</a>
       <a class="nav-link" href="/send">Send</a>
     </div>
   </div>

--- a/data/kosit/bis/LICENSE
+++ b/data/kosit/bis/LICENSE
@@ -1,0 +1,208 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-----
+Der Standard XRechnung steht unter dem Lizenzabkommen (englischsprachige Originalquelle: https://ec.europa.eu/cefdigital/wiki/display/CEFDIGITAL/Obtaining+a+copy+of+the+European+standard+on+eInvoicing) der Europäischen Kommission (EK) und dem Europäischen Komitee für Normung (CEN):
+
+Der europäische Standard zur elektronischen Rechnungsstellung (EN 16931) wird vom CEN durch Beauftragung der EK entwickelt und veröffentlicht. Die Urheberrechte am Standard liegen beim CEN, Kopien des Standards werden über die nationalen Standardisierungsorganisationen vertrieben.
+Das Abkommen zwischen EK und CEN besagt, dass im Rahmen der geistigen Eigentumsrechte (IPR) am Standard das semantische Datenmodell der Kernelemente einer elektronischen Rechnung (EN 16931-1:2017) und den zwei mandatorischen Syntaxen (CEN/TS 16931-2:2017) unentgeltlich über das Deutsche Institut für Normung (DIN) in ihrer Rolle als nationale Standardisierungsorganisation zu beziehen sind.
+Der Standard XRechnung ist eine Implementierung dieses Datenmodelles und der zwei mandatorischen Syntaxen und die Vervielfältigung ist durch die Genehmigung von CEN und DIN als Urheberrechtsträger gestattet.
+CEN und DIN übernehmen keine Garantie für den Inhalt und die Implementierung dieser Derivate und im Zweifelsfalle ist immer auf die offiziell autorisierten Dokumente des semantischen Datenmodells und der zwei mandatorischen Syntaxen zurückzugreifen, welche durch das DIN zur Verfügung gestellt werden.

--- a/data/kosit/bis/NOTICE
+++ b/data/kosit/bis/NOTICE
@@ -1,0 +1,5 @@
+KoSIT XML-Validator Configuration for XRechnung
+Copyright 2020 Koordinierungsstelle für IT-Standards
+
+This product includes software developed by
+Coordination Office for IT-Standards (http://www.xoev.de/).

--- a/data/kosit/bis/README.md
+++ b/data/kosit/bis/README.md
@@ -1,0 +1,108 @@
+# Validator Configuration for Peppol Billing BIS 3.0
+
+This is a special configuration of the [KoSIT Validator](https://github.com/itplr-kosit/validator).
+
+If you think you have found a bug, please [contact us](https://xeinkauf.de/peppol/).
+
+Existing issues can be found at [our issue tracker](https://projekte.kosit.org/peppol/validator-configuration-bis/-/issues).
+
+You can find packaged releases on [our GitLab project](https://projekte.kosit.org/peppol/validator-configuration-bis/-/releases).
+
+
+This validator uses the latest Peppol BIS 2025-05 rules.
+
+This is the "May 2025" release announced on 2025-05-22.
+
+It is valid per 2025-08-25 00:00 CEST.
+
+The next Peppol update is foreseen in Q4 2025.
+
+**Please note: this configuration uses validation artefacts published by OpenPeppol ([OpenPeppol - GitHub](https://github.com/OpenPEPPOL)). Please use the [Peppol Service desk](https://openpeppol.atlassian.net/servicedesk/customer/portal/1) to report any issues related to the validation. KoSIT is offering this configuration of the [KoSIT Validator](https://github.com/itplr-kosit/validator), but excludes any liability.**
+
+## Getting started
+
+### Prerequisites
+
+Required tools:
+* curl
+* unzip
+
+As a prerequisite you need the KoSIT Validator to run it.
+
+```shell
+# download validator
+curl -L "https://github.com/itplr-kosit/validator/releases/download/v1.5.0/validator-1.5.0-distribution.zip" --output validator.zip
+
+# unzip the validator (ensure the target directory "bin" is empty before unzipping)
+unzip validator.zip -d bin/
+```
+
+### Running the validator
+
+Required tools:
+* Java 11+
+
+Verify all examples files (`test-files/good/*.xml`) and produced HTML output to directory `result-reports/` - all of them should be valid:
+
+```shell
+java -jar bin/validationtool-1.5.0-standalone.jar -s scenarios.xml -r "" -h -o result-reports/ test-files/good/ubl/*.xml
+```
+
+Note: eventually you need to explicitly use `"%JAVA_HOME%\bin\java"` on Windows
+
+Validator 1.5.0 help:
+
+```
+Usage: KoSIT Validator [-?dX] [-l <logLevel>] [-r repository-path]... -s
+                       scenario.xml [-s scenario.xml]... [[-D] [-H <host>] [-P
+                       <port>] [-T <workerCount>] [-G]] [[-o <outputPath>] [-h]
+                       [--serialize-report-input] [-c assertions-file]
+                       [--report-postfix <reportPostfix>] [--report-prefix
+                       <reportPrefix>] [-m] [-p] <files>...]
+Structural and semantic validation of xml files
+  -?, --help            display this help message
+  -d, --debug           Prints some more debug information
+  -l, --log-level <logLevel>
+                        Enables a certain log level for debugging purposes
+  -r, --repository repository-path
+                        Directory containing scenario content
+  -s, --scenarios scenario.xml
+                        Location of scenarios.xml
+  -X, --debug-logging   Enables full debug log. Alias for -l debug
+Daemon options
+  -D, --daemon          Starts a daemon listing for validation requests
+  -G, --disable-gui     Disables the GUI of the daemon mode
+  -H, --host <host>     The hostname / IP address to bind the daemon.
+                          Default: localhost
+  -P, --port <port>     The port to bind the daemon.
+                          Default: 8080
+  -T, --threads <workerCount>
+                        Number of threads processing validation requests.
+                          Default depends on processor count
+CLI usage options
+      <files>...        Files to validate
+  -c, --check-assertions assertions-file
+                        Check the result using defined assertions
+  -h, --html, --extract-html
+                        Extract and save any html content within result as a
+                          separate file
+  -m, --memory-stats    Prints some memory stats
+  -o, --output-directory <outputPath>
+                        Defines the out directory for results.
+  -p, --print           Prints the check result to stdout
+      --report-postfix <reportPostfix>
+                        Postfix of the generated report name
+      --report-prefix <reportPrefix>
+                        Prefix of the generated report name
+      --serialize-report-input
+                        Serializes the report input to the cwd
+```
+
+## Building a release
+
+Required tools:
+* zip
+
+```shell
+zip -r -9 validation-configuration-bis-3.0.19.zip README.md scenarios.xml resources/*
+```

--- a/data/kosit/bis/resources/default-report.xsl
+++ b/data/kosit/bis/resources/default-report.xsl
@@ -1,0 +1,764 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:rep="http://www.xoev.de/de/validator/varl/1"
+    xmlns:s="http://www.xoev.de/de/validator/framework/1/scenarios" 
+    xmlns:in="http://www.xoev.de/de/validator/framework/1/createreportinput"
+    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+    xmlns:html="http://www.w3.org/1999/xhtml"
+    exclude-result-prefixes="xs"
+    version="2.0">
+    <xd:doc>
+        <xd:desc>Diese Transformation überführt eine Instanz des internen Zwischenformats der Prüftools in den
+            Prüfbericht im Zielformat. Dabei werden die verschiedenen Teil-Validierungsergebnisse aggregiert und
+            vereinheitlicht sowie eine Empfehlung zur Annahme oder Ablehnung erzeugt.</xd:desc>
+    </xd:doc>
+    
+    <xsl:output method="xml" indent="yes"/>
+
+    <xd:doc>
+        <xd:desc>Das geprüfte Dokument wird via Parameter zur Verfügung gestellt, um ggf. ausgewählte Inhalte separat im
+        Prüfbericht auszuweisen.</xd:desc>
+    </xd:doc>
+    <xsl:param name="input-document" required="yes"/>
+
+    <xsl:variable name="custom-levels" as="element(s:customLevel)*" select="//s:customLevel"/>
+
+    <xd:doc>
+        <xd:desc>Einstiegspunkt</xd:desc>
+    </xd:doc>
+    <xsl:template match="in:createReportInput">
+
+        <xsl:variable name="validationStepResults" as="element(rep:validationStepResult)*">
+            <xsl:apply-templates select="in:validationResultsXmlSchema"/>
+            <xsl:apply-templates select="in:validationResultsSchematron"/>
+        </xsl:variable>
+
+        <!-- Zwischenergebnis: Der an sich fertige Bericht, dem lediglich noch die Bewertung fehlt -->
+        <xsl:variable name="report-without-assessment" as="document-node(element(rep:report))">
+            <xsl:document>
+                <rep:report>
+                    <xsl:attribute name="valid">
+                        <xsl:choose>
+                            <xsl:when test="empty(s:scenario)">false</xsl:when>
+                            <xsl:when test="$validationStepResults[@valid = 'false']">false</xsl:when>
+                            <xsl:otherwise>true</xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:attribute>
+                    <xsl:apply-templates select="in:engine" mode="copy-to-report-ns"/>    
+                    <xsl:apply-templates select="in:timestamp" mode="copy-to-report-ns"/>
+                    <xsl:apply-templates select="in:documentIdentification" mode="copy-to-report-ns"/>
+                    <xsl:choose>
+                        <xsl:when test="s:scenario">
+                            <rep:scenarioMatched>
+                                <xsl:apply-templates select="s:scenario" mode="copy"/>
+                                <xsl:call-template name="documentData"/>
+                                <xsl:sequence select="$validationStepResults"/>
+                            </rep:scenarioMatched>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <rep:noScenarioMatched>
+                                <xsl:apply-templates select="in:validationResultsWellformedness"/>
+                            </rep:noScenarioMatched>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </rep:report>
+            </xsl:document>
+        </xsl:variable>
+        
+        <rep:report varlVersion="1.0.0">
+            <xsl:copy-of select="$report-without-assessment/rep:report/(node()|@*)"/>
+            <xsl:apply-templates select="$report-without-assessment" mode="assessment"/>
+        </rep:report>
+        
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>Dieses Template kann in einem "Customization Layer" überschrieben werden, um spezifische
+            Dokumentinhalte gesondert im Prüfbericht auszuweisen. Das Template muss ein Element rep:documentData
+            liefern.
+            erzeugen.</xd:desc>
+    </xd:doc>
+    <xsl:template name="documentData"/>
+    
+    <xsl:template mode="copy" match="node()|attribute()">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|attribute()" mode="copy"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template mode="copy" match="s:*">
+        <xsl:element name="s:{local-name()}">
+            <xsl:apply-templates select="node()|attribute()" mode="copy"/>
+        </xsl:element>
+    </xsl:template>
+    
+    
+    <!-- ************************************************************************************** -->
+    <!-- *                                                                                    * -->
+    <!-- * Syntax checks (well-formedness and XML Schema)                                     * -->
+    <!-- *                                                                                    * -->
+    <!-- ************************************************************************************** -->
+
+    <xsl:template match="in:validationResultsWellformedness">
+        <xsl:variable name="messages" as="element(rep:message)*">
+            <!-- skip raw exception messages -->
+            <xsl:apply-templates select="in:xmlSyntaxError[not(starts-with(.,'SAXParseException'))]">
+                <xsl:with-param name="parent-id">val-xml</xsl:with-param>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <rep:validationStepResult id="val-xml"
+            valid="{if ($messages[@level = ('warning', 'error')]) then false() else true()}">
+            <xsl:apply-templates select="s:resource" mode="copy"/>
+            <xsl:sequence select="$messages"/>
+        </rep:validationStepResult>
+    </xsl:template>
+    
+
+    <xsl:template match="in:validationResultsXmlSchema">
+        <xsl:variable name="messages" as="element(rep:message)*">
+            <xsl:apply-templates select="in:xmlSyntaxError">
+                <xsl:with-param name="parent-id">val-xsd</xsl:with-param>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <rep:validationStepResult id="val-xsd"
+            valid="{if ($messages[@level = ('warning', 'error')]) then false() else true()}">
+            <xsl:apply-templates select="s:resource" mode="copy"/>
+            <xsl:sequence select="$messages"/>
+        </rep:validationStepResult>
+    </xsl:template>
+    
+    
+    <xsl:template match="in:xmlSyntaxError">
+        <xsl:param name="parent-id" as="xs:string" required="yes"/>
+        <xsl:variable name="id" select="concat($parent-id, '.', count(preceding-sibling::in:xmlSyntaxError) + 1)"/>
+        <xsl:variable name="level" select="if (@severity = 'SEVERITY_WARNING') then 'warning' else 'error'"/>
+        <rep:message id="{$id}" level="{$level}">
+            <xsl:apply-templates select="*"/>
+            <xsl:choose>
+                <xsl:when test="starts-with(in:message,'cvc-')">
+                    <!-- Xerces error messages -->
+                    <xsl:attribute name="code">
+                        <xsl:value-of select="tokenize(in:message,': ')[1]"/>
+                    </xsl:attribute>
+                    <xsl:value-of select="substring-after(in:message,concat(tokenize(in:message,': ')[1],': '))"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:attribute name="code">generic-error</xsl:attribute>
+                    <xsl:value-of select="in:message"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </rep:message> 
+    </xsl:template>
+    
+    <xsl:template match="in:xmlSyntaxError/in:*" priority="-1"/>
+    
+    
+    <xsl:template match="in:xmlSyntaxError/in:rowNumber[. != '-1']">
+        <xsl:attribute name="lineNumber" select="."/>
+    </xsl:template>
+    
+    <xsl:template match="in:xmlSyntaxError/in:columnNumber[. != '-1']">
+        <xsl:attribute name="columnNumber" select="."/>
+    </xsl:template>
+
+    <!-- ************************************************************************************** -->
+    <!-- *                                                                                    * -->
+    <!-- * Schematron (SVRL)                                                                  * -->
+    <!-- *                                                                                    * -->
+    <!-- ************************************************************************************** -->
+    
+
+    <xsl:template match="in:validationResultsSchematron">
+        <xsl:variable name="schematron-output" as="element(svrl:schematron-output)?" select="in:results/svrl:schematron-output"/>
+        <xsl:if test="empty($schematron-output)">
+            <xsl:message terminate="yes">Unexpected result from schematron validation - there is no svrl:schematron-output element!</xsl:message>
+        </xsl:if>
+        <xsl:variable name="id" as="xs:string" select="concat('val-sch.',1 + count(preceding-sibling::in:validationResultsSchematron))"/>
+        <xsl:variable name="messages" as="element(rep:message)*">
+            <xsl:apply-templates select="$schematron-output/(svrl:failed-assert|svrl:successful-report)">
+                <xsl:with-param name="parent-id" select="$id"/>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <rep:validationStepResult id="{$id}" valid="{if ($messages[@level = ('warning', 'error')]) then false() else true()}">
+            <xsl:apply-templates select="s:resource" mode="copy"/>
+            <xsl:sequence select="$messages"/>
+        </rep:validationStepResult>
+    </xsl:template>
+    
+    
+    <xsl:template match="svrl:failed-assert|svrl:successful-report">
+        <xsl:param name="parent-id" as="xs:string" required="yes"/>
+        <xsl:variable name="id" select="concat($parent-id, '.', count(preceding-sibling::svrl:failed-assert | preceding-sibling::svrl:successful-report) + 1)"/>
+        <rep:message id="{$id}">
+            <xsl:apply-templates select="in:location/*"/>
+            <xsl:attribute name="level">
+                <xsl:choose>
+                    <xsl:when test="(@flag,@role) = ('fatal', 'error')">error</xsl:when>
+                    <xsl:when test="(@flag,@role) = ('warning', 'warn')">warning</xsl:when>
+                    <xsl:when test="(@flag,@role) = ('information', 'info')">information</xsl:when>
+                    <xsl:when test="@role = ('information', 'info')">warning</xsl:when>
+                    <xsl:otherwise>error</xsl:otherwise>
+                </xsl:choose>
+            </xsl:attribute>
+            <xsl:apply-templates select="@location"/>
+            <xsl:apply-templates select="@id"/>
+            <xsl:if test="empty(@id)">
+                <xsl:attribute name="code">UNSPECIFIC</xsl:attribute>
+            </xsl:if>
+            <xsl:value-of select="svrl:text"/>
+        </rep:message> 
+    </xsl:template>
+    
+    <xsl:template match="svrl:*/@location">
+        <xsl:attribute name="xpathLocation" select="."/>
+    </xsl:template>
+    
+    <xsl:template match="svrl:failed-assert/@id">
+        <xsl:attribute name="code" select="."/>
+    </xsl:template>
+
+    <xsl:template match="svrl:failed-assert/@flag">
+        <xsl:attribute name="code" select="."/>
+    </xsl:template>
+
+    <xsl:template match="svrl:successful-report/@id">
+        <xsl:attribute name="code" select="."/>
+    </xsl:template>
+    
+    <!-- ************************************************************************************** -->
+    <!-- * Validation helpers                                                                 * -->
+    <!-- ************************************************************************************** -->
+    
+    <!-- Identity template -->
+    <xsl:template mode="copy-to-report-ns" match="@*">
+        <xsl:copy/>
+    </xsl:template>
+    
+    <xsl:template mode="copy-to-report-ns" match="element()" priority="5">
+        <xsl:element name="rep:{local-name()}">
+            <xsl:apply-templates mode="copy-to-report-ns" select="node()|@*"/>
+        </xsl:element>
+    </xsl:template>
+    
+    <!-- ************************************************************************************** -->
+    <!-- *                                                                                    * -->
+    <!-- * Assessment                                                            * -->
+    <!-- *                                                                                    * -->
+    <!-- ************************************************************************************** -->
+    
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Dieses Template ergänzt einen Prüfbericht um eine Handlungsempfehlung in Form eines
+                <xd:i>accept</xd:i> oder <xd:i>reject</xd:i> Elements.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="rep:report" mode="assessment">
+        <rep:assessment>
+            <xsl:variable name="element-name" as="xs:string">
+                <xsl:choose>
+                    <xsl:when test="empty(rep:scenarioMatched/s:scenario)">reject</xsl:when>
+                    <xsl:when test="//rep:message[rep:custom-level(.) = 'error']">reject</xsl:when>
+                    <xsl:otherwise>accept</xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:element name="rep:{$element-name}" exclude-result-prefixes="#all">
+                <xsl:call-template name="explanations"/>
+            </xsl:element>
+        </rep:assessment>
+    </xsl:template>
+
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Ermittelt für eine während der Validierung ausgegebene Meldung deren
+                Rolle <xd:i>(error, warning, information)</xd:i> gemäß der
+                benutzerspezifischen Qualifizierung.</xd:p>
+            <xd:p>Jede Meldung hat im Rahmen der Validierung ein solche Rolle
+                erhalten (siehe Attribut <xd:i>@level</xd:i>). Im Regelfall entspricht die
+                benutzerspezifische Qualifizierung unverändert diesem Level. Nutzer können jedoch im
+                Rahmen der Bewertung eigene Qualifizierungen als <xd:i>customLevel</xd:i> festlegen.</xd:p>
+            <xd:p>Dies kann z. B. genutzt werden, um einen <xd:i>error</xd:i>, der ansonsten zur
+                Rückweisung der Nachricht führen würde, zumindest zeitweilig als
+                <xd:i>warning</xd:i> zu qualifizieren, so dass eine entsprechende
+                Dokumenteninstanz trotz einer Warnung angenommen und verarbeitet würde.</xd:p>
+            <xd:p>Die Funktion prüft für eine Meldung, ob deren <xd:i>@code</xd:i> Attribut
+                Bestandteil der für ein bestimmtes <xd:i>customLevel</xd:i> angegebenen Fehlercodes ist.
+                Falls ja, dann gilt das jeweilige <xd:i>customLevel</xd:i>. Andernfalls wird der im
+                Rahmen der Validierung ermittelte Fehlerlevel unverändert übernommen.</xd:p>
+        </xd:desc>
+        <xd:param name="message">Eine im Rahmen der Validierung ausgegebene
+            Fehlernachricht</xd:param>
+        <xd:return/>
+    </xd:doc>
+    <xsl:function name="rep:custom-level" as="xs:string">
+        <xsl:param name="message" as="element(rep:message)"/>
+        <xsl:variable name="cl" as="element(s:customLevel)?"
+            select="$custom-levels[tokenize(., '\s+') = $message/@code]"/>
+        <xsl:value-of select="if ($cl) then $cl/@level else $message/@level"/>
+    </xsl:function>
+    
+    <xsl:template name="explanations">
+        <rep:explanation>
+            <xsl:call-template name="html:html"/>
+        </rep:explanation>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>Dieses Template erstellt aus dem ansonsten fertigen Prüfbericht eine HTML-Darstellung. Dieses Template
+            oder Unter-Temlates (Name html:*) können in einem Customization Layer überschrieben werden.</xd:desc>
+    </xd:doc>
+    <xsl:template name="html:html" xmlns="http://www.w3.org/1999/xhtml" >
+        <html data-report-type="report">
+            <xsl:call-template name="html:head"/>
+            <body>
+                <xsl:call-template name="html:document"/>
+            </body>
+        </html>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Generiert das <xd:i>head</xd:i> Element eines eingebetteten HTML Dokuments,
+                welches den Prüf- und Bewertungsbericht visualisiert und die Handlungsempfehlung
+                begründet</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template name="html:head" as="element(html:head)" xmlns="http://www.w3.org/1999/xhtml" >
+        <head>
+            <title>Prüfbericht</title>
+            <style>
+                body{
+                font-family: Calibri;
+                width: 230mm;
+                }
+                
+                .metadata dt {
+                float: left;
+                width: 230px;
+                clear: left;
+                }
+                
+                .metadata dd {
+                margin-left: 250px;
+                }
+                
+                table{
+                border-collapse: collapse;
+                width: 100%;
+                }
+                
+                table.tbl-errors{
+                font-size: smaller;
+                }
+               
+                table.document{
+                font-size: smaller;
+                }
+               
+                table.document td {vertical-align:top;}
+                
+                .tbl-errors td{
+                border: 1px solid lightgray;
+                padding: 2px;
+                vertical-align: top;
+                }
+                
+                thead{
+                font-weight: bold;
+                background-color: #f0f0f0;
+                padding-top: 6pt;
+                padding-bottom: 2pt;
+                }
+                
+                .tbl-meta td{
+                padding-right: 1em;
+                }
+                
+                td.pos{
+                padding-left: 3pt;
+                width: 5%;
+                color: gray
+                }
+                
+                td.element{
+                width: 95%;
+                word-wrap: break-word;
+                }
+                
+                
+                td.element:before{
+                content: attr(title);
+                color: gray;
+                }
+                
+                
+                div.attribute{
+                display: inline;
+                font-style: italic;
+                color: gray;
+                }
+                div.attribute:before{
+                content: attr(title) '=';
+                }
+                div.val{
+                display: inline;
+                font-weight: bold;
+                }
+                
+                td.level1{
+                padding-left: 2mm;
+                }
+                
+                td.level2{
+                padding-left: 5mm;
+                }
+                
+                td.level3{
+                padding-left: 10mm;
+                }
+                
+                td.level4{
+                padding-left: 15mm;
+                }
+                
+                td.level5{
+                padding-left: 20mm;
+                }
+                td.level6{
+                padding-left: 25mm;
+                }
+                
+                tr{
+                vertical-align: bottom;
+                border-bottom: 1px solid #c0c0c0;
+                }
+                
+                .error{
+                color: red;
+                }
+                
+                .warning{
+                }
+                
+                p.important{
+                font-weight: bold;
+                text-align: left;
+                background-color: #e0e0e0;
+                padding: 3pt;
+                }
+                
+                td.right{
+                text-align: right
+                }</style>
+        </head>
+    </xsl:template>
+    
+    <xsl:template name="html:document" xmlns="http://www.w3.org/1999/xhtml">
+        <h1>Prüfbericht</h1>
+        
+        <xsl:call-template name="html:document-metadata"/>
+        
+        <xsl:call-template name="html:conformance"/>
+        
+        <xsl:if test="//rep:message">
+            <xsl:call-template name="html:validationresults"/>
+        </xsl:if>
+        <xsl:call-template name="html:assessment"/>
+        
+        <xsl:if test="$input-document instance of document-node(element())">
+            <xsl:call-template name="html:contentdoc">
+                <xsl:with-param name="invoice" select="$input-document"/>
+            </xsl:call-template>
+        </xsl:if>
+        
+        <xsl:call-template name="html:epilog"/>
+    </xsl:template>
+    
+    
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Generiert am Beginn eines eingebetteten HTML Dokuments, welches den Prüf- und
+                Bewertungsbericht visualisiert und die Handlungsempfehlung begründet, eine Übersicht
+                mit Metadaten des geprüften Dokuments.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template name="html:document-metadata" as="element()+" xmlns="http://www.w3.org/1999/xhtml" >
+        <div class="metadata">
+            <p  class="important">
+                <xsl:text>Angaben zum geprüften Dokument</xsl:text>
+            </p>
+            <dl>
+                <dt>Referenz:</dt>
+                <dd>
+                    <xsl:value-of select="rep:documentIdentification/rep:documentReference"/>
+                </dd>
+                    
+                <dt>Zeitpunkt der Prüfung:</dt>
+                <dd>
+                    <xsl:value-of select="format-dateTime(rep:timestamp, '[D].[M].[Y] [H]:[m]:[s]')"/>
+                </dd>
+    
+                <dt>Erkannter Dokumenttyp:</dt>
+                <dd>
+                    <xsl:choose>
+                        <xsl:when test="rep:scenarioMatched">
+                            <xsl:value-of select="rep:scenarioMatched/s:scenario/s:name"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <b class="error">unbekannt</b>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </dd>
+            </dl>
+            <xsl:call-template name="html:documentData"/>        
+        </div>
+    </xsl:template>
+
+    <xsl:template name="html:documentData"/>
+
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Generiert am Ende eines eingebetteten HTML Dokuments, welches den Prüf- und
+                Bewertungsbericht visualisiert und die Handlungsempfehlung begründet, eine Übersicht
+                mit Metadaten zum Prüfmodul.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template name="html:epilog" as="element()+" xmlns="http://www.w3.org/1999/xhtml" >
+        <p class="info">
+            <xsl:text>Dieser Prüfbericht wurde erstellt mit </xsl:text>
+            <xsl:value-of select="rep:engine/rep:name"/>
+            <xsl:text>.</xsl:text>
+        </p>
+    </xsl:template>
+
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Generiert in dem eingebetetteten HTML Dokument eine Tabelle mit den während der
+                Validierung ausgegebenen Daten.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template name="html:validationresults" as="element()*" xmlns="http://www.w3.org/1999/xhtml" >
+        <p>Übersicht der Validierungsergebnisse:</p>
+        <table class="tbl-errors">
+            <thead>
+                <tr>
+                    <th>Prüfschritt</th>
+                    <th>Fehler</th>
+                    <th>Warnungen</th>
+                    <th>Informationen</th>
+                </tr>
+            </thead>
+            <tbody>
+               <xsl:for-each select="//rep:validationStepResult">
+                   <xsl:variable name="step-id" select="@id"/>
+                   <tr>
+                       <td>
+                           <xsl:value-of select="s:resource/s:name"/>
+                           <xsl:text> (</xsl:text>
+                           <xsl:value-of select="@id"/>
+                           <xsl:text>)</xsl:text>
+                       </td>
+                       <td style="width: 30mm;">
+                           <xsl:value-of
+                               select="count(rep:message[@level eq 'error'])"/>
+                       </td>
+                       <td style="width: 30mm;">
+                           <xsl:value-of
+                               select="count(rep:message[@level eq 'warning'])"/>
+                       </td>
+                       <td style="width: 30mm;">
+                           <xsl:value-of
+                               select="count(rep:message[@level eq 'information'])"
+                           />
+                       </td>
+                   </tr>
+               </xsl:for-each>
+            </tbody>
+        </table>
+        
+        <p>Validierungsergebnisse im Detail:</p>
+        <table xmlns="http://www.w3.org/1999/xhtml" class="tbl-errors">
+            <thead>
+                <tr>
+                    <th style="width: 30mm;">Pos</th>
+                    <th style="width: 25mm;">Code</th>
+                    <th style="width: 25mm;">Adj. Grad (Grad)</th>
+                    <th>Text</th>
+                </tr>
+            </thead>
+            <tbody>
+                <xsl:for-each select="//rep:message">
+                    <tr>
+                        <xsl:attribute name="class">
+                            <xsl:value-of select="rep:custom-level(.)"/>
+                        </xsl:attribute>
+                        <td rowspan="2">
+                            <xsl:value-of select="@id"/>
+                        </td>
+                        <td rowspan="2">
+                            <xsl:value-of select="@code"/>
+                        </td>
+                        <td rowspan="2">
+                            <xsl:value-of select="rep:custom-level(.)"/>
+                            <xsl:if test="not(rep:custom-level(.) eq @level)">
+                                <xsl:value-of select="concat(' (', @level, ')')"/>
+                            </xsl:if>
+                        </td>
+                        <td>
+                            <xsl:value-of select="normalize-space(.)"/>
+                        </td>
+                    </tr>
+                    <tr>
+                        <xsl:attribute name="class">
+                            <xsl:value-of select="rep:custom-level(.)"/>
+                        </xsl:attribute>
+                        <td>
+                            <xsl:if test="@xpathLocation">
+                                <xsl:text>Pfad: </xsl:text><xsl:value-of select="@xpathLocation"/>
+                            </xsl:if>
+                            <xsl:if test="@lineNumber">
+                                <xsl:text> Zeile: </xsl:text><xsl:value-of select="@lineNumber"/>
+                            </xsl:if>
+                            <xsl:if test="@columnNumber">
+                                <xsl:text> Spalte: </xsl:text><xsl:value-of select="@columnNumber"/>
+                            </xsl:if>
+                        </td>
+                    </tr>
+                </xsl:for-each>
+            </tbody>
+        </table>
+    </xsl:template>
+
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Generiert in dem eingebetteten HTML Dokument eine Aussage zur Konformität des
+                geprüften Dokuments zu den formalen Vorgaben.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template name="html:conformance" xmlns="http://www.w3.org/1999/xhtml" >
+        <xsl:variable name="e" as="xs:integer" select="count(//rep:message[@level eq 'error'])"/>
+        <xsl:variable name="w" as="xs:integer" select="count(//rep:message[@level eq 'warning'])"/>
+        <xsl:choose>
+            <xsl:when test="rep:scenarioMatched">
+                <p class="important">
+                    <b>Konformitätsprüfung: </b>
+                    <xsl:text>Das geprüfte Dokument enthält </xsl:text>
+                    <xsl:choose>
+                        <xsl:when test="$e + $w eq 0">
+                            <xsl:text>weder Fehler noch Warnungen. Es ist konform zu den formalen Vorgaben.</xsl:text>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="concat($e, ' Fehler / ', $w, ' Warnungen. Es ist ')"/>
+                            <b>nicht konform</b>
+                            <xsl:text> zu den formalen Vorgaben.</xsl:text>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </p>
+            </xsl:when>
+            <xsl:otherwise>
+                <p class="important">
+                    <b>Konformitätsprüfung: </b>
+                    <xsl:text>Das geprüfte Dokument entspricht keinen zulässigen Dokumenttyp und ist damit </xsl:text>
+                    <b>nicht konform</b>
+                    <xsl:text> zu den formalen Vorgaben.</xsl:text>
+                </p>
+            </xsl:otherwise>
+        </xsl:choose>
+        
+    </xsl:template>
+
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Generiert in dem eingebetteten HTML Dokument die Aussage zur
+                Handlungsempfehlung.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template name="html:assessment" xmlns="http://www.w3.org/1999/xhtml">
+        <!-- changed 2019-12-17 from count(//message[@level eq 'error']) -->
+        <xsl:variable name="e1" as="xs:integer" select="count(//rep:message[@level eq 'error'])"/>
+        <xsl:variable name="e2" as="xs:integer"
+            select="count(//rep:message[rep:custom-level(.) eq 'error'])"/>
+            <xsl:choose>
+                <xsl:when test="empty(rep:scenarioMatched)">
+                    <p class="important error">Bewertung: Es wird empfohlen das Dokument zurückzuweisen.</p>
+                </xsl:when>
+                <xsl:when test="$e1 eq 0 and $e2 eq 0">
+                    <p class="important">Bewertung: Es wird empfohlen das Dokument anzunehmen und weiter zu verarbeiten.</p>
+                </xsl:when>
+                <xsl:when test="$e1 gt 0 and $e2 eq 0">
+                    <p class="important">Bewertung: Es wird empfohlen das Dokument anzunehmen und zu verarbeiten, da die vorhandenen Fehler derzeit toleriert werden.</p>
+                </xsl:when>
+                <xsl:otherwise>
+                    <p class="important error">Bewertung: Es wird empfohlen das Dokument zurückzuweisen.</p>
+                </xsl:otherwise>
+            </xsl:choose>
+    </xsl:template>
+    
+    
+    
+    
+    <xsl:template name="html:contentdoc" xmlns="http://www.w3.org/1999/xhtml" >
+        <xsl:param name="invoice" as="document-node(element())"/>
+        <p  class="important">
+            <xsl:text>Inhalt des Rechnungsdokuments:</xsl:text>
+        </p>
+        <table class="document">
+            <xsl:apply-templates select="$invoice/*" mode="html:contentdoc"/>
+        </table>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Eine Element wird als eine Zeile in einer Tabelle visualisiert. Die erste Spalte
+                enthält die Zeilennummer, die zweite Attribute und Text des Elements</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="*" mode="html:contentdoc" xmlns="http://www.w3.org/1999/xhtml">
+        <xsl:variable name="line-number" as="xs:string">
+            <xsl:number select="." count="*" level="any" format="0001"/>
+        </xsl:variable>
+        <tr class="row"  id="{$line-number}">
+            <td class="pos">
+                <xsl:value-of select="$line-number"/>
+            </td>
+            <td class="element {concat('level',count(ancestor-or-self::*))}" title="{local-name()}">
+                <xsl:apply-templates select="text()" mode="html:contentdoc"/>
+                <xsl:apply-templates select="@*" mode="html:contentdoc"/>
+            </td>
+        </tr>
+        <xsl:apply-templates select="*" mode="html:contentdoc"/>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Ein Textbereich (in der Zeile des Elements)</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="text()" mode="html:contentdoc" xmlns="http://www.w3.org/1999/xhtml">
+        <div class="val">
+            <xsl:value-of select="."/>
+        </div>
+    </xsl:template>
+    
+    <xsl:template match="element(*, xs:base64Binary)/text()" priority="10" mode="html:contentdoc">
+        <div class="val" xmlns="http://www.w3.org/1999/xhtml">
+            <xsl:text>[ … ]</xsl:text>
+        </div>
+    </xsl:template>
+    
+    <xsl:template match="@xsi:schemaLocation" mode="html:contentdoc"/>
+    
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Ein Attributbereich (in der Zeile des Elements)</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="@*" mode="html:contentdoc" xmlns="http://www.w3.org/1999/xhtml" >
+        <div class="attribute" title="{local-name(.)}">
+            <xsl:value-of select="."/>
+        </div>
+    </xsl:template>    
+        
+</xsl:stylesheet>

--- a/data/kosit/bis/resources/peppol/billing-bis/3.0.19/CEN-EN16931-UBL.xslt
+++ b/data/kosit/bis/resources/peppol/billing-bis/3.0.19/CEN-EN16931-UBL.xslt
@@ -1,0 +1,15565 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xsl:stylesheet xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cn="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:iso="http://purl.oclc.org/dsdl/schematron" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:saxon="http://saxon.sf.net/" xmlns:schold="http://www.ascc.net/xml/schematron" xmlns:ubl="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<!--Implementers: please note that overriding process-prolog or process-root is 
+    the preferred method for meta-stylesheets to use where possible. -->
+
+<xsl:param name="archiveDirParameter" />
+  <xsl:param name="archiveNameParameter" />
+  <xsl:param name="fileNameParameter" />
+  <xsl:param name="fileDirParameter" />
+  <xsl:variable name="document-uri">
+    <xsl:value-of select="document-uri(/)" />
+  </xsl:variable>
+
+<!--PHASES-->
+
+
+<!--PROLOG-->
+<xsl:output indent="yes" method="xml" omit-xml-declaration="no" standalone="yes" />
+
+<!--XSD TYPES FOR XSLT2-->
+
+
+<!--KEYS AND FUNCTIONS-->
+
+
+<!--DEFAULT RULES-->
+
+
+<!--MODE: SCHEMATRON-SELECT-FULL-PATH-->
+<!--This mode can be used to generate an ugly though full XPath for locators-->
+<xsl:template match="*" mode="schematron-select-full-path">
+    <xsl:apply-templates mode="schematron-get-full-path" select="." />
+  </xsl:template>
+
+<!--MODE: SCHEMATRON-FULL-PATH-->
+<!--This mode can be used to generate an ugly though full XPath for locators-->
+<xsl:template match="*" mode="schematron-get-full-path">
+    <xsl:apply-templates mode="schematron-get-full-path" select="parent::*" />
+    <xsl:text>/</xsl:text>
+    <xsl:choose>
+      <xsl:when test="namespace-uri()=''">
+        <xsl:value-of select="name()" />
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>*:</xsl:text>
+        <xsl:value-of select="local-name()" />
+        <xsl:text>[namespace-uri()='</xsl:text>
+        <xsl:value-of select="namespace-uri()" />
+        <xsl:text>']</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:variable name="preceding" select="count(preceding-sibling::*[local-name()=local-name(current())                                   and namespace-uri() = namespace-uri(current())])" />
+    <xsl:text>[</xsl:text>
+    <xsl:value-of select="1+ $preceding" />
+    <xsl:text>]</xsl:text>
+  </xsl:template>
+  <xsl:template match="@*" mode="schematron-get-full-path">
+    <xsl:apply-templates mode="schematron-get-full-path" select="parent::*" />
+    <xsl:text>/</xsl:text>
+    <xsl:choose>
+      <xsl:when test="namespace-uri()=''">@<xsl:value-of select="name()" />
+</xsl:when>
+      <xsl:otherwise>
+        <xsl:text>@*[local-name()='</xsl:text>
+        <xsl:value-of select="local-name()" />
+        <xsl:text>' and namespace-uri()='</xsl:text>
+        <xsl:value-of select="namespace-uri()" />
+        <xsl:text>']</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+<!--MODE: SCHEMATRON-FULL-PATH-2-->
+<!--This mode can be used to generate prefixed XPath for humans-->
+<xsl:template match="node() | @*" mode="schematron-get-full-path-2">
+    <xsl:for-each select="ancestor-or-self::*">
+      <xsl:text>/</xsl:text>
+      <xsl:value-of select="name(.)" />
+      <xsl:if test="preceding-sibling::*[name(.)=name(current())]">
+        <xsl:text>[</xsl:text>
+        <xsl:value-of select="count(preceding-sibling::*[name(.)=name(current())])+1" />
+        <xsl:text>]</xsl:text>
+      </xsl:if>
+    </xsl:for-each>
+    <xsl:if test="not(self::*)">
+      <xsl:text />/@<xsl:value-of select="name(.)" />
+    </xsl:if>
+  </xsl:template>
+<!--MODE: SCHEMATRON-FULL-PATH-3-->
+<!--This mode can be used to generate prefixed XPath for humans 
+	(Top-level element has index)-->
+
+<xsl:template match="node() | @*" mode="schematron-get-full-path-3">
+    <xsl:for-each select="ancestor-or-self::*">
+      <xsl:text>/</xsl:text>
+      <xsl:value-of select="name(.)" />
+      <xsl:if test="parent::*">
+        <xsl:text>[</xsl:text>
+        <xsl:value-of select="count(preceding-sibling::*[name(.)=name(current())])+1" />
+        <xsl:text>]</xsl:text>
+      </xsl:if>
+    </xsl:for-each>
+    <xsl:if test="not(self::*)">
+      <xsl:text />/@<xsl:value-of select="name(.)" />
+    </xsl:if>
+  </xsl:template>
+
+<!--MODE: GENERATE-ID-FROM-PATH -->
+<xsl:template match="/" mode="generate-id-from-path" />
+  <xsl:template match="text()" mode="generate-id-from-path">
+    <xsl:apply-templates mode="generate-id-from-path" select="parent::*" />
+    <xsl:value-of select="concat('.text-', 1+count(preceding-sibling::text()), '-')" />
+  </xsl:template>
+  <xsl:template match="comment()" mode="generate-id-from-path">
+    <xsl:apply-templates mode="generate-id-from-path" select="parent::*" />
+    <xsl:value-of select="concat('.comment-', 1+count(preceding-sibling::comment()), '-')" />
+  </xsl:template>
+  <xsl:template match="processing-instruction()" mode="generate-id-from-path">
+    <xsl:apply-templates mode="generate-id-from-path" select="parent::*" />
+    <xsl:value-of select="concat('.processing-instruction-', 1+count(preceding-sibling::processing-instruction()), '-')" />
+  </xsl:template>
+  <xsl:template match="@*" mode="generate-id-from-path">
+    <xsl:apply-templates mode="generate-id-from-path" select="parent::*" />
+    <xsl:value-of select="concat('.@', name())" />
+  </xsl:template>
+  <xsl:template match="*" mode="generate-id-from-path" priority="-0.5">
+    <xsl:apply-templates mode="generate-id-from-path" select="parent::*" />
+    <xsl:text>.</xsl:text>
+    <xsl:value-of select="concat('.',name(),'-',1+count(preceding-sibling::*[name()=name(current())]),'-')" />
+  </xsl:template>
+
+<!--MODE: GENERATE-ID-2 -->
+<xsl:template match="/" mode="generate-id-2">U</xsl:template>
+  <xsl:template match="*" mode="generate-id-2" priority="2">
+    <xsl:text>U</xsl:text>
+    <xsl:number count="*" level="multiple" />
+  </xsl:template>
+  <xsl:template match="node()" mode="generate-id-2">
+    <xsl:text>U.</xsl:text>
+    <xsl:number count="*" level="multiple" />
+    <xsl:text>n</xsl:text>
+    <xsl:number count="node()" />
+  </xsl:template>
+  <xsl:template match="@*" mode="generate-id-2">
+    <xsl:text>U.</xsl:text>
+    <xsl:number count="*" level="multiple" />
+    <xsl:text>_</xsl:text>
+    <xsl:value-of select="string-length(local-name(.))" />
+    <xsl:text>_</xsl:text>
+    <xsl:value-of select="translate(name(),':','.')" />
+  </xsl:template>
+<!--Strip characters-->  <xsl:template match="text()" priority="-1" />
+
+<!--SCHEMA SETUP-->
+<xsl:template match="/">
+    <svrl:schematron-output schemaVersion="" title="EN16931  model bound to UBL">
+      <xsl:comment>
+        <xsl:value-of select="$archiveDirParameter" />   
+		 <xsl:value-of select="$archiveNameParameter" />  
+		 <xsl:value-of select="$fileNameParameter" />  
+		 <xsl:value-of select="$fileDirParameter" />
+      </xsl:comment>
+      <svrl:ns-prefix-in-attribute-values prefix="ext" uri="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="cbc" uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="cac" uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="qdt" uri="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="udt" uri="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="cn" uri="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="ubl" uri="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="xs" uri="http://www.w3.org/2001/XMLSchema" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="id">UBL-model</xsl:attribute>
+        <xsl:attribute name="name">UBL-model</xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M11" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="id">UBL-syntax</xsl:attribute>
+        <xsl:attribute name="name">UBL-syntax</xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M12" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="id">Codesmodel</xsl:attribute>
+        <xsl:attribute name="name">Codesmodel</xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M13" select="/" />
+    </svrl:schematron-output>
+  </xsl:template>
+
+<!--SCHEMATRON PATTERNS-->
+<svrl:text>EN16931  model bound to UBL</svrl:text>
+
+<!--PATTERN UBL-model-->
+
+
+	<!--RULE -->
+<xsl:template match="cac:AdditionalDocumentReference" mode="M11" priority="1066">
+    <svrl:fired-rule context="cac:AdditionalDocumentReference" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID) != ''">
+          <xsl:attribute name="id">BR-52</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-52]-Each Additional supporting document (BG-24) shall contain a Supporting document reference (BT-122).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/ubl:Invoice/cac:LegalMonetaryTotal/cbc:PayableAmount" mode="M11" priority="1065">
+    <svrl:fired-rule context="/ubl:Invoice/cac:LegalMonetaryTotal/cbc:PayableAmount" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((. > 0) and (exists(//cbc:DueDate) or exists(//cac:PaymentTerms/cbc:Note))) or (. &lt;= 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((. > 0) and (exists(//cbc:DueDate) or exists(//cac:PaymentTerms/cbc:Note))) or (. &lt;= 0)">
+          <xsl:attribute name="id">BR-CO-25</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-25]-In case the Amount due for payment (BT-115) is positive, either the Payment due date (BT-9) or the Payment terms (BT-20) shall be present.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingCustomerParty/cac:Party/cbc:EndpointID" mode="M11" priority="1064">
+    <svrl:fired-rule context="cac:AccountingCustomerParty/cac:Party/cbc:EndpointID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(@schemeID)">
+          <xsl:attribute name="id">BR-63</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-63]-The Buyer electronic address (BT-49) shall have a Scheme identifier.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingCustomerParty/cac:Party/cac:PostalAddress" mode="M11" priority="1063">
+    <svrl:fired-rule context="cac:AccountingCustomerParty/cac:Party/cac:PostalAddress" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cac:Country/cbc:IdentificationCode) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cac:Country/cbc:IdentificationCode) != ''">
+          <xsl:attribute name="id">BR-11</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-11]-The Buyer postal address shall contain a Buyer country code (BT-55).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PaymentMeans/cac:CardAccount/cbc:PrimaryAccountNumberID" mode="M11" priority="1062">
+    <svrl:fired-rule context="cac:PaymentMeans/cac:CardAccount/cbc:PrimaryAccountNumberID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space(.))&lt;=10" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space(.))&lt;=10">
+          <xsl:attribute name="id">BR-51</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-51]-In accordance with card payments security standards an invoice should never include a full card primary account number (BT-87). At the moment PCI Security Standards Council has defined that the first 6 digits and last 4 digits are the maximum number of digits to be shown.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:Delivery/cac:DeliveryLocation/cac:Address" mode="M11" priority="1061">
+    <svrl:fired-rule context="cac:Delivery/cac:DeliveryLocation/cac:Address" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:Country/cbc:IdentificationCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:Country/cbc:IdentificationCode)">
+          <xsl:attribute name="id">BR-57</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-57]-Each Deliver to address (BG-15) shall contain a Deliver to country code (BT-80).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/ubl:Invoice/cac:AllowanceCharge[cbc:ChargeIndicator = false()] | /cn:CreditNote/cac:AllowanceCharge[cbc:ChargeIndicator = false()]" mode="M11" priority="1060">
+    <svrl:fired-rule context="/ubl:Invoice/cac:AllowanceCharge[cbc:ChargeIndicator = false()] | /cn:CreditNote/cac:AllowanceCharge[cbc:ChargeIndicator = false()]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:Amount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:Amount)">
+          <xsl:attribute name="id">BR-31</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-31]-Each Document level allowance (BG-20) shall have a Document level allowance amount (BT-92).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID)">
+          <xsl:attribute name="id">BR-32</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-32]-Each Document level allowance (BG-20) shall have a Document level allowance VAT category code (BT-95).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)">
+          <xsl:attribute name="id">BR-33</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-33]-Each Document level allowance (BG-20) shall have a Document level allowance reason (BT-97) or a Document level allowance reason code (BT-98).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="true()" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="true()">
+          <xsl:attribute name="id">BR-CO-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-05]-Document level allowance reason code (BT-98) and Document level allowance reason (BT-97) shall indicate the same type of allowance.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)">
+          <xsl:attribute name="id">BR-CO-21</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-21]-Each Document level allowance (BG-20) shall contain a Document level allowance reason (BT-97) or a Document level allowance reason code (BT-98), or both.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:Amount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:Amount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-01]-The allowed maximum number of decimals for the Document level allowance amount (BT-92) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:BaseAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:BaseAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-02]-The allowed maximum number of decimals for the Document level allowance base amount (BT-93) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/ubl:Invoice/cac:AllowanceCharge[cbc:ChargeIndicator = true()] | /cn:CreditNote/cac:AllowanceCharge[cbc:ChargeIndicator = true()]" mode="M11" priority="1059">
+    <svrl:fired-rule context="/ubl:Invoice/cac:AllowanceCharge[cbc:ChargeIndicator = true()] | /cn:CreditNote/cac:AllowanceCharge[cbc:ChargeIndicator = true()]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:Amount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:Amount)">
+          <xsl:attribute name="id">BR-36</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-36]-Each Document level charge (BG-21) shall have a Document level charge amount (BT-99).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID)">
+          <xsl:attribute name="id">BR-37</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-37]-Each Document level charge (BG-21) shall have a Document level charge VAT category code (BT-102).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)">
+          <xsl:attribute name="id">BR-38</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-38]-Each Document level charge (BG-21) shall have a Document level charge reason (BT-104) or a Document level charge reason code (BT-105).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="true()" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="true()">
+          <xsl:attribute name="id">BR-CO-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-06]-Document level charge reason code (BT-105) and Document level charge reason (BT-104) shall indicate the same type of charge.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)">
+          <xsl:attribute name="id">BR-CO-22</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-22]-Each Document level charge (BG-21) shall contain a Document level charge reason (BT-104) or a Document level charge reason code (BT-105), or both.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:Amount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:Amount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-05]-The allowed maximum number of decimals for the Document level charge amount (BT-99) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:BaseAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:BaseAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-06]-The allowed maximum number of decimals for the Document level charge base amount (BT-100) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:LegalMonetaryTotal" mode="M11" priority="1058">
+    <svrl:fired-rule context="cac:LegalMonetaryTotal" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:LineExtensionAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:LineExtensionAmount)">
+          <xsl:attribute name="id">BR-12</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-12]-An Invoice shall have the Sum of Invoice line net amount (BT-106).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:TaxExclusiveAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:TaxExclusiveAmount)">
+          <xsl:attribute name="id">BR-13</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-13]-An Invoice shall have the Invoice total amount without VAT (BT-109).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:TaxInclusiveAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:TaxInclusiveAmount)">
+          <xsl:attribute name="id">BR-14</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-14]-An Invoice shall have the Invoice total amount with VAT (BT-112).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:PayableAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:PayableAmount)">
+          <xsl:attribute name="id">BR-15</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-15]-An Invoice shall have the Amount due for payment (BT-115).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:LineExtensionAmount) = xs:decimal(round(sum(//(cac:InvoiceLine|cac:CreditNoteLine)/xs:decimal(cbc:LineExtensionAmount)) * 10 * 10) div 100))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:LineExtensionAmount) = xs:decimal(round(sum(//(cac:InvoiceLine|cac:CreditNoteLine)/xs:decimal(cbc:LineExtensionAmount)) * 10 * 10) div 100))">
+          <xsl:attribute name="id">BR-CO-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-10]-Sum of Invoice line net amount (BT-106) = Σ Invoice line net amount (BT-131).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="xs:decimal(cbc:AllowanceTotalAmount) = (round(sum(../cac:AllowanceCharge[cbc:ChargeIndicator=false()]/xs:decimal(cbc:Amount)) * 10 * 10) div 100) or  (not(cbc:AllowanceTotalAmount) and not(../cac:AllowanceCharge[cbc:ChargeIndicator=false()]))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="xs:decimal(cbc:AllowanceTotalAmount) = (round(sum(../cac:AllowanceCharge[cbc:ChargeIndicator=false()]/xs:decimal(cbc:Amount)) * 10 * 10) div 100) or (not(cbc:AllowanceTotalAmount) and not(../cac:AllowanceCharge[cbc:ChargeIndicator=false()]))">
+          <xsl:attribute name="id">BR-CO-11</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-11]-Sum of allowances on document level (BT-107) = Σ Document level allowance amount (BT-92).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="xs:decimal(cbc:ChargeTotalAmount) = (round(sum(../cac:AllowanceCharge[cbc:ChargeIndicator=true()]/xs:decimal(cbc:Amount)) * 10 * 10) div 100) or (not(cbc:ChargeTotalAmount) and not(../cac:AllowanceCharge[cbc:ChargeIndicator=true()]))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="xs:decimal(cbc:ChargeTotalAmount) = (round(sum(../cac:AllowanceCharge[cbc:ChargeIndicator=true()]/xs:decimal(cbc:Amount)) * 10 * 10) div 100) or (not(cbc:ChargeTotalAmount) and not(../cac:AllowanceCharge[cbc:ChargeIndicator=true()]))">
+          <xsl:attribute name="id">BR-CO-12</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-12]-Sum of charges on document level (BT-108) = Σ Document level charge amount (BT-99).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((cbc:ChargeTotalAmount) and (cbc:AllowanceTotalAmount) and (xs:decimal(cbc:TaxExclusiveAmount) = round((xs:decimal(cbc:LineExtensionAmount) + xs:decimal(cbc:ChargeTotalAmount) - xs:decimal(cbc:AllowanceTotalAmount)) * 10 * 10) div 100 ))  or (not(cbc:ChargeTotalAmount) and (cbc:AllowanceTotalAmount) and (xs:decimal(cbc:TaxExclusiveAmount) = round((xs:decimal(cbc:LineExtensionAmount) - xs:decimal(cbc:AllowanceTotalAmount)) * 10 * 10 ) div 100)) or ((cbc:ChargeTotalAmount) and not(cbc:AllowanceTotalAmount) and (xs:decimal(cbc:TaxExclusiveAmount) = round((xs:decimal(cbc:LineExtensionAmount) + xs:decimal(cbc:ChargeTotalAmount)) * 10 * 10 ) div 100)) or (not(cbc:ChargeTotalAmount) and not(cbc:AllowanceTotalAmount) and (xs:decimal(cbc:TaxExclusiveAmount) = xs:decimal(cbc:LineExtensionAmount)))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((cbc:ChargeTotalAmount) and (cbc:AllowanceTotalAmount) and (xs:decimal(cbc:TaxExclusiveAmount) = round((xs:decimal(cbc:LineExtensionAmount) + xs:decimal(cbc:ChargeTotalAmount) - xs:decimal(cbc:AllowanceTotalAmount)) * 10 * 10) div 100 )) or (not(cbc:ChargeTotalAmount) and (cbc:AllowanceTotalAmount) and (xs:decimal(cbc:TaxExclusiveAmount) = round((xs:decimal(cbc:LineExtensionAmount) - xs:decimal(cbc:AllowanceTotalAmount)) * 10 * 10 ) div 100)) or ((cbc:ChargeTotalAmount) and not(cbc:AllowanceTotalAmount) and (xs:decimal(cbc:TaxExclusiveAmount) = round((xs:decimal(cbc:LineExtensionAmount) + xs:decimal(cbc:ChargeTotalAmount)) * 10 * 10 ) div 100)) or (not(cbc:ChargeTotalAmount) and not(cbc:AllowanceTotalAmount) and (xs:decimal(cbc:TaxExclusiveAmount) = xs:decimal(cbc:LineExtensionAmount)))">
+          <xsl:attribute name="id">BR-CO-13</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-13]-Invoice total amount without VAT (BT-109) = Σ Invoice line net amount (BT-131) - Sum of allowances on document level (BT-107) + Sum of charges on document level (BT-108).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cbc:PrepaidAmount) and not(exists(cbc:PayableRoundingAmount)) and (xs:decimal(cbc:PayableAmount) = (round((xs:decimal(cbc:TaxInclusiveAmount) - xs:decimal(cbc:PrepaidAmount)) * 10 * 10) div 100))) or (not(exists(cbc:PrepaidAmount)) and not(exists(cbc:PayableRoundingAmount)) and xs:decimal(cbc:PayableAmount) = xs:decimal(cbc:TaxInclusiveAmount)) or (exists(cbc:PrepaidAmount) and exists(cbc:PayableRoundingAmount) and ((round((xs:decimal(cbc:PayableAmount) - xs:decimal(cbc:PayableRoundingAmount)) * 10 * 10) div 100) = (round((xs:decimal(cbc:TaxInclusiveAmount) - xs:decimal(cbc:PrepaidAmount)) * 10 * 10) div 100))) or  (not(exists(cbc:PrepaidAmount)) and exists(cbc:PayableRoundingAmount) and ((round((xs:decimal(cbc:PayableAmount) - xs:decimal(cbc:PayableRoundingAmount)) * 10 * 10) div 100) = xs:decimal(cbc:TaxInclusiveAmount)))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cbc:PrepaidAmount) and not(exists(cbc:PayableRoundingAmount)) and (xs:decimal(cbc:PayableAmount) = (round((xs:decimal(cbc:TaxInclusiveAmount) - xs:decimal(cbc:PrepaidAmount)) * 10 * 10) div 100))) or (not(exists(cbc:PrepaidAmount)) and not(exists(cbc:PayableRoundingAmount)) and xs:decimal(cbc:PayableAmount) = xs:decimal(cbc:TaxInclusiveAmount)) or (exists(cbc:PrepaidAmount) and exists(cbc:PayableRoundingAmount) and ((round((xs:decimal(cbc:PayableAmount) - xs:decimal(cbc:PayableRoundingAmount)) * 10 * 10) div 100) = (round((xs:decimal(cbc:TaxInclusiveAmount) - xs:decimal(cbc:PrepaidAmount)) * 10 * 10) div 100))) or (not(exists(cbc:PrepaidAmount)) and exists(cbc:PayableRoundingAmount) and ((round((xs:decimal(cbc:PayableAmount) - xs:decimal(cbc:PayableRoundingAmount)) * 10 * 10) div 100) = xs:decimal(cbc:TaxInclusiveAmount)))">
+          <xsl:attribute name="id">BR-CO-16</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-16]-Amount due for payment (BT-115) = Invoice total amount with VAT (BT-112) -Paid amount (BT-113) +Rounding amount (BT-114).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:LineExtensionAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:LineExtensionAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-09]-The allowed maximum number of decimals for the Sum of Invoice line net amount (BT-106) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:AllowanceTotalAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:AllowanceTotalAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-10]-The allowed maximum number of decimals for the Sum of allowanced on document level (BT-107) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:ChargeTotalAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:ChargeTotalAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-11</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-11]-The allowed maximum number of decimals for the Sum of charges on document level (BT-108) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:TaxExclusiveAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:TaxExclusiveAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-12</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-12]-The allowed maximum number of decimals for the Invoice total amount without VAT (BT-109) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:TaxInclusiveAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:TaxInclusiveAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-14</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-14]-The allowed maximum number of decimals for the Invoice total amount with VAT (BT-112) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:PrepaidAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:PrepaidAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-16</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-16]-The allowed maximum number of decimals for the Paid amount (BT-113) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:PayableRoundingAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:PayableRoundingAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-17</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-17]-The allowed maximum number of decimals for the Rounding amount (BT-114) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:PayableAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:PayableAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-18</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-18]-The allowed maximum number of decimals for the Amount due for payment (BT-115) is 2.  </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/ubl:Invoice | /cn:CreditNote" mode="M11" priority="1057">
+    <svrl:fired-rule context="/ubl:Invoice | /cn:CreditNote" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:CustomizationID) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:CustomizationID) != ''">
+          <xsl:attribute name="id">BR-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-01]-An Invoice shall have a Specification identifier (BT-24).   </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID) != ''">
+          <xsl:attribute name="id">BR-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-02]-An Invoice shall have an Invoice number (BT-1).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:IssueDate) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:IssueDate) != ''">
+          <xsl:attribute name="id">BR-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-03]-An Invoice shall have an Invoice issue date (BT-2).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:InvoiceTypeCode) != '' or normalize-space(cbc:CreditNoteTypeCode) !=''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:InvoiceTypeCode) != '' or normalize-space(cbc:CreditNoteTypeCode) !=''">
+          <xsl:attribute name="id">BR-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-04]-An Invoice shall have an Invoice type code (BT-3).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:DocumentCurrencyCode) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:DocumentCurrencyCode) != ''">
+          <xsl:attribute name="id">BR-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-05]-An Invoice shall have an Invoice currency code (BT-5).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName) != ''">
+          <xsl:attribute name="id">BR-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-06]-An Invoice shall contain the Seller name (BT-27).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName) != ''">
+          <xsl:attribute name="id">BR-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-07]-An Invoice shall contain the Buyer name (BT-44).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress)">
+          <xsl:attribute name="id">BR-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-08]-An Invoice shall contain the Seller postal address. </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress)">
+          <xsl:attribute name="id">BR-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-10]-An Invoice shall contain the Buyer postal address (BG-8).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:InvoiceLine) or exists(cac:CreditNoteLine)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:InvoiceLine) or exists(cac:CreditNoteLine)">
+          <xsl:attribute name="id">BR-16</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-16]-An Invoice shall have at least one Invoice line (BG-25)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="every $taxcurrency in cbc:TaxCurrencyCode satisfies exists(//cac:TaxTotal/cbc:TaxAmount[@currencyID=$taxcurrency])" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="every $taxcurrency in cbc:TaxCurrencyCode satisfies exists(//cac:TaxTotal/cbc:TaxAmount[@currencyID=$taxcurrency])">
+          <xsl:attribute name="id">BR-53</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-53]-If the VAT accounting currency code (BT-6) is present, then the Invoice total VAT amount in accounting currency (BT-111) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:PaymentMeans/cac:CardAccount) &lt;= 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:PaymentMeans/cac:CardAccount) &lt;= 1">
+          <xsl:attribute name="id">BR-66</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-66]-An Invoice shall contain maximum one Payment Card account (BG-18).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:PaymentMeans/cac:PaymentMandate) &lt;= 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:PaymentMeans/cac:PaymentMandate) &lt;= 1">
+          <xsl:attribute name="id">BR-67</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-67]-An Invoice shall contain maximum one Payment Mandate (BG-19).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'AE']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'AE'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'AE']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'AE']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'AE']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'AE']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'AE'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'AE']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'AE']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'AE']))">
+          <xsl:attribute name="id">BR-AE-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AE-01]-An Invoice that contains an Invoice line (BG-25), a Document level allowance (BG-20) or a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is "Reverse charge" shall contain in the VAT Breakdown (BG-23) exactly one VAT category code (BT-118) equal with "VAT reverse charge".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-AE-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AE-02]-An Invoice that contains an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Reverse charge" shall contain the Seller VAT Identifier (BT-31), the Seller Tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63) and the Buyer VAT identifier (BT-48) and/or the Buyer legal registration identifier (BT-47).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-AE-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AE-03]-An Invoice that contains a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Reverse charge" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63) and the Buyer VAT identifier (BT-48) and/or the Buyer legal registration identifier (BT-47).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-AE-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AE-04]-An Invoice that contains a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Reverse charge" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63) and the Buyer VAT identifier (BT-48) and/or the Buyer legal registration identifier (BT-47).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cbc:TaxPointDate) and not(cac:InvoicePeriod/cbc:DescriptionCode)) or (not(cbc:TaxPointDate) and exists(cac:InvoicePeriod/cbc:DescriptionCode)) or (not(cbc:TaxPointDate) and not(cac:InvoicePeriod/cbc:DescriptionCode))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cbc:TaxPointDate) and not(cac:InvoicePeriod/cbc:DescriptionCode)) or (not(cbc:TaxPointDate) and exists(cac:InvoicePeriod/cbc:DescriptionCode)) or (not(cbc:TaxPointDate) and not(cac:InvoicePeriod/cbc:DescriptionCode))">
+          <xsl:attribute name="id">BR-CO-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-03]-Value added tax point date (BT-7) and Value added tax point date code (BT-8) are mutually exclusive.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="every $Currency in cbc:DocumentCurrencyCode satisfies (count(cac:TaxTotal/xs:decimal(cbc:TaxAmount[@currencyID=$Currency])) eq 1) and (cac:LegalMonetaryTotal/xs:decimal(cbc:TaxInclusiveAmount) = round( (cac:LegalMonetaryTotal/xs:decimal(cbc:TaxExclusiveAmount) + cac:TaxTotal/xs:decimal(cbc:TaxAmount[@currencyID=$Currency])) * 10 * 10) div 100)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="every $Currency in cbc:DocumentCurrencyCode satisfies (count(cac:TaxTotal/xs:decimal(cbc:TaxAmount[@currencyID=$Currency])) eq 1) and (cac:LegalMonetaryTotal/xs:decimal(cbc:TaxInclusiveAmount) = round( (cac:LegalMonetaryTotal/xs:decimal(cbc:TaxExclusiveAmount) + cac:TaxTotal/xs:decimal(cbc:TaxAmount[@currencyID=$Currency])) * 10 * 10) div 100)">
+          <xsl:attribute name="id">BR-CO-15</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-15]-Invoice total amount with VAT (BT-112) = Invoice total amount without VAT (BT-109) + Invoice total VAT amount (BT-110).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:TaxTotal/cac:TaxSubtotal)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:TaxTotal/cac:TaxSubtotal)">
+          <xsl:attribute name="id">BR-CO-18</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-18]-An Invoice shall at least have one VAT breakdown group (BG-23).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:DocumentCurrencyCode] and (string-length(substring-after(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:DocumentCurrencyCode],'.'))&lt;=2)) or (not(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:DocumentCurrencyCode]))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:DocumentCurrencyCode] and (string-length(substring-after(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:DocumentCurrencyCode],'.'))&lt;=2)) or (not(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:DocumentCurrencyCode]))">
+          <xsl:attribute name="id">BR-DEC-13</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-13]-The allowed maximum number of decimals for the Invoice total VAT amount (BT-110) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:TaxCurrencyCode] and (string-length(substring-after(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:TaxCurrencyCode],'.'))&lt;=2)) or (not(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:TaxCurrencyCode]))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:TaxCurrencyCode] and (string-length(substring-after(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:TaxCurrencyCode],'.'))&lt;=2)) or (not(//cac:TaxTotal/cbc:TaxAmount[@currencyID = cbc:TaxCurrencyCode]))">
+          <xsl:attribute name="id">BR-DEC-15</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-15]-The allowed maximum number of decimals for the Invoice total VAT amount in accounting currency (BT-111) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'E']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'E'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'E']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'E']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'E']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'E']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'E'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'E']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'E']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'E']))">
+          <xsl:attribute name="id">BR-E-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-E-01]-An Invoice that contains an Invoice line (BG-25), a Document level allowance (BG-20) or a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is "Exempt from VAT" shall contain exactly one VAT breakdown (BG-23) with the VAT category code (BT-118) equal to "Exempt from VAT".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-E-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-E-02]-An Invoice that contains an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Exempt from VAT" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-E-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-E-03]-An Invoice that contains a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Exempt from VAT" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-E-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-E-04]-An Invoice that contains a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Exempt from VAT" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'G']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'G'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'G']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'G']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'G']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'G']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'G'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'G']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'G']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'G']))">
+          <xsl:attribute name="id">BR-G-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-G-01]-An Invoice that contains an Invoice line (BG-25), a Document level allowance (BG-20) or a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is "Export outside the EU" shall contain in the VAT breakdown (BG-23) exactly one VAT category code (BT-118) equal with "Export outside the EU".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-G-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-G-02]-An Invoice that contains an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Export outside the EU" shall contain the Seller VAT Identifier (BT-31) or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='G']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='G']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-G-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-G-03]-An Invoice that contains a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Export outside the EU" shall contain the Seller VAT Identifier (BT-31) or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='G']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='G']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-G-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-G-04]-An Invoice that contains a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Export outside the EU" shall contain the Seller VAT Identifier (BT-31) or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']))">
+          <xsl:attribute name="id">BR-IC-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-01]-An Invoice that contains an Invoice line (BG-25), a Document level allowance (BG-20) or a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is "Intra-community supply" shall contain in the VAT breakdown (BG-23) exactly one VAT category code (BT-118) equal with "Intra-community supply".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])">
+          <xsl:attribute name="id">BR-IC-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-02]-An Invoice that contains an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Intra-community supply" shall contain the Seller VAT Identifier (BT-31) or the Seller tax representative VAT identifier (BT-63) and the Buyer VAT identifier (BT-48).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-IC-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-03]-An Invoice that contains a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Intra-community supply" shall contain the Seller VAT Identifier (BT-31) or the Seller tax representative VAT identifier (BT-63) and the Buyer VAT identifier (BT-48).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)) and (exists(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-IC-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-04]-An Invoice that contains a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Intra-community supply" shall contain the Seller VAT Identifier (BT-31) or the Seller tax representative VAT identifier (BT-63) and the Buyer VAT identifier (BT-48).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K'])  and (string-length(cac:Delivery/cbc:ActualDeliveryDate) > 1 or (cac:InvoicePeriod/*))) or (not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']) and (string-length(cac:Delivery/cbc:ActualDeliveryDate) > 1 or (cac:InvoicePeriod/*))) or (not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']))">
+          <xsl:attribute name="id">BR-IC-11</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-11]-In an Invoice with a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Intra-community supply" the Actual delivery date (BT-72) or the Invoicing period (BG-14) shall not be blank.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']) and (string-length(cac:Delivery/cac:DeliveryLocation/cac:Address/cac:Country/cbc:IdentificationCode) >1)) or (not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']) and (string-length(cac:Delivery/cac:DeliveryLocation/cac:Address/cac:Country/cbc:IdentificationCode) >1)) or (not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'K']))">
+          <xsl:attribute name="id">BR-IC-12</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-12]-In an Invoice with a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Intra-community supply" the Deliver to country code (BT-80) shall not be blank.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])) > 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cbc:ID = 'L']) > 0) or ((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])) = 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])) > 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cbc:ID = 'L']) > 0) or ((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])) = 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0)">
+          <xsl:attribute name="id">BR-AF-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AF-01]-An Invoice that contains an Invoice line (BG-25), a Document level allowance (BG-20) or a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is "IGIC" shall contain in the VAT breakdown (BG-23) at least one VAT category code (BT-118) equal with "IGIC".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-AF-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AF-02]-An Invoice that contains an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "IGIC" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-AF-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AF-03]-An Invoice that contains a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "IGIC" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[cbc:ID='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[cbc:ID='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-AF-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AF-04]-An Invoice that contains a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "IGIC" shall contain the Seller VAT Identifier (BT-31), the Seller Tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])) > 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cbc:ID = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) > 0) or ((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])) = 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])) > 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cbc:ID = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) > 0) or ((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])) = 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0)">
+          <xsl:attribute name="id">BR-AG-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AG-01]-An Invoice that contains an Invoice line (BG-25), a Document level allowance (BG-20) or a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is "IPSI" shall contain in the VAT breakdown (BG-23) at least one VAT category code (BT-118) equal with "IPSI".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-AG-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AG-02]-An Invoice that contains an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "IPSI" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-AG-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AG-03]-An Invoice that contains a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "IPSI" shall contain the Seller VAT Identifier (BT-31), the Seller Tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-AG-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AG-04]-An Invoice that contains a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "IPSI" shall contain the Seller VAT Identifier (BT-31), the Seller Tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']))">
+          <xsl:attribute name="id">BR-O-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-01]-An Invoice that contains an Invoice line (BG-25), a Document level allowance (BG-20) or a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is "Not subject to VAT" shall contain exactly one VAT breakdown group (BG-23) with the VAT category code (BT-118) equal to "Not subject to VAT".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (not(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (not(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'])">
+          <xsl:attribute name="id">BR-O-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-02]-An Invoice that contains an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Not subject to VAT" shall not contain the Seller VAT identifier (BT-31), the Seller tax representative VAT identifier (BT-63) or the Buyer VAT identifier (BT-48).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists((/ubl:Invoice|/cn:CreditNote)/cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (not(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists((/ubl:Invoice|/cn:CreditNote)/cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists((/ubl:Invoice|/cn:CreditNote)/cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (not(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists((/ubl:Invoice|/cn:CreditNote)/cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-O-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-03]-An Invoice that contains a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Not subject to VAT" shall not contain the Seller VAT identifier (BT-31), the Seller tax representative VAT identifier (BT-63) or the Buyer VAT identifier (BT-48).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists((/ubl:Invoice|/cn:CreditNote)/cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (not(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists((/ubl:Invoice|/cn:CreditNote)/cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists((/ubl:Invoice|/cn:CreditNote)/cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (not(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID) and not(//cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists((/ubl:Invoice|/cn:CreditNote)/cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-O-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-04]-An Invoice that contains a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Not subject to VAT" shall not contain the Seller VAT identifier (BT-31), the Seller tax representative VAT identifier (BT-63) or the Buyer VAT identifier (BT-48).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) != 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0) or not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O'])" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) != 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0) or not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O'])">
+          <xsl:attribute name="id">BR-O-11</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-11]-An Invoice that contains a VAT breakdown group (BG-23) with a VAT category code (BT-118) "Not subject to VAT" shall not contain other VAT breakdown groups (BG-23).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) and count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) != 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0) or not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O'])" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) and count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) != 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0) or not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O'])">
+          <xsl:attribute name="id">BR-O-12</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-12]-An Invoice that contains a VAT breakdown group (BG-23) with a VAT category code (BT-118) "Not subject to VAT" shall not contain an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is not "Not subject to VAT".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) and count(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) != 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0) or not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O'])" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) and count(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) != 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0) or not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O'])">
+          <xsl:attribute name="id">BR-O-13</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-13]-An Invoice that contains a VAT breakdown group (BG-23) with a VAT category code (BT-118) "Not subject to VAT" shall not contain Document level allowances (BG-20) where Document level allowance VAT category code (BT-95) is not "Not subject to VAT".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) and count(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) != 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0) or not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O'])" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O']) and count(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) != 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) = 0) or not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'O'])">
+          <xsl:attribute name="id">BR-O-14</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-14]-An Invoice that contains a VAT breakdown group (BG-23) with a VAT category code (BT-118) "Not subject to VAT" shall not contain Document level charges (BG-21) where Document level charge VAT category code (BT-102) is not "Not subject to VAT".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'S']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S'])) > 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'S']) > 0) or ((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'S']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S'])) = 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'S']) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'S']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S'])) > 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'S']) > 0) or ((count(//cac:AllowanceCharge/cac:TaxCategory[normalize-space(cbc:ID) = 'S']) + count(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S'])) = 0 and count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'S']) = 0)">
+          <xsl:attribute name="id">BR-S-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-S-01]-An Invoice that contains an Invoice line (BG-25), a Document level allowance (BG-20) or a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is "Standard rated" shall contain in the VAT breakdown (BG-23) at least one VAT category code (BT-118) equal with "Standard rated".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S']))">
+          <xsl:attribute name="id">BR-S-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-S-02]-An Invoice that contains an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Standard rated" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-S-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-S-03]-An Invoice that contains a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Standard rated" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-S-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-S-04]-An Invoice that contains a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Standard rated" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'Z']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'Z'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'Z']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'Z']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'Z']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((exists(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'Z']) or exists(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'Z'])) and (count(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'Z']) = 1)) or (not(//cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'Z']) and not(//cac:ClassifiedTaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID[normalize-space(.) = 'Z']))">
+          <xsl:attribute name="id">BR-Z-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-Z-01]-An Invoice that contains an Invoice line (BG-25), a Document level allowance (BG-20) or a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is "Zero rated" shall contain in the VAT breakdown (BG-23) exactly one VAT category code (BT-118) equal with "Zero rated".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-Z-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-Z-02]-An Invoice that contains an Invoice line where the Invoiced item VAT category code (BT-151) is "Zero rated" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID) or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-Z-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-Z-03]-An Invoice that contains a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Zero rated" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID)or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']) and (exists(//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID)or exists(//cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID))) or not(exists(//cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']))">
+          <xsl:attribute name="id">BR-Z-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-Z-04]-An Invoice that contains a Document level charge where the Document level charge VAT category code (BT-102) is "Zero rated" shall contain the Seller VAT Identifier (BT-31), the Seller tax registration identifier (BT-32) and/or the Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(not(//cbc:IdentificationCode != 'IT') and (//cac:TaxCategory/cbc:ID ='B' or //cac:ClassifiedTaxCategory/cbc:ID = 'B')) or (not(//cac:TaxCategory/cbc:ID ='B' or //cac:ClassifiedTaxCategory/cbc:ID = 'B'))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(not(//cbc:IdentificationCode != 'IT') and (//cac:TaxCategory/cbc:ID ='B' or //cac:ClassifiedTaxCategory/cbc:ID = 'B')) or (not(//cac:TaxCategory/cbc:ID ='B' or //cac:ClassifiedTaxCategory/cbc:ID = 'B'))">
+          <xsl:attribute name="id">BR-B-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-B-01]-An Invoice where the VAT category code (BT-151, BT-95 or BT-102) is “Split payment” shall be a domestic Italian invoice.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:ID ='B' or cac:AllowanceCharge/cac:TaxCategory/cbc:ID ='B' or //cac:ClassifiedTaxCategory/cbc:ID = 'B') and (not(cac:TaxTotal/cac:TaxSubtotal/cbc:ID ='S' or cac:AllowanceCharge/cac:TaxCategory/cbc:ID ='S' or //cac:ClassifiedTaxCategory/cbc:ID = 'S'))) or (not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:ID ='B' or cac:AllowanceCharge/cac:TaxCategory/cbc:ID ='B' or //cac:ClassifiedTaxCategory/cbc:ID = 'B'))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:ID ='B' or cac:AllowanceCharge/cac:TaxCategory/cbc:ID ='B' or //cac:ClassifiedTaxCategory/cbc:ID = 'B') and (not(cac:TaxTotal/cac:TaxSubtotal/cbc:ID ='S' or cac:AllowanceCharge/cac:TaxCategory/cbc:ID ='S' or //cac:ClassifiedTaxCategory/cbc:ID = 'S'))) or (not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:ID ='B' or cac:AllowanceCharge/cac:TaxCategory/cbc:ID ='B' or //cac:ClassifiedTaxCategory/cbc:ID = 'B'))">
+          <xsl:attribute name="id">BR-B-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-B-02]-An Invoice that contains an Invoice line (BG-25), a Document level allowance (BG-20) or a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is “Split payment" shall not contain an invoice line (BG-25), a Document level allowance (BG-20) or  a Document level charge (BG-21) where the VAT category code (BT-151, BT-95 or BT-102) is “Standard rated”.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine | cac:CreditNoteLine" mode="M11" priority="1056">
+    <svrl:fired-rule context="cac:InvoiceLine | cac:CreditNoteLine" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID) != ''">
+          <xsl:attribute name="id">BR-21</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-21]-Each Invoice line (BG-25) shall have an Invoice line identifier (BT-126).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:InvoicedQuantity) or exists(cbc:CreditedQuantity)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:InvoicedQuantity) or exists(cbc:CreditedQuantity)">
+          <xsl:attribute name="id">BR-22</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-22]-Each Invoice line (BG-25) shall have an Invoiced quantity (BT-129).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:InvoicedQuantity/@unitCode) or exists(cbc:CreditedQuantity/@unitCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:InvoicedQuantity/@unitCode) or exists(cbc:CreditedQuantity/@unitCode)">
+          <xsl:attribute name="id">BR-23</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-23]-An Invoice line (BG-25) shall have an Invoiced quantity unit of measure code (BT-130).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:LineExtensionAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:LineExtensionAmount)">
+          <xsl:attribute name="id">BR-24</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-24]-Each Invoice line (BG-25) shall have an Invoice line net amount (BT-131).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cac:Item/cbc:Name) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cac:Item/cbc:Name) != ''">
+          <xsl:attribute name="id">BR-25</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-25]-Each Invoice line (BG-25) shall contain the Item name (BT-153).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:Price/cbc:PriceAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:Price/cbc:PriceAmount)">
+          <xsl:attribute name="id">BR-26</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-26]-Each Invoice line (BG-25) shall contain the Item net price (BT-146).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cac:Price/cbc:PriceAmount) >= 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cac:Price/cbc:PriceAmount) >= 0">
+          <xsl:attribute name="id">BR-27</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-27]-The Item net price (BT-146) shall NOT be negative.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cac:Price/cac:AllowanceCharge/cbc:BaseAmount) >= 0 or not(exists(cac:Price/cac:AllowanceCharge/cbc:BaseAmount))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cac:Price/cac:AllowanceCharge/cbc:BaseAmount) >= 0 or not(exists(cac:Price/cac:AllowanceCharge/cbc:BaseAmount))">
+          <xsl:attribute name="id">BR-28</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-28]-The Item gross price (BT-148) shall NOT be negative.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cac:Item/cac:ClassifiedTaxCategory[cac:TaxScheme/(normalize-space(upper-case(cbc:ID))='VAT')]/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cac:Item/cac:ClassifiedTaxCategory[cac:TaxScheme/(normalize-space(upper-case(cbc:ID))='VAT')]/cbc:ID)">
+          <xsl:attribute name="id">BR-CO-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-04]-Each Invoice line (BG-25) shall be categorized with an Invoiced item VAT category code (BT-151).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:LineExtensionAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:LineExtensionAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-23</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-23]-The allowed maximum number of decimals for the Invoice line net amount (BT-131) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:InvoiceLine/cac:AllowanceCharge[cbc:ChargeIndicator = false()] | //cac:CreditNoteLine/cac:AllowanceCharge[cbc:ChargeIndicator = false()]" mode="M11" priority="1055">
+    <svrl:fired-rule context="//cac:InvoiceLine/cac:AllowanceCharge[cbc:ChargeIndicator = false()] | //cac:CreditNoteLine/cac:AllowanceCharge[cbc:ChargeIndicator = false()]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:Amount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:Amount)">
+          <xsl:attribute name="id">BR-41</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-41]-Each Invoice line allowance (BG-27) shall have an Invoice line allowance amount (BT-136).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)">
+          <xsl:attribute name="id">BR-42</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-42]-Each Invoice line allowance (BG-27) shall have an Invoice line allowance reason (BT-139) or an Invoice line allowance reason code (BT-140).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="true()" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="true()">
+          <xsl:attribute name="id">BR-CO-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-07]-Invoice line allowance reason code (BT-140) and Invoice line allowance reason (BT-139) shall indicate the same type of allowance reason.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)">
+          <xsl:attribute name="id">BR-CO-23</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-23]-Each Invoice line allowance (BG-27) shall contain an Invoice line allowance reason (BT-139) or an Invoice line allowance reason code (BT-140), or both.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:Amount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:Amount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-24</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-24]-The allowed maximum number of decimals for the Invoice line allowance amount (BT-136) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:BaseAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:BaseAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-25</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-25]-The allowed maximum number of decimals for the Invoice line allowance base amount (BT-137) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:InvoiceLine/cac:AllowanceCharge[cbc:ChargeIndicator = true()] | //cac:CreditNoteLine/cac:AllowanceCharge[cbc:ChargeIndicator = true()]" mode="M11" priority="1054">
+    <svrl:fired-rule context="//cac:InvoiceLine/cac:AllowanceCharge[cbc:ChargeIndicator = true()] | //cac:CreditNoteLine/cac:AllowanceCharge[cbc:ChargeIndicator = true()]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:Amount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:Amount)">
+          <xsl:attribute name="id">BR-43</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-43]-Each Invoice line charge (BG-28) shall have an Invoice line charge amount (BT-141).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)">
+          <xsl:attribute name="id">BR-44</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-44]-Each Invoice line charge shall have an Invoice line charge reason or an invoice line allowance reason code. </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="true()" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="true()">
+          <xsl:attribute name="id">BR-CO-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-08]-Invoice line charge reason code (BT-145) and Invoice line charge reason (BT-144) shall indicate the same type of charge reason.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:AllowanceChargeReason) or exists(cbc:AllowanceChargeReasonCode)">
+          <xsl:attribute name="id">BR-CO-24</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-24]-Each Invoice line charge (BG-28) shall contain an Invoice line charge reason (BT-144) or an Invoice line charge reason code (BT-145), or both.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:Amount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:Amount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-27</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-27]-The allowed maximum number of decimals for the Invoice line charge amount (BT-141) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:BaseAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:BaseAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-28</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-28]-The allowed maximum number of decimals for the Invoice line charge base amount (BT-142) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:InvoicePeriod | cac:CreditNoteLine/cac:InvoicePeriod" mode="M11" priority="1053">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:InvoicePeriod | cac:CreditNoteLine/cac:InvoicePeriod" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cbc:EndDate) and exists(cbc:StartDate) and xs:date(cbc:EndDate) >= xs:date(cbc:StartDate)) or not(exists(cbc:StartDate)) or not(exists(cbc:EndDate))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cbc:EndDate) and exists(cbc:StartDate) and xs:date(cbc:EndDate) >= xs:date(cbc:StartDate)) or not(exists(cbc:StartDate)) or not(exists(cbc:EndDate))">
+          <xsl:attribute name="id">BR-30</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-30]-If both Invoice line period start date (BT-134) and Invoice line period end date (BT-135) are given then the Invoice line period end date (BT-135) shall be later or equal to the Invoice line period start date (BT-134).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:StartDate) or exists(cbc:EndDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:StartDate) or exists(cbc:EndDate)">
+          <xsl:attribute name="id">BR-CO-20</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-20]-If Invoice line period (BG-26) is used, the Invoice line period start date (BT-134) or the Invoice line period end date (BT-135) shall be filled, or both.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoicePeriod" mode="M11" priority="1052">
+    <svrl:fired-rule context="cac:InvoicePeriod" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cbc:EndDate) and exists(cbc:StartDate) and xs:date(cbc:EndDate) >= xs:date(cbc:StartDate)) or not(exists(cbc:StartDate)) or not(exists(cbc:EndDate))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cbc:EndDate) and exists(cbc:StartDate) and xs:date(cbc:EndDate) >= xs:date(cbc:StartDate)) or not(exists(cbc:StartDate)) or not(exists(cbc:EndDate))">
+          <xsl:attribute name="id">BR-29</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-29]-If both Invoicing period start date (BT-73) and Invoicing period end date (BT-74) are given then the Invoicing period end date (BT-74) shall be later or equal to the Invoicing period start date (BT-73).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:StartDate) or exists(cbc:EndDate) or (exists(cbc:DescriptionCode) and not(exists(cbc:StartDate)) and not(exists(cbc:EndDate)))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:StartDate) or exists(cbc:EndDate) or (exists(cbc:DescriptionCode) and not(exists(cbc:StartDate)) and not(exists(cbc:EndDate)))">
+          <xsl:attribute name="id">BR-CO-19</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-19]-If Invoicing period (BG-14) is used, the Invoicing period start date (BT-73) or the Invoicing period end date (BT-74) shall be filled, or both.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:AdditionalItemProperty" mode="M11" priority="1051">
+    <svrl:fired-rule context="//cac:AdditionalItemProperty" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:Name) and exists(cbc:Value)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:Name) and exists(cbc:Value)">
+          <xsl:attribute name="id">BR-54</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-54]-Each Item attribute (BG-32) shall contain an Item attribute name (BT-160) and an Item attribute value (BT-161).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode | cac:CreditNoteLine/cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode" mode="M11" priority="1050">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode | cac:CreditNoteLine/cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(@listID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(@listID)">
+          <xsl:attribute name="id">BR-65</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-65]-The Item classification identifier (BT-158) shall have a Scheme identifier.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:StandardItemIdentification/cbc:ID | cac:CreditNoteLine/cac:Item/cac:StandardItemIdentification/cbc:ID" mode="M11" priority="1049">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:StandardItemIdentification/cbc:ID | cac:CreditNoteLine/cac:Item/cac:StandardItemIdentification/cbc:ID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(@schemeID)">
+          <xsl:attribute name="id">BR-64</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-64]-The Item standard identifier (BT-157) shall have a Scheme identifier.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/ubl:Invoice/cbc:Note | /cn:CreditNote/cbc:Note" mode="M11" priority="1048">
+    <svrl:fired-rule context="/ubl:Invoice/cbc:Note | /cn:CreditNote/cbc:Note" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(contains(.,'#') and string-length(substring-before(substring-after(.,'#'),'#'))=3 and ( ( contains(' AAA AAB AAC AAD AAE AAF AAG AAI AAJ AAK AAL AAM AAN AAO AAP AAQ AAR AAS AAT AAU AAV AAW AAX AAY AAZ ABA ABB ABC ABD ABE ABF ABG ABH ABI ABJ ABK ABL ABM ABN ABO ABP ABQ ABR ABS ABT ABU ABV ABW ABX ABZ ACA ACB ACC ACD ACE ACF ACG ACH ACI ACJ ACK ACL ACM ACN ACO ACP ACQ ACR ACS ACT ACU ACV ACW ACX ACY ACZ ADA ADB ADC ADD ADE ADF ADG ADH ADI ADJ ADK ADL ADM ADN ADO ADP ADQ ADR ADS ADT ADU ADV ADW ADX ADY ADZ AEA AEB AEC AED AEE AEF AEG AEH AEI AEJ AEK AEL AEM AEN AEO AEP AEQ AER AES AET AEU AEV AEW AEX AEY AEZ AFA AFB AFC AFD AFE AFF AFG AFH AFI AFJ AFK AFL AFM AFN AFO AFP AFQ AFR AFS AFT AFU AFV AFW AFX AFY AFZ AGA AGB AGC AGD AGE AGF AGG AGH AGI AGJ AGK AGL AGM AGN AGO AGP AGQ AGR AGS AGT AGU AGV AGW AGX AGY AGZ AHA AHB AHC AHD AHE AHF AHG AHH AHI AHJ AHK AHL AHM AHN AHO AHP AHQ AHR AHS AHT AHU AHV AHW AHX AHY AHZ AIA AIB AIC AID AIE AIF AIG AIH AII AIJ AIK AIL AIM AIN AIO AIP AIQ AIR AIS AIT AIU AIV AIW AIX AIY AIZ AJA AJB ALC ALD ALE ALF ALG ALH ALI ALJ ALK ALL ALM ALN ALO ALP ALQ ARR ARS AUT AUU AUV AUW AUX AUY AUZ AVA AVB AVC AVD AVE AVF BAG BAH BAI BAJ BAK BAL BAM BAN BAO BAP BAQ BAR BAS BLC BLD BLE BLF BLG BLH BLI BLJ BLK BLL BLM BLN BLO BLP BLQ BLR BLS BLT BLU BLV BLW BLX BLY BLZ BMA BMB BMC BMD BME CCI CEX CHG CIP CLP CLR COI CUR CUS DAR DCL DEL DIN DOC DUT EUR FBC GBL GEN GS7 HAN HAZ ICN IIN IMI IND INS INV IRP ITR ITS LAN LIN LOI MCO MDH MKS ORI OSI PAC PAI PAY PKG PKT PMD PMT PRD PRF PRI PUR QIN QQD QUT RAH REG RET REV RQR SAF SIC SIN SLR SPA SPG SPH SPP SPT SRN SSR SUR TCA TDT TRA TRR TXD WHI ZZZ ',substring-before(substring-after(.,'#'),'#') ) ) )) or not(contains(.,'#')) or not(string-length(substring-before(substring-after(.,'#'),'#'))=3)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(contains(.,'#') and string-length(substring-before(substring-after(.,'#'),'#'))=3 and ( ( contains(' AAA AAB AAC AAD AAE AAF AAG AAI AAJ AAK AAL AAM AAN AAO AAP AAQ AAR AAS AAT AAU AAV AAW AAX AAY AAZ ABA ABB ABC ABD ABE ABF ABG ABH ABI ABJ ABK ABL ABM ABN ABO ABP ABQ ABR ABS ABT ABU ABV ABW ABX ABZ ACA ACB ACC ACD ACE ACF ACG ACH ACI ACJ ACK ACL ACM ACN ACO ACP ACQ ACR ACS ACT ACU ACV ACW ACX ACY ACZ ADA ADB ADC ADD ADE ADF ADG ADH ADI ADJ ADK ADL ADM ADN ADO ADP ADQ ADR ADS ADT ADU ADV ADW ADX ADY ADZ AEA AEB AEC AED AEE AEF AEG AEH AEI AEJ AEK AEL AEM AEN AEO AEP AEQ AER AES AET AEU AEV AEW AEX AEY AEZ AFA AFB AFC AFD AFE AFF AFG AFH AFI AFJ AFK AFL AFM AFN AFO AFP AFQ AFR AFS AFT AFU AFV AFW AFX AFY AFZ AGA AGB AGC AGD AGE AGF AGG AGH AGI AGJ AGK AGL AGM AGN AGO AGP AGQ AGR AGS AGT AGU AGV AGW AGX AGY AGZ AHA AHB AHC AHD AHE AHF AHG AHH AHI AHJ AHK AHL AHM AHN AHO AHP AHQ AHR AHS AHT AHU AHV AHW AHX AHY AHZ AIA AIB AIC AID AIE AIF AIG AIH AII AIJ AIK AIL AIM AIN AIO AIP AIQ AIR AIS AIT AIU AIV AIW AIX AIY AIZ AJA AJB ALC ALD ALE ALF ALG ALH ALI ALJ ALK ALL ALM ALN ALO ALP ALQ ARR ARS AUT AUU AUV AUW AUX AUY AUZ AVA AVB AVC AVD AVE AVF BAG BAH BAI BAJ BAK BAL BAM BAN BAO BAP BAQ BAR BAS BLC BLD BLE BLF BLG BLH BLI BLJ BLK BLL BLM BLN BLO BLP BLQ BLR BLS BLT BLU BLV BLW BLX BLY BLZ BMA BMB BMC BMD BME CCI CEX CHG CIP CLP CLR COI CUR CUS DAR DCL DEL DIN DOC DUT EUR FBC GBL GEN GS7 HAN HAZ ICN IIN IMI IND INS INV IRP ITR ITS LAN LIN LOI MCO MDH MKS ORI OSI PAC PAI PAY PKG PKT PMD PMT PRD PRF PRI PUR QIN QQD QUT RAH REG RET REV RQR SAF SIC SIN SLR SPA SPG SPH SPP SPT SRN SSR SUR TCA TDT TRA TRR TXD WHI ZZZ ',substring-before(substring-after(.,'#'),'#') ) ) )) or not(contains(.,'#')) or not(string-length(substring-before(substring-after(.,'#'),'#'))=3)">
+          <xsl:attribute name="id">BR-CL-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-08]-Invoiced note subject code shall be coded using UNCL4451</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PayeeParty" mode="M11" priority="1047">
+    <svrl:fired-rule context="cac:PayeeParty" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:PartyName/cbc:Name) and (not(cac:PartyName/cbc:Name = ../cac:AccountingSupplierParty/cac:Party/cac:PartyName/cbc:Name) and not(cac:PartyIdentification/cbc:ID = ../cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:PartyName/cbc:Name) and (not(cac:PartyName/cbc:Name = ../cac:AccountingSupplierParty/cac:Party/cac:PartyName/cbc:Name) and not(cac:PartyIdentification/cbc:ID = ../cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID) )">
+          <xsl:attribute name="id">BR-17</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-17]-The Payee name (BT-59) shall be provided in the Invoice, if the Payee (BG-10) is different from the Seller (BG-4)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PaymentMeans[cbc:PaymentMeansCode='30' or cbc:PaymentMeansCode='58']/cac:PayeeFinancialAccount" mode="M11" priority="1046">
+    <svrl:fired-rule context="cac:PaymentMeans[cbc:PaymentMeansCode='30' or cbc:PaymentMeansCode='58']/cac:PayeeFinancialAccount" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID) != ''">
+          <xsl:attribute name="id">BR-50</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-50]-A Payment account identifier (BT-84) shall be present if Credit transfer (BG-17) information is provided in the Invoice.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PaymentMeans" mode="M11" priority="1045">
+    <svrl:fired-rule context="cac:PaymentMeans" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:PaymentMeansCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:PaymentMeansCode)">
+          <xsl:attribute name="id">BR-49</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-49]-A Payment instruction (BG-16) shall specify the Payment means type code (BT-81).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cac:PayeeFinancialAccount/cbc:ID) and ((normalize-space(cbc:PaymentMeansCode) = '30') or (normalize-space(cbc:PaymentMeansCode) = '58') )) or ((normalize-space(cbc:PaymentMeansCode) != '30') and (normalize-space(cbc:PaymentMeansCode) != '58'))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cac:PayeeFinancialAccount/cbc:ID) and ((normalize-space(cbc:PaymentMeansCode) = '30') or (normalize-space(cbc:PaymentMeansCode) = '58') )) or ((normalize-space(cbc:PaymentMeansCode) != '30') and (normalize-space(cbc:PaymentMeansCode) != '58'))">
+          <xsl:attribute name="id">BR-61</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-61]-If the Payment means type code (BT-81) means SEPA credit transfer, Local credit transfer or Non-SEPA international credit transfer, the Payment account identifier (BT-84) shall be present.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:BillingReference" mode="M11" priority="1044">
+    <svrl:fired-rule context="cac:BillingReference" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:InvoiceDocumentReference/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:InvoiceDocumentReference/cbc:ID)">
+          <xsl:attribute name="id">BR-55</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-55]-Each Preceding Invoice reference (BG-3) shall contain a Preceding Invoice reference (BT-25).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty" mode="M11" priority="1043">
+    <svrl:fired-rule context="cac:AccountingSupplierParty" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:Party/cac:PartyTaxScheme[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:CompanyID) or exists(cac:Party/cac:PartyIdentification/cbc:ID) or exists(cac:Party/cac:PartyLegalEntity/cbc:CompanyID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:Party/cac:PartyTaxScheme[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:CompanyID) or exists(cac:Party/cac:PartyIdentification/cbc:ID) or exists(cac:Party/cac:PartyLegalEntity/cbc:CompanyID)">
+          <xsl:attribute name="id">BR-CO-26</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-26]-In order for the buyer to automatically identify a supplier, the Seller identifier (BT-29), the Seller legal registration identifier (BT-30) and/or the Seller VAT identifier (BT-31) shall be present.  </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty/cac:Party/cbc:EndpointID" mode="M11" priority="1042">
+    <svrl:fired-rule context="cac:AccountingSupplierParty/cac:Party/cbc:EndpointID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(@schemeID)">
+          <xsl:attribute name="id">BR-62</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-62]-The Seller electronic address (BT-34) shall have a Scheme identifier.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty/cac:Party/cac:PostalAddress" mode="M11" priority="1041">
+    <svrl:fired-rule context="cac:AccountingSupplierParty/cac:Party/cac:PostalAddress" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cac:Country/cbc:IdentificationCode) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cac:Country/cbc:IdentificationCode) != ''">
+          <xsl:attribute name="id">BR-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-09]-The Seller postal address (BG-5) shall contain a Seller country code (BT-40).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxRepresentativeParty" mode="M11" priority="1040">
+    <svrl:fired-rule context="cac:TaxRepresentativeParty" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cac:PartyName/cbc:Name) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cac:PartyName/cbc:Name) != ''">
+          <xsl:attribute name="id">BR-18</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-18]-The Seller tax representative name (BT-62) shall be provided in the Invoice, if the Seller (BG-4) has a Seller tax representative party (BG-11)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:PostalAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:PostalAddress)">
+          <xsl:attribute name="id">BR-19</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-19]-The Seller tax representative postal address (BG-12) shall be provided in the Invoice, if the Seller (BG-4) has a Seller tax representative party (BG-11).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:PartyTaxScheme[cac:TaxScheme/(normalize-space(upper-case(cbc:ID)) = 'VAT')]/cbc:CompanyID)">
+          <xsl:attribute name="id">BR-56</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-56]-Each Seller tax representative party (BG-11) shall have a Seller tax representative VAT identifier (BT-63).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxRepresentativeParty/cac:PostalAddress" mode="M11" priority="1039">
+    <svrl:fired-rule context="cac:TaxRepresentativeParty/cac:PostalAddress" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cac:Country/cbc:IdentificationCode) != ''" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cac:Country/cbc:IdentificationCode) != ''">
+          <xsl:attribute name="id">BR-20</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-20]-The Seller tax representative postal address (BG-12) shall contain a Tax representative country code (BT-69), if the Seller (BG-4) has a Seller tax representative party (BG-11).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/ubl:Invoice/cac:TaxTotal | /cn:CreditNote/cac:TaxTotal" mode="M11" priority="1038">
+    <svrl:fired-rule context="/ubl:Invoice/cac:TaxTotal | /cn:CreditNote/cac:TaxTotal" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(child::cbc:TaxAmount)= round((sum(cac:TaxSubtotal/xs:decimal(cbc:TaxAmount)) * 10 * 10)) div 100) or not(cac:TaxSubtotal)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(child::cbc:TaxAmount)= round((sum(cac:TaxSubtotal/xs:decimal(cbc:TaxAmount)) * 10 * 10)) div 100) or not(cac:TaxSubtotal)">
+          <xsl:attribute name="id">BR-CO-14</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-14]-Invoice total VAT amount (BT-110) = Σ VAT category tax amount (BT-117).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxTotal/cac:TaxSubtotal" mode="M11" priority="1037">
+    <svrl:fired-rule context="cac:TaxTotal/cac:TaxSubtotal" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:TaxableAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:TaxableAmount)">
+          <xsl:attribute name="id">BR-45</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-45]-Each VAT breakdown (BG-23) shall have a VAT category taxable amount (BT-116).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:TaxAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:TaxAmount)">
+          <xsl:attribute name="id">BR-46</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-46]-Each VAT breakdown (BG-23) shall have a VAT category tax amount (BT-117).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:ID)">
+          <xsl:attribute name="id">BR-47</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-47]-Each VAT breakdown (BG-23) shall be defined through a VAT category code (BT-118).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:Percent) or (cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/normalize-space(cbc:ID)='O')" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/cbc:Percent) or (cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/normalize-space(cbc:ID)='O')">
+          <xsl:attribute name="id">BR-48</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-48]-Each VAT breakdown (BG-23) shall have a VAT category rate (BT-119), except if the Invoice is not subject to VAT.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(round(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/xs:decimal(cbc:Percent)) = 0 and (round(xs:decimal(cbc:TaxAmount)) = 0)) or (round(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/xs:decimal(cbc:Percent)) != 0 and ((abs(xs:decimal(cbc:TaxAmount)) - 1 &lt; round(abs(xs:decimal(cbc:TaxableAmount)) * (cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/xs:decimal(cbc:Percent) div 100) * 10 * 10) div 100 ) and (abs(xs:decimal(cbc:TaxAmount)) + 1 > round(abs(xs:decimal(cbc:TaxableAmount)) * (cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/xs:decimal(cbc:Percent) div 100) * 10 * 10) div 100 )))  or (not(exists(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/xs:decimal(cbc:Percent))) and (round(xs:decimal(cbc:TaxAmount)) = 0))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(round(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/xs:decimal(cbc:Percent)) = 0 and (round(xs:decimal(cbc:TaxAmount)) = 0)) or (round(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/xs:decimal(cbc:Percent)) != 0 and ((abs(xs:decimal(cbc:TaxAmount)) - 1 &lt; round(abs(xs:decimal(cbc:TaxableAmount)) * (cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/xs:decimal(cbc:Percent) div 100) * 10 * 10) div 100 ) and (abs(xs:decimal(cbc:TaxAmount)) + 1 > round(abs(xs:decimal(cbc:TaxableAmount)) * (cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/xs:decimal(cbc:Percent) div 100) * 10 * 10) div 100 ))) or (not(exists(cac:TaxCategory[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']/xs:decimal(cbc:Percent))) and (round(xs:decimal(cbc:TaxAmount)) = 0))">
+          <xsl:attribute name="id">BR-CO-17</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-17]-VAT category tax amount (BT-117) = VAT category taxable amount (BT-116) x (VAT category rate (BT-119) / 100), rounded to two decimals.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:TaxableAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:TaxableAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-19</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-19]-The allowed maximum number of decimals for the VAT category taxable amount (BT-116) is 2.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(cbc:TaxAmount,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(cbc:TaxAmount,'.'))&lt;=2">
+          <xsl:attribute name="id">BR-DEC-20</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-DEC-20]-The allowed maximum number of decimals for the VAT category tax amount (BT-117) is 2.    </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:PartyTaxScheme[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1036">
+    <svrl:fired-rule context="//cac:PartyTaxScheme[cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="( contains( ' 1A AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH EL ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS XI YE YT ZA ZM ZW ',substring(cbc:CompanyID,1,2) ) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="( contains( ' 1A AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH EL ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS XI YE YT ZA ZM ZW ',substring(cbc:CompanyID,1,2) ) )">
+          <xsl:attribute name="id">BR-CO-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CO-09]-The Seller VAT identifier (BT-31), the Seller tax representative VAT identifier (BT-63) and the Buyer VAT identifier (BT-48) shall have a prefix in accordance with ISO code ISO 3166-1 alpha-2 by which the country of issue may be identified. Nevertheless, Greece may use the prefix ‘EL’.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1035">
+    <svrl:fired-rule context="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:Amount)))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='AE']/xs:decimal(cbc:Amount)))))">
+          <xsl:attribute name="id">BR-AE-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AE-08]-In a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Reverse charge" the VAT category taxable amount (BT-116) shall equal the sum of Invoice line net amounts (BT-131) minus the sum of Document level allowance amounts (BT-92) plus the sum of Document level charge amounts (BT-99) where the VAT category codes (BT-151, BT-95, BT-102) are "Reverse charge".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="xs:decimal(../cbc:TaxAmount) = 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="xs:decimal(../cbc:TaxAmount) = 0">
+          <xsl:attribute name="id">BR-AE-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AE-09]-The VAT category tax amount (BT-117) in a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Reverse charge" shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:TaxExemptionReason) or (exists(cbc:TaxExemptionReasonCode) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:TaxExemptionReason) or (exists(cbc:TaxExemptionReasonCode) )">
+          <xsl:attribute name="id">BR-AE-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AE-10]-A VAT breakdown (BG-23) with VAT Category code (BT-118) "Reverse charge" shall have a VAT exemption reason code (BT-121), meaning "Reverse charge" or the VAT exemption reason text (BT-120) "Reverse charge" (or the equivalent standard text in another language).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1034">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-AE-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AE-06]-In a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Reverse charge" the Document level allowance VAT rate (BT-96) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1033">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-AE-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AE-07]-In a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Reverse charge" the Document level charge VAT rate (BT-103) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1032">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'AE'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-AE-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AE-05]-In an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Reverse charge" the Invoiced item VAT rate (BT-152) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1031">
+    <svrl:fired-rule context="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:Amount)))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='E']/xs:decimal(cbc:Amount)))))">
+          <xsl:attribute name="id">BR-E-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-E-08]-In a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Exempt from VAT" the VAT category taxable amount (BT-116) shall equal the sum of Invoice line net amounts (BT-131) minus the sum of Document level allowance amounts (BT-92) plus the sum of Document level charge amounts (BT-99) where the VAT category codes (BT-151, BT-95, BT-102) are "Exempt from VAT".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="xs:decimal(../cbc:TaxAmount) = 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="xs:decimal(../cbc:TaxAmount) = 0">
+          <xsl:attribute name="id">BR-E-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-E-09]-The VAT category tax amount (BT-117) In a VAT breakdown (BG-23) where the VAT category code (BT-118) equals "Exempt from VAT" shall equal 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:TaxExemptionReason) or exists(cbc:TaxExemptionReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:TaxExemptionReason) or exists(cbc:TaxExemptionReasonCode)">
+          <xsl:attribute name="id">BR-E-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-E-10]-A VAT breakdown (BG-23) with VAT Category code (BT-118) "Exempt from VAT" shall have a VAT exemption reason code (BT-121) or a VAT exemption reason text (BT-120).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1030">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-E-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-E-06]-In a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Exempt from VAT", the Document level allowance VAT rate (BT-96) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1029">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-E-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-E-07]-In a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Exempt from VAT", the Document level charge VAT rate (BT-103) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1028">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'E'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-E-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-E-05]-In an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Exempt from VAT", the Invoiced item VAT rate (BT-152) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1027">
+    <svrl:fired-rule context="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:Amount)))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='G']/xs:decimal(cbc:Amount)))))">
+          <xsl:attribute name="id">BR-G-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-G-08]-In a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Export outside the EU" the VAT category taxable amount (BT-116) shall equal the sum of Invoice line net amounts (BT-131) minus the sum of Document level allowance amounts (BT-92) plus the sum of Document level charge amounts (BT-99) where the VAT category codes (BT-151, BT-95, BT-102) are "Export outside the EU".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="xs:decimal(../cbc:TaxAmount) = 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="xs:decimal(../cbc:TaxAmount) = 0">
+          <xsl:attribute name="id">BR-G-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-G-09]-The VAT category tax amount (BT-117) in a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Export outside the EU" shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:TaxExemptionReason) or (exists(cbc:TaxExemptionReasonCode) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:TaxExemptionReason) or (exists(cbc:TaxExemptionReasonCode) )">
+          <xsl:attribute name="id">BR-G-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-G-10]-A VAT breakdown (BG-23) with the VAT Category code (BT-118) "Export outside the EU" shall have a VAT exemption reason code (BT-121), meaning "Export outside the EU" or the VAT exemption reason text (BT-120) "Export outside the EU" (or the equivalent standard text in another language).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1026">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-G-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-G-06]-In a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Export outside the EU" the Document level allowance VAT rate (BT-96) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1025">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-G-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-G-07]-In a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Export outside the EU" the Document level charge VAT rate (BT-103) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1024">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'G'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-G-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-G-05]-In an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Export outside the EU" the Invoiced item VAT rate (BT-152) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1023">
+    <svrl:fired-rule context="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:Amount)))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='K']/xs:decimal(cbc:Amount)))))">
+          <xsl:attribute name="id">BR-IC-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-08]-In a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Intra-community supply" the VAT category taxable amount (BT-116) shall equal the sum of Invoice line net amounts (BT-131) minus the sum of Document level allowance amounts (BT-92) plus the sum of Document level charge amounts (BT-99) where the VAT category codes (BT-151, BT-95, BT-102) are "Intra-community supply".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="xs:decimal(../cbc:TaxAmount) = 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="xs:decimal(../cbc:TaxAmount) = 0">
+          <xsl:attribute name="id">BR-IC-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-09]-The VAT category tax amount (BT-117) in a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Intra-community supply" shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:TaxExemptionReason) or (exists(cbc:TaxExemptionReasonCode) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:TaxExemptionReason) or (exists(cbc:TaxExemptionReasonCode) )">
+          <xsl:attribute name="id">BR-IC-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-10]-A VAT breakdown (BG-23) with the VAT Category code (BT-118) "Intra-community supply" shall have a VAT exemption reason code (BT-121), meaning "Intra-community supply" or the VAT exemption reason text (BT-120) "Intra-community supply" (or the equivalent standard text in another language).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1022">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-IC-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-06]-In a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Intra-community supply" the Document level allowance VAT rate (BT-96) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1021">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-IC-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-07]-In a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Intra-community supply" the Document level charge VAT rate (BT-103) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1020">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'K'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-IC-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-IC-05]-In an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Intracommunity supply" the Invoiced item VAT rate (BT-152) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1019">
+    <svrl:fired-rule context="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="every $rate in xs:decimal(cbc:Percent) satisfies ((exists(//cac:InvoiceLine) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='L'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='L'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))))) or (exists(//cac:CreditNoteLine) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='L'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='L'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="every $rate in xs:decimal(cbc:Percent) satisfies ((exists(//cac:InvoiceLine) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='L'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='L'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))))) or (exists(//cac:CreditNoteLine) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='L'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='L'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='L'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))))))">
+          <xsl:attribute name="id">BR-AF-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AF-08]-For each different value of VAT category rate (BT-119) where the VAT category code (BT-118) is "IGIC", the VAT category taxable amount (BT-116) in a VAT breakdown (BG-23) shall equal the sum of Invoice line net amounts (BT-131) plus the sum of document level charge amounts (BT-99) minus the sum of document level allowance amounts (BT-92) where the VAT category code (BT-151, BT-102, BT-95) is "IGIC" and the VAT rate (BT-152, BT-103, BT-96) equals the VAT category rate (BT-119).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(abs(xs:decimal(../cbc:TaxAmount)) - 1 &lt;  round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 ) and (abs(xs:decimal(../cbc:TaxAmount)) + 1 >  round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(abs(xs:decimal(../cbc:TaxAmount)) - 1 &lt; round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 ) and (abs(xs:decimal(../cbc:TaxAmount)) + 1 > round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 )">
+          <xsl:attribute name="id">BR-AF-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AF-09]-The VAT category tax amount (BT-117) in a VAT breakdown (BG-23) where VAT category code (BT-118) is "IGIC" shall equal the VAT category taxable amount (BT-116) multiplied by the VAT category rate (BT-119).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:TaxExemptionReason) and not(cbc:TaxExemptionReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:TaxExemptionReason) and not(cbc:TaxExemptionReasonCode)">
+          <xsl:attribute name="id">BR-AF-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AF-10]-A VAT breakdown (BG-23) with VAT Category code (BT-118) "IGIC" shall not have a VAT exemption reason code (BT-121) or VAT exemption reason text (BT-120).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1018">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cbc:Percent) >= 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cbc:Percent) >= 0">
+          <xsl:attribute name="id">BR-AF-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AF-06]-In a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "IGIC" the Document level allowance VAT rate (BT-96) shall be 0 (zero) or greater than zero.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1017">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cbc:Percent) >= 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cbc:Percent) >= 0">
+          <xsl:attribute name="id">BR-AF-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AF-07]-In a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "IGIC" the Document level charge VAT rate (BT-103) shall be 0 (zero) or greater than zero.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']| cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1016">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']| cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'L'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cbc:Percent) >= 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cbc:Percent) >= 0">
+          <xsl:attribute name="id">BR-AF-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AF-05]-In an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "IGIC" the invoiced item VAT rate (BT-152) shall be 0 (zero) or greater than zero.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1015">
+    <svrl:fired-rule context="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="every $rate in xs:decimal(cbc:Percent) satisfies ((exists(//cac:InvoiceLine) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='M'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='M'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))))) or (exists(//cac:CreditNoteLine) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='M'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='M'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="every $rate in xs:decimal(cbc:Percent) satisfies ((exists(//cac:InvoiceLine) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='M'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='M'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))))) or (exists(//cac:CreditNoteLine) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='M'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='M'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='M'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))))))">
+          <xsl:attribute name="id">BR-AG-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AG-08]-For each different value of VAT category rate (BT-119) where the VAT category code (BT-118) is "IPSI", the VAT category taxable amount (BT-116) in a VAT breakdown (BG-23) shall equal the sum of Invoice line net amounts (BT-131) plus the sum of document level charge amounts (BT-99) minus the sum of document level allowance amounts (BT-92) where the VAT category code (BT-151, BT-102, BT-95) is "IPSI" and the VAT rate (BT-152, BT-103, BT-96) equals the VAT category rate (BT-119).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(abs(xs:decimal(../cbc:TaxAmount)) - 1 &lt;  round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 ) and (abs(xs:decimal(../cbc:TaxAmount)) + 1 >  round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(abs(xs:decimal(../cbc:TaxAmount)) - 1 &lt; round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 ) and (abs(xs:decimal(../cbc:TaxAmount)) + 1 > round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 )">
+          <xsl:attribute name="id">BR-AG-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AG-09]-The VAT category tax amount (BT-117) in a VAT breakdown (BG-23) where VAT category code (BT-118) is "IPSI" shall equal the VAT category taxable amount (BT-116) multiplied by the VAT category rate (BT-119).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:TaxExemptionReason) and not(cbc:TaxExemptionReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:TaxExemptionReason) and not(cbc:TaxExemptionReasonCode)">
+          <xsl:attribute name="id">BR-AG-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AG-10]-A VAT breakdown (BG-23) with VAT Category code (BT-118) "IPSI" shall not have a VAT exemption reason code (BT-121) or VAT exemption reason text (BT-120).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1014">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cbc:Percent) >= 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cbc:Percent) >= 0">
+          <xsl:attribute name="id">BR-AG-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AG-06]-In a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "IPSI" the Document level allowance VAT rate (BT-96) shall be 0 (zero) or greater than zero.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1013">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cbc:Percent) >= 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cbc:Percent) >= 0">
+          <xsl:attribute name="id">BR-AG-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AG-07]-In a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "IPSI" the Document level charge VAT rate (BT-103) shall be 0 (zero) or greater than zero.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']| cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1012">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']| cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'M'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cbc:Percent) >= 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cbc:Percent) >= 0">
+          <xsl:attribute name="id">BR-AG-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-AG-05]-In an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "IPSI" the Invoiced item VAT rate (BT-152) shall be 0 (zero) or greater than zero.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1011">
+    <svrl:fired-rule context="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:Amount)))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='O']/xs:decimal(cbc:Amount)))))">
+          <xsl:attribute name="id">BR-O-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-08]-In a VAT breakdown (BG-23) where the VAT category code (BT-118) is " Not subject to VAT" the VAT category taxable amount (BT-116) shall equal the sum of Invoice line net amounts (BT-131) minus the sum of Document level allowance amounts (BT-92) plus the sum of Document level charge amounts (BT-99) where the VAT category codes (BT-151, BT-95, BT-102) are "Not subject to VAT".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="xs:decimal(../cbc:TaxAmount) = 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="xs:decimal(../cbc:TaxAmount) = 0">
+          <xsl:attribute name="id">BR-O-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-09]-The VAT category tax amount (BT-117) in a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Not subject to VAT" shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cbc:TaxExemptionReason) or (exists(cbc:TaxExemptionReasonCode) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cbc:TaxExemptionReason) or (exists(cbc:TaxExemptionReasonCode) )">
+          <xsl:attribute name="id">BR-O-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-10]-A VAT breakdown (BG-23) with VAT Category code (BT-118) " Not subject to VAT" shall have a VAT exemption reason code (BT-121), meaning " Not subject to VAT" or a VAT exemption reason text (BT-120) " Not subject to VAT" (or the equivalent standard text in another language).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1010">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:Percent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:Percent)">
+          <xsl:attribute name="id">BR-O-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-06]-A Document level allowance (BG-20) where VAT category code (BT-95) is "Not subject to VAT" shall not contain a Document level allowance VAT rate (BT-96).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1009">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:Percent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:Percent)">
+          <xsl:attribute name="id">BR-O-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-07]-A Document level charge (BG-21) where the VAT category code (BT-102) is "Not subject to VAT" shall not contain a Document level charge VAT rate (BT-103).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1008">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:Percent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:Percent)">
+          <xsl:attribute name="id">BR-O-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-O-05]-An Invoice line (BG-25) where the VAT category code (BT-151) is "Not subject to VAT" shall not contain an Invoiced item VAT rate (BT-152).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1007">
+    <svrl:fired-rule context="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="every $rate in xs:decimal(cbc:Percent) satisfies (((exists(//cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID) = 'S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]) or exists(//cac:AllowanceCharge[cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate])) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))))) or (exists(//cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID) = 'S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]) or exists(//cac:AllowanceCharge[cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate])) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount))))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="every $rate in xs:decimal(cbc:Percent) satisfies (((exists(//cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID) = 'S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]) or exists(//cac:AllowanceCharge[cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate])) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))))) or (exists(//cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID) = 'S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]) or exists(//cac:AllowanceCharge[cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate])) and ((../xs:decimal(cbc:TaxableAmount - 1) &lt; (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)))) and (../xs:decimal(cbc:TaxableAmount + 1) > (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='S'][cac:Item/cac:ClassifiedTaxCategory/xs:decimal(cbc:Percent) =$rate]/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='S'][cac:TaxCategory/xs:decimal(cbc:Percent) = $rate]/xs:decimal(cbc:Amount))))))">
+          <xsl:attribute name="id">BR-S-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-S-08]-For each different value of VAT category rate (BT-119) where the VAT category code (BT-118) is "Standard rated", the VAT category taxable amount (BT-116) in a VAT breakdown (BG-23) shall equal the sum of Invoice line net amounts (BT-131) plus the sum of document level charge amounts (BT-99) minus the sum of document level allowance amounts (BT-92) where the VAT category code (BT-151, BT-102, BT-95) is "Standard rated" and the VAT rate (BT-152, BT-103, BT-96) equals the VAT category rate (BT-119).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(abs(xs:decimal(../cbc:TaxAmount)) - 1 &lt;  round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 ) and (abs(xs:decimal(../cbc:TaxAmount)) + 1 >  round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(abs(xs:decimal(../cbc:TaxAmount)) - 1 &lt; round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 ) and (abs(xs:decimal(../cbc:TaxAmount)) + 1 > round((abs(xs:decimal(../cbc:TaxableAmount)) * (xs:decimal(cbc:Percent) div 100)) * 10 * 10) div 100 )">
+          <xsl:attribute name="id">BR-S-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-S-09]-The VAT category tax amount (BT-117) in a VAT breakdown (BG-23) where VAT category code (BT-118) is "Standard rated" shall equal the VAT category taxable amount (BT-116) multiplied by the VAT category rate (BT-119).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:TaxExemptionReason) and not(cbc:TaxExemptionReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:TaxExemptionReason) and not(cbc:TaxExemptionReasonCode)">
+          <xsl:attribute name="id">BR-S-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-S-10]-A VAT breakdown (BG-23) with VAT Category code (BT-118) "Standard rate" shall not have a VAT exemption reason code (BT-121) or VAT exemption reason text (BT-120).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1006">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cbc:Percent) > 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cbc:Percent) > 0">
+          <xsl:attribute name="id">BR-S-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-S-06]-In a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Standard rated" the Document level allowance VAT rate (BT-96) shall be greater than zero.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1005">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cbc:Percent) > 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cbc:Percent) > 0">
+          <xsl:attribute name="id">BR-S-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-S-07]-In a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Standard rated" the Document level charge VAT rate (BT-103) shall be greater than zero.  </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1004">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'S'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cbc:Percent) > 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cbc:Percent) > 0">
+          <xsl:attribute name="id">BR-S-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-S-05]-In an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Standard rated" the Invoiced item VAT rate (BT-152) shall be greater than zero.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1003">
+    <svrl:fired-rule context="/*/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:Amount)))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(//cac:InvoiceLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:InvoiceLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:Amount))))) or (exists(//cac:CreditNoteLine) and (xs:decimal(../cbc:TaxableAmount) = (sum(../../../cac:CreditNoteLine[cac:Item/cac:ClassifiedTaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:LineExtensionAmount)) + sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=true()][cac:TaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:Amount)) - sum(../../../cac:AllowanceCharge[cbc:ChargeIndicator=false()][cac:TaxCategory/normalize-space(cbc:ID)='Z']/xs:decimal(cbc:Amount)))))">
+          <xsl:attribute name="id">BR-Z-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-Z-08]-In a VAT breakdown (BG-23) where VAT category code (BT-118) is "Zero rated" the VAT category taxable amount (BT-116) shall equal the sum of Invoice line net amount (BT-131) minus the sum of Document level allowance amounts (BT-92) plus the sum of Document level charge amounts (BT-99) where the VAT category codes (BT-151, BT-95, BT-102) are "Zero rated".</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="xs:decimal(../cbc:TaxAmount) = 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="xs:decimal(../cbc:TaxAmount) = 0">
+          <xsl:attribute name="id">BR-Z-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-Z-09]-The VAT category tax amount (BT-117) in a VAT breakdown (BG-23) where VAT category code (BT-118) is "Zero rated" shall equal 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cbc:TaxExemptionReason) or (cbc:TaxExemptionReasonCode))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cbc:TaxExemptionReason) or (cbc:TaxExemptionReasonCode))">
+          <xsl:attribute name="id">BR-Z-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-Z-10]-A VAT breakdown (BG-23) with VAT Category code (BT-118) "Zero rated" shall not have a VAT exemption reason code (BT-121) or VAT exemption reason text (BT-120).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1002">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=false()]/cac:TaxCategory[normalize-space(cbc:ID)='Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-Z-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-Z-06]-In a Document level allowance (BG-20) where the Document level allowance VAT category code (BT-95) is "Zero rated" the Document level allowance VAT rate (BT-96) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1001">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator=true()]/cac:TaxCategory[normalize-space(cbc:ID)='Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-Z-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-Z-07]-In a Document level charge (BG-21) where the Document level charge VAT category code (BT-102) is "Zero rated" the Document level charge VAT rate (BT-103) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" mode="M11" priority="1000">
+    <svrl:fired-rule context="cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'Z'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(xs:decimal(cbc:Percent) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(xs:decimal(cbc:Percent) = 0)">
+          <xsl:attribute name="id">BR-Z-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-Z-05]-In an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "Zero rated" the Invoiced item VAT rate (BT-152) shall be 0 (zero).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M11" priority="-1" />
+  <xsl:template match="@*|node()" mode="M11" priority="-2">
+    <xsl:apply-templates mode="M11" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN UBL-syntax-->
+
+
+	<!--RULE -->
+<xsl:template match="//cac:PostalAddress | //cac:Address" mode="M12" priority="1015">
+    <svrl:fired-rule context="//cac:PostalAddress | //cac:Address" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AddressLine) or count(cac:AddressLine) = 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AddressLine) or count(cac:AddressLine) = 1">
+          <xsl:attribute name="id">UBL-SR-51</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-51]-An address can only have one third line.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty/cac:Party" mode="M12" priority="1014">
+    <svrl:fired-rule context="cac:AccountingSupplierParty/cac:Party" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:PartyTaxScheme) &lt;= 2)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:PartyTaxScheme) &lt;= 2)">
+          <xsl:attribute name="id">UBL-SR-42</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-42]-Party tax scheme shall occur maximum twice in accounting supplier party</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AdditionalDocumentReference" mode="M12" priority="1013">
+    <svrl:fired-rule context="cac:AdditionalDocumentReference" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cbc:DocumentDescription) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cbc:DocumentDescription) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-33</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-33]-Supporting document description shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((cbc:DocumentTypeCode='130') or ((local-name(/*) = 'CreditNote') and (cbc:DocumentTypeCode='50')) or (not(cbc:ID/@schemeID) and not(cbc:DocumentTypeCode)))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((cbc:DocumentTypeCode='130') or ((local-name(/*) = 'CreditNote') and (cbc:DocumentTypeCode='50')) or (not(cbc:ID/@schemeID) and not(cbc:DocumentTypeCode)))">
+          <xsl:attribute name="id">UBL-SR-43</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-43]-Scheme identifier shall only be used for invoiced object (document type code with value 130 or 50)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//*[ends-with(name(), 'Amount') and not(ends-with(name(),'PriceAmount')) and not(ancestor::cac:Price/cac:AllowanceCharge)]" mode="M12" priority="1012">
+    <svrl:fired-rule context="//*[ends-with(name(), 'Amount') and not(ends-with(name(),'PriceAmount')) and not(ancestor::cac:Price/cac:AllowanceCharge)]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(substring-after(.,'.'))&lt;=2" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(substring-after(.,'.'))&lt;=2">
+          <xsl:attribute name="id">UBL-DT-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-01]-Amounts shall be decimal up to two fraction digits</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//*[ends-with(name(), 'BinaryObject')]" mode="M12" priority="1011">
+    <svrl:fired-rule context="//*[ends-with(name(), 'BinaryObject')]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(@mimeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(@mimeCode)">
+          <xsl:attribute name="id">UBL-DT-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-06]-Binary object elements shall contain the mime code attribute</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(@filename)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(@filename)">
+          <xsl:attribute name="id">UBL-DT-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-07]-Binary object elements shall contain the file name attribute</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:Delivery" mode="M12" priority="1010">
+    <svrl:fired-rule context="cac:Delivery" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:DeliveryParty/cac:PartyName/cbc:Name) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:DeliveryParty/cac:PartyName/cbc:Name) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-25</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-25]-Deliver to party name shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator = false()]" mode="M12" priority="1009">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator = false()]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cbc:AllowanceChargeReason) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cbc:AllowanceChargeReason) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-30</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-30]-Document level allowance reason shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator = true()]" mode="M12" priority="1008">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator = true()]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cbc:AllowanceChargeReason) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cbc:AllowanceChargeReason) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-31</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-31]-Document level charge reason shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PartyTaxScheme" mode="M12" priority="1007">
+    <svrl:fired-rule context="cac:PartyTaxScheme" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:TaxScheme/cbc:ID) and exists(cbc:CompanyID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:TaxScheme/cbc:ID) and exists(cbc:CompanyID)">
+          <xsl:attribute name="id">UBL-SR-53</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-53]- CompanyID (VAT Identifier) must be stated when providing the PartyTaxScheme/TaxScheme/ID.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/ubl:Invoice | /cn:CreditNote" mode="M12" priority="1006">
+    <svrl:fired-rule context="/ubl:Invoice | /cn:CreditNote" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(ext:UBLExtensions)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(ext:UBLExtensions)">
+          <xsl:attribute name="id">UBL-CR-001</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-001]-A UBL invoice should not include extensions</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:UBLVersionID) or cbc:UBLVersionID = '2.1'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:UBLVersionID) or cbc:UBLVersionID = '2.1'">
+          <xsl:attribute name="id">UBL-CR-002</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-002]-A UBL invoice should not include the UBLVersionID or it should be 2.1</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:ProfileExecutionID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:ProfileExecutionID)">
+          <xsl:attribute name="id">UBL-CR-003</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-003]-A UBL invoice should not include the ProfileExecutionID </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:CopyIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:CopyIndicator)">
+          <xsl:attribute name="id">UBL-CR-004</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-004]-A UBL invoice should not include the CopyIndicator </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-005</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-005]-A UBL invoice should not include the UUID </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:IssueTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:IssueTime)">
+          <xsl:attribute name="id">UBL-CR-006</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-006]-A UBL invoice should not include the IssueTime </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:PricingCurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:PricingCurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-007</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-007]-A UBL invoice should not include the PricingCurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:PaymentCurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:PaymentCurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-008</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-008]-A UBL invoice should not include the PaymentCurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:PaymentAlternativeCurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:PaymentAlternativeCurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-009</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-009]-A UBL invoice should not include the PaymentAlternativeCurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:AccountingCostCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:AccountingCostCode)">
+          <xsl:attribute name="id">UBL-CR-010</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-010]-A UBL invoice should not include the AccountingCostCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:LineCountNumeric)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:LineCountNumeric)">
+          <xsl:attribute name="id">UBL-CR-011</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-011]-A UBL invoice should not include the LineCountNumeric</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:InvoicePeriod/cbc:StartTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:InvoicePeriod/cbc:StartTime)">
+          <xsl:attribute name="id">UBL-CR-012</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-012]-A UBL invoice should not include the InvoicePeriod StartTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:InvoicePeriod/cbc:EndTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:InvoicePeriod/cbc:EndTime)">
+          <xsl:attribute name="id">UBL-CR-013</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-013]-A UBL invoice should not include the InvoicePeriod EndTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:InvoicePeriod/cbc:DurationMeasure)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:InvoicePeriod/cbc:DurationMeasure)">
+          <xsl:attribute name="id">UBL-CR-014</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-014]-A UBL invoice should not include the InvoicePeriod DurationMeasure</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:InvoicePeriod/cbc:Description)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:InvoicePeriod/cbc:Description)">
+          <xsl:attribute name="id">UBL-CR-015</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-015]-A UBL invoice should not include the InvoicePeriod Description</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OrderReference/cbc:CopyIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OrderReference/cbc:CopyIndicator)">
+          <xsl:attribute name="id">UBL-CR-016</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-016]-A UBL invoice should not include the OrderReference CopyIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OrderReference/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OrderReference/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-017</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-017]-A UBL invoice should not include the OrderReference UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OrderReference/cbc:IssueDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OrderReference/cbc:IssueDate)">
+          <xsl:attribute name="id">UBL-CR-018</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-018]-A UBL invoice should not include the OrderReference IssueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OrderReference/cbc:IssueTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OrderReference/cbc:IssueTime)">
+          <xsl:attribute name="id">UBL-CR-019</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-019]-A UBL invoice should not include the OrderReference IssueTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OrderReference/cbc:CustomerReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OrderReference/cbc:CustomerReference)">
+          <xsl:attribute name="id">UBL-CR-020</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-020]-A UBL invoice should not include the OrderReference CustomerReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OrderReference/cbc:OrderTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OrderReference/cbc:OrderTypeCode)">
+          <xsl:attribute name="id">UBL-CR-021</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-021]-A UBL invoice should not include the OrderReference OrderTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OrderReference/cac:DocumentReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OrderReference/cac:DocumentReference)">
+          <xsl:attribute name="id">UBL-CR-022</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-022]-A UBL invoice should not include the OrderReference DocumentReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:CopyIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:CopyIndicator)">
+          <xsl:attribute name="id">UBL-CR-023</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-023]-A UBL invoice should not include the BillingReference CopyIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-024</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-024]-A UBL invoice should not include the BillingReference UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:IssueTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:IssueTime)">
+          <xsl:attribute name="id">UBL-CR-025</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-025]-A UBL invoice should not include the BillingReference IssueTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:DocumentTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:DocumentTypeCode)">
+          <xsl:attribute name="id">UBL-CR-026</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-026]-A UBL invoice should not include the BillingReference DocumentTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:DocumentType)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:DocumentType)">
+          <xsl:attribute name="id">UBL-CR-027</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-027]-A UBL invoice should not include the BillingReference DocumentType</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:XPath)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:XPath)">
+          <xsl:attribute name="id">UBL-CR-028</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-028]-A UBL invoice should not include the BillingReference Xpath</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:LanguageID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:LanguageID)">
+          <xsl:attribute name="id">UBL-CR-029</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-029]-A UBL invoice should not include the BillingReference LanguageID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:LocaleCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:LocaleCode)">
+          <xsl:attribute name="id">UBL-CR-030</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-030]-A UBL invoice should not include the BillingReference LocaleCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:VersionID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:VersionID)">
+          <xsl:attribute name="id">UBL-CR-031</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-031]-A UBL invoice should not include the BillingReference VersionID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:DocumentStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:DocumentStatusCode)">
+          <xsl:attribute name="id">UBL-CR-032</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-032]-A UBL invoice should not include the BillingReference DocumentStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:DocumentDescription)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cbc:DocumentDescription)">
+          <xsl:attribute name="id">UBL-CR-033</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-033]-A UBL invoice should not include the BillingReference DocumenDescription</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cac:Attachment)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cac:Attachment)">
+          <xsl:attribute name="id">UBL-CR-034</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-034]-A UBL invoice should not include the BillingReference Attachment</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cac:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cac:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-035</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-035]-A UBL invoice should not include the BillingReference ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cac:IssuerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cac:IssuerParty)">
+          <xsl:attribute name="id">UBL-CR-036</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-036]-A UBL invoice should not include the BillingReference IssuerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:InvoiceDocumentReference/cac:ResultOfVerification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:InvoiceDocumentReference/cac:ResultOfVerification)">
+          <xsl:attribute name="id">UBL-CR-037</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-037]-A UBL invoice should not include the BillingReference ResultOfVerification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:SelfBilledInvoiceDocumentReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:SelfBilledInvoiceDocumentReference)">
+          <xsl:attribute name="id">UBL-CR-038</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-038]-A UBL invoice should not include the BillingReference SelfBilledInvoiceDocumentReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:CreditNoteDocumentReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:CreditNoteDocumentReference)">
+          <xsl:attribute name="id">UBL-CR-039</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-039]-A UBL invoice should not include the BillingReference CreditNoteDocumentReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:SelfBilledCreditNoteDocumentReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:SelfBilledCreditNoteDocumentReference)">
+          <xsl:attribute name="id">UBL-CR-040</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-040]-A UBL invoice should not include the BillingReference SelfBilledCreditNoteDocumentReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:DebitNoteDocumentReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:DebitNoteDocumentReference)">
+          <xsl:attribute name="id">UBL-CR-041</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-041]-A UBL invoice should not include the BillingReference DebitNoteDocumentReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:ReminderDocumentReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:ReminderDocumentReference)">
+          <xsl:attribute name="id">UBL-CR-042</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-042]-A UBL invoice should not include the BillingReference ReminderDocumentReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:AdditionalDocumentReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:AdditionalDocumentReference)">
+          <xsl:attribute name="id">UBL-CR-043</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-043]-A UBL invoice should not include the BillingReference AdditionalDocumentReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BillingReference/cac:BillingReferenceLine)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BillingReference/cac:BillingReferenceLine)">
+          <xsl:attribute name="id">UBL-CR-044</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-044]-A UBL invoice should not include the BillingReference BillingReferenceLine</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:CopyIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:CopyIndicator)">
+          <xsl:attribute name="id">UBL-CR-045</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-045]-A UBL invoice should not include the DespatchDocumentReference CopyIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-046</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-046]-A UBL invoice should not include the DespatchDocumentReference UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:IssueDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:IssueDate)">
+          <xsl:attribute name="id">UBL-CR-047</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-047]-A UBL invoice should not include the DespatchDocumentReference IssueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:IssueTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:IssueTime)">
+          <xsl:attribute name="id">UBL-CR-048</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-048]-A UBL invoice should not include the DespatchDocumentReference IssueTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:DocumentTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:DocumentTypeCode)">
+          <xsl:attribute name="id">UBL-CR-049</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-049]-A UBL invoice should not include the DespatchDocumentReference DocumentTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:DocumentType)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:DocumentType)">
+          <xsl:attribute name="id">UBL-CR-050</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-050]-A UBL invoice should not include the DespatchDocumentReference DocumentType</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:XPath)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:XPath)">
+          <xsl:attribute name="id">UBL-CR-051</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-051]-A UBL invoice should not include the DespatchDocumentReference Xpath</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:LanguageID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:LanguageID)">
+          <xsl:attribute name="id">UBL-CR-052</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-052]-A UBL invoice should not include the DespatchDocumentReference LanguageID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:LocaleCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:LocaleCode)">
+          <xsl:attribute name="id">UBL-CR-053</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-053]-A UBL invoice should not include the DespatchDocumentReference LocaleCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:VersionID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:VersionID)">
+          <xsl:attribute name="id">UBL-CR-054</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-054]-A UBL invoice should not include the DespatchDocumentReference VersionID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:DocumentStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:DocumentStatusCode)">
+          <xsl:attribute name="id">UBL-CR-055</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-055]-A UBL invoice should not include the DespatchDocumentReference DocumentStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cbc:DocumentDescription)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cbc:DocumentDescription)">
+          <xsl:attribute name="id">UBL-CR-056</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-056]-A UBL invoice should not include the DespatchDocumentReference DocumentDescription</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cac:Attachment)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cac:Attachment)">
+          <xsl:attribute name="id">UBL-CR-057</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-057]-A UBL invoice should not include the DespatchDocumentReference Attachment</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cac:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cac:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-058</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-058]-A UBL invoice should not include the DespatchDocumentReference ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cac:IssuerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cac:IssuerParty)">
+          <xsl:attribute name="id">UBL-CR-059</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-059]-A UBL invoice should not include the DespatchDocumentReference IssuerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DespatchDocumentReference/cac:ResultOfVerification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DespatchDocumentReference/cac:ResultOfVerification)">
+          <xsl:attribute name="id">UBL-CR-060</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-060]-A UBL invoice should not include the DespatchDocumentReference ResultOfVerification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:CopyIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:CopyIndicator)">
+          <xsl:attribute name="id">UBL-CR-061</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-061]-A UBL invoice should not include the ReceiptDocumentReference CopyIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-062</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-062]-A UBL invoice should not include the ReceiptDocumentReference UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:IssueDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:IssueDate)">
+          <xsl:attribute name="id">UBL-CR-063</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-063]-A UBL invoice should not include the ReceiptDocumentReference IssueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:IssueTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:IssueTime)">
+          <xsl:attribute name="id">UBL-CR-064</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-064]-A UBL invoice should not include the ReceiptDocumentReference IssueTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:DocumentTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:DocumentTypeCode)">
+          <xsl:attribute name="id">UBL-CR-065</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-065]-A UBL invoice should not include the ReceiptDocumentReference DocumentTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:DocumentType)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:DocumentType)">
+          <xsl:attribute name="id">UBL-CR-066</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-066]-A UBL invoice should not include the ReceiptDocumentReference DocumentType</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:XPath)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:XPath)">
+          <xsl:attribute name="id">UBL-CR-067</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-067]-A UBL invoice should not include the ReceiptDocumentReference Xpath</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:LanguageID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:LanguageID)">
+          <xsl:attribute name="id">UBL-CR-068</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-068]-A UBL invoice should not include the ReceiptDocumentReference LanguageID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:LocaleCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:LocaleCode)">
+          <xsl:attribute name="id">UBL-CR-069</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-069]-A UBL invoice should not include the ReceiptDocumentReference LocaleCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:VersionID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:VersionID)">
+          <xsl:attribute name="id">UBL-CR-070</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-070]-A UBL invoice should not include the ReceiptDocumentReference VersionID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:DocumentStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:DocumentStatusCode)">
+          <xsl:attribute name="id">UBL-CR-071</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-071]-A UBL invoice should not include the ReceiptDocumentReference DocumentStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cbc:DocumentDescription)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cbc:DocumentDescription)">
+          <xsl:attribute name="id">UBL-CR-072</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-072]-A UBL invoice should not include the ReceiptDocumentReference DocumentDescription</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cac:Attachment)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cac:Attachment)">
+          <xsl:attribute name="id">UBL-CR-073</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-073]-A UBL invoice should not include the ReceiptDocumentReference Attachment</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cac:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cac:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-074</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-074]-A UBL invoice should not include the ReceiptDocumentReference ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cac:IssuerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cac:IssuerParty)">
+          <xsl:attribute name="id">UBL-CR-075</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-075]-A UBL invoice should not include the ReceiptDocumentReference IssuerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ReceiptDocumentReference/cac:ResultOfVerification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ReceiptDocumentReference/cac:ResultOfVerification)">
+          <xsl:attribute name="id">UBL-CR-076</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-076]-A UBL invoice should not include the ReceiptDocumentReference ResultOfVerification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:StatementDocumentReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:StatementDocumentReference)">
+          <xsl:attribute name="id">UBL-CR-077</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-077]-A UBL invoice should not include the StatementDocumentReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:CopyIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:CopyIndicator)">
+          <xsl:attribute name="id">UBL-CR-078</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-078]-A UBL invoice should not include the OriginatorDocumentReference CopyIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-079</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-079]-A UBL invoice should not include the OriginatorDocumentReference UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:IssueDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:IssueDate)">
+          <xsl:attribute name="id">UBL-CR-080</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-080]-A UBL invoice should not include the OriginatorDocumentReference IssueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:IssueTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:IssueTime)">
+          <xsl:attribute name="id">UBL-CR-081</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-081]-A UBL invoice should not include the OriginatorDocumentReference IssueTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:DocumentTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:DocumentTypeCode)">
+          <xsl:attribute name="id">UBL-CR-082</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-082]-A UBL invoice should not include the OriginatorDocumentReference DocumentTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:DocumentType)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:DocumentType)">
+          <xsl:attribute name="id">UBL-CR-083</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-083]-A UBL invoice should not include the OriginatorDocumentReference DocumentType</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:XPath)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:XPath)">
+          <xsl:attribute name="id">UBL-CR-084</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-084]-A UBL invoice should not include the OriginatorDocumentReference Xpath</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:LanguageID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:LanguageID)">
+          <xsl:attribute name="id">UBL-CR-085</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-085]-A UBL invoice should not include the OriginatorDocumentReference LanguageID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:LocaleCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:LocaleCode)">
+          <xsl:attribute name="id">UBL-CR-086</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-086]-A UBL invoice should not include the OriginatorDocumentReference LocaleCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:VersionID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:VersionID)">
+          <xsl:attribute name="id">UBL-CR-087</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-087]-A UBL invoice should not include the OriginatorDocumentReference VersionID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:DocumentStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:DocumentStatusCode)">
+          <xsl:attribute name="id">UBL-CR-088</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-088]-A UBL invoice should not include the OriginatorDocumentReference DocumentStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cbc:DocumentDescription)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cbc:DocumentDescription)">
+          <xsl:attribute name="id">UBL-CR-089</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-089]-A UBL invoice should not include the OriginatorDocumentReference DocumentDescription</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cac:Attachment)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cac:Attachment)">
+          <xsl:attribute name="id">UBL-CR-090</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-090]-A UBL invoice should not include the OriginatorDocumentReference Attachment</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cac:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cac:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-091</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-091]-A UBL invoice should not include the OriginatorDocumentReference ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cac:IssuerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cac:IssuerParty)">
+          <xsl:attribute name="id">UBL-CR-092</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-092]-A UBL invoice should not include the OriginatorDocumentReference IssuerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:OriginatorDocumentReference/cac:ResultOfVerification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:OriginatorDocumentReference/cac:ResultOfVerification)">
+          <xsl:attribute name="id">UBL-CR-093</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-093]-A UBL invoice should not include the OriginatorDocumentReference ResultOfVerification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:CopyIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:CopyIndicator)">
+          <xsl:attribute name="id">UBL-CR-094</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-094]-A UBL invoice should not include the ContractDocumentReference CopyIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-095</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-095]-A UBL invoice should not include the ContractDocumentReference UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:IssueDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:IssueDate)">
+          <xsl:attribute name="id">UBL-CR-096</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-096]-A UBL invoice should not include the ContractDocumentReference IssueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:IssueTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:IssueTime)">
+          <xsl:attribute name="id">UBL-CR-097</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-097]-A UBL invoice should not include the ContractDocumentReference IssueTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:DocumentTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:DocumentTypeCode)">
+          <xsl:attribute name="id">UBL-CR-098</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-098]-A UBL invoice should not include the ContractDocumentReference DocumentTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:DocumentType)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:DocumentType)">
+          <xsl:attribute name="id">UBL-CR-099</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-099]-A UBL invoice should not include the ContractDocumentReference DocumentType</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:XPath)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:XPath)">
+          <xsl:attribute name="id">UBL-CR-100</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-100]-A UBL invoice should not include the ContractDocumentReference Xpath</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:LanguageID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:LanguageID)">
+          <xsl:attribute name="id">UBL-CR-101</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-101]-A UBL invoice should not include the ContractDocumentReference LanguageID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:LocaleCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:LocaleCode)">
+          <xsl:attribute name="id">UBL-CR-102</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-102]-A UBL invoice should not include the ContractDocumentReference LocaleCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:VersionID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:VersionID)">
+          <xsl:attribute name="id">UBL-CR-103</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-103]-A UBL invoice should not include the ContractDocumentReference VersionID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:DocumentStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:DocumentStatusCode)">
+          <xsl:attribute name="id">UBL-CR-104</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-104]-A UBL invoice should not include the ContractDocumentReference DocumentStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cbc:DocumentDescription)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cbc:DocumentDescription)">
+          <xsl:attribute name="id">UBL-CR-105</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-105]-A UBL invoice should not include the ContractDocumentReference DocumentDescription</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cac:Attachment)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cac:Attachment)">
+          <xsl:attribute name="id">UBL-CR-106</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-106]-A UBL invoice should not include the ContractDocumentReference Attachment</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cac:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cac:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-107</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-107]-A UBL invoice should not include the ContractDocumentReference ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cac:IssuerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cac:IssuerParty)">
+          <xsl:attribute name="id">UBL-CR-108</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-108]-A UBL invoice should not include the ContractDocumentReference IssuerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ContractDocumentReference/cac:ResultOfVerification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ContractDocumentReference/cac:ResultOfVerification)">
+          <xsl:attribute name="id">UBL-CR-109</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-109]-A UBL invoice should not include the ContractDocumentReference ResultOfVerification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:CopyIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:CopyIndicator)">
+          <xsl:attribute name="id">UBL-CR-110</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-110]-A UBL invoice should not include the AdditionalDocumentReference CopyIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-111</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-111]-A UBL invoice should not include the AdditionalDocumentReference UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:IssueDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:IssueDate)">
+          <xsl:attribute name="id">UBL-CR-112</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-112]-A UBL invoice should not include the AdditionalDocumentReference IssueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:IssueTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:IssueTime)">
+          <xsl:attribute name="id">UBL-CR-113</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-113]-A UBL invoice should not include the AdditionalDocumentReference IssueTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:DocumentType)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:DocumentType)">
+          <xsl:attribute name="id">UBL-CR-114</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-114]-A UBL invoice should not include the AdditionalDocumentReference DocumentType</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:XPath)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:XPath)">
+          <xsl:attribute name="id">UBL-CR-115</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-115]-A UBL invoice should not include the AdditionalDocumentReference Xpath</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:LanguageID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:LanguageID)">
+          <xsl:attribute name="id">UBL-CR-116</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-116]-A UBL invoice should not include the AdditionalDocumentReference LanguageID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:LocaleCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:LocaleCode)">
+          <xsl:attribute name="id">UBL-CR-117</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-117]-A UBL invoice should not include the AdditionalDocumentReference LocaleCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:VersionID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:VersionID)">
+          <xsl:attribute name="id">UBL-CR-118</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-118]-A UBL invoice should not include the AdditionalDocumentReference VersionID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:DocumentStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:DocumentStatusCode)">
+          <xsl:attribute name="id">UBL-CR-119</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-119]-A UBL invoice should not include the AdditionalDocumentReference DocumentStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:DocumentHash)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:DocumentHash)">
+          <xsl:attribute name="id">UBL-CR-121</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-121]-A UBL invoice should not include the AdditionalDocumentReference Attachment External DocumentHash</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:HashAlgorithmMethod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:HashAlgorithmMethod)">
+          <xsl:attribute name="id">UBL-CR-122</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-122]-A UBL invoice should not include the AdditionalDocumentReference Attachment External HashAlgorithmMethod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:ExpiryDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:ExpiryDate)">
+          <xsl:attribute name="id">UBL-CR-123</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-123]-A UBL invoice should not include the AdditionalDocumentReference Attachment External ExpiryDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:ExpiryTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:ExpiryTime)">
+          <xsl:attribute name="id">UBL-CR-124</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-124]-A UBL invoice should not include the AdditionalDocumentReference Attachment External ExpiryTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:MimeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:MimeCode)">
+          <xsl:attribute name="id">UBL-CR-125</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-125]-A UBL invoice should not include the AdditionalDocumentReference Attachment External MimeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:FormatCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:FormatCode)">
+          <xsl:attribute name="id">UBL-CR-126</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-126]-A UBL invoice should not include the AdditionalDocumentReference Attachment External FormatCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:EncodingCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:EncodingCode)">
+          <xsl:attribute name="id">UBL-CR-127</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-127]-A UBL invoice should not include the AdditionalDocumentReference Attachment External EncodingCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:CharacterSetCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:CharacterSetCode)">
+          <xsl:attribute name="id">UBL-CR-128</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-128]-A UBL invoice should not include the AdditionalDocumentReference Attachment External CharacterSetCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:FileName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:FileName)">
+          <xsl:attribute name="id">UBL-CR-129</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-129]-A UBL invoice should not include the AdditionalDocumentReference Attachment External FileName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:Description)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:Description)">
+          <xsl:attribute name="id">UBL-CR-130</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-130]-A UBL invoice should not include the AdditionalDocumentReference Attachment External Descriprion</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-131</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-131]-A UBL invoice should not include the AdditionalDocumentReference ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:IssuerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:IssuerParty)">
+          <xsl:attribute name="id">UBL-CR-132</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-132]-A UBL invoice should not include the AdditionalDocumentReference IssuerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cac:ResultOfVerification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cac:ResultOfVerification)">
+          <xsl:attribute name="id">UBL-CR-133</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-133]-A UBL invoice should not include the AdditionalDocumentReference ResultOfVerification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ProjectReference/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ProjectReference/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-134</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-134]-A UBL invoice should not include the ProjectReference UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ProjectReference/cbc:IssueDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ProjectReference/cbc:IssueDate)">
+          <xsl:attribute name="id">UBL-CR-135</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-135]-A UBL invoice should not include the ProjectReference IssueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:ProjectReference/cac:WorkPhaseReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:ProjectReference/cac:WorkPhaseReference)">
+          <xsl:attribute name="id">UBL-CR-136</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-136]-A UBL invoice should not include the ProjectReference WorkPhaseReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Signature)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Signature)">
+          <xsl:attribute name="id">UBL-CR-137</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-137]-A UBL invoice should not include the Signature</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cbc:CustomerAssignedAccountID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cbc:CustomerAssignedAccountID)">
+          <xsl:attribute name="id">UBL-CR-138</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-138]-A UBL invoice should not include the AccountingSupplierParty CustomerAssignedAccountID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cbc:AdditionalAccountID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cbc:AdditionalAccountID)">
+          <xsl:attribute name="id">UBL-CR-139</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-139]-A UBL invoice should not include the AccountingSupplierParty AdditionalAccountID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cbc:DataSendingCapability)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cbc:DataSendingCapability)">
+          <xsl:attribute name="id">UBL-CR-140</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-140]-A UBL invoice should not include the AccountingSupplierParty DataSendingCapability</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cbc:MarkCareIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cbc:MarkCareIndicator)">
+          <xsl:attribute name="id">UBL-CR-141</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-141]-A UBL invoice should not include the AccountingSupplierParty Party MarkCareIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cbc:MarkAttentionIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cbc:MarkAttentionIndicator)">
+          <xsl:attribute name="id">UBL-CR-142</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-142]-A UBL invoice should not include the AccountingSupplierParty Party MarkAttentionIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cbc:WebsiteURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cbc:WebsiteURI)">
+          <xsl:attribute name="id">UBL-CR-143</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-143]-A UBL invoice should not include the AccountingSupplierParty Party WebsiteURI</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cbc:LogoReferenceID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cbc:LogoReferenceID)">
+          <xsl:attribute name="id">UBL-CR-144</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-144]-A UBL invoice should not include the AccountingSupplierParty Party LogoReferenceID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cbc:IndustryClassificationCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cbc:IndustryClassificationCode)">
+          <xsl:attribute name="id">UBL-CR-145</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-145]-A UBL invoice should not include the AccountingSupplierParty Party IndustryClassificationCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:Language)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:Language)">
+          <xsl:attribute name="id">UBL-CR-146</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-146]-A UBL invoice should not include the AccountingSupplierParty Party Language</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-147</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-147]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:AddressTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:AddressTypeCode)">
+          <xsl:attribute name="id">UBL-CR-148</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-148]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress AddressTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:AddressFormatCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:AddressFormatCode)">
+          <xsl:attribute name="id">UBL-CR-149</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-149]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress AddressFormatCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:Postbox)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:Postbox)">
+          <xsl:attribute name="id">UBL-CR-150</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-150]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress Postbox</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:Floor)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:Floor)">
+          <xsl:attribute name="id">UBL-CR-151</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-151]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress Floor</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:Room)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:Room)">
+          <xsl:attribute name="id">UBL-CR-152</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-152]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress Room</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:BlockName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:BlockName)">
+          <xsl:attribute name="id">UBL-CR-153</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-153]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress BlockName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:BuildingName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:BuildingName)">
+          <xsl:attribute name="id">UBL-CR-154</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-154]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress BuildingName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:BuildingNumber)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:BuildingNumber)">
+          <xsl:attribute name="id">UBL-CR-155</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-155]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress BuildingNumber</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:InhouseMail)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:InhouseMail)">
+          <xsl:attribute name="id">UBL-CR-156</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-156]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress InhouseMail</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:Department)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:Department)">
+          <xsl:attribute name="id">UBL-CR-157</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-157]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress Department</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:MarkAttention)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:MarkAttention)">
+          <xsl:attribute name="id">UBL-CR-158</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-158]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress MarkAttention</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:MarkCare)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:MarkCare)">
+          <xsl:attribute name="id">UBL-CR-159</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-159]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress MarkCare</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:PlotIdentification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:PlotIdentification)">
+          <xsl:attribute name="id">UBL-CR-160</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-160]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress PlotIdentification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:CitySubdivisionName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:CitySubdivisionName)">
+          <xsl:attribute name="id">UBL-CR-161</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-161]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress CitySubdivisionName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:CountrySubentityCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:CountrySubentityCode)">
+          <xsl:attribute name="id">UBL-CR-162</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-162]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress CountrySubentityCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:Region)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:Region)">
+          <xsl:attribute name="id">UBL-CR-163</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-163]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress Region</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:District)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:District)">
+          <xsl:attribute name="id">UBL-CR-164</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-164]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress District</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:TimezoneOffset)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:TimezoneOffset)">
+          <xsl:attribute name="id">UBL-CR-165</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-165]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress TimezoneOffset</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-166</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-166]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress Country Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:LocationCoordinate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:LocationCoordinate)">
+          <xsl:attribute name="id">UBL-CR-167</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-167]-A UBL invoice should not include the AccountingSupplierParty Party PostalAddress LocationCoordinate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PhysicalLocation)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PhysicalLocation)">
+          <xsl:attribute name="id">UBL-CR-168</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-168]-A UBL invoice should not include the AccountingSupplierParty Party PhysicalLocation</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:RegistrationName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:RegistrationName)">
+          <xsl:attribute name="id">UBL-CR-169</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-169]-A UBL invoice should not include the AccountingSupplierParty Party PartyTaxScheme RegistrationName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:TaxLevelCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:TaxLevelCode)">
+          <xsl:attribute name="id">UBL-CR-170</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-170]-A UBL invoice should not include the AccountingSupplierParty Party PartyTaxScheme TaxLevelCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:ExemptionReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:ExemptionReasonCode)">
+          <xsl:attribute name="id">UBL-CR-171</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-171]-A UBL invoice should not include the AccountingSupplierParty Party PartyTaxScheme ExemptionReasonCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:ExemptionReason)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:ExemptionReason)">
+          <xsl:attribute name="id">UBL-CR-172</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-172]-A UBL invoice should not include the AccountingSupplierParty Party PartyTaxScheme ExemptionReason</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cac:RegistrationAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cac:RegistrationAddress)">
+          <xsl:attribute name="id">UBL-CR-173</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-173]-A UBL invoice should not include the AccountingSupplierParty Party PartyTaxScheme RegistrationAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-174</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-174]-A UBL invoice should not include the AccountingSupplierParty Party PartyTaxScheme TaxScheme Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:TaxTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:TaxTypeCode)">
+          <xsl:attribute name="id">UBL-CR-175</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-175]-A UBL invoice should not include the AccountingSupplierParty Party PartyTaxScheme TaxScheme TaxTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:CurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:CurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-176</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-176]-A UBL invoice should not include the AccountingSupplierParty Party PartyTaxScheme TaxScheme CurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cac:JurisdictionRegionAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cac:JurisdictionRegionAddress)">
+          <xsl:attribute name="id">UBL-CR-177</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-177]-A UBL invoice should not include the AccountingSupplierParty Party PartyTaxScheme TaxScheme JurisdictionRegionAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationDate)">
+          <xsl:attribute name="id">UBL-CR-178</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-178]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity RegistrationDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationExpirationDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationExpirationDate)">
+          <xsl:attribute name="id">UBL-CR-179</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-179]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity RegistrationExpirationDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLegalFormCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLegalFormCode)">
+          <xsl:attribute name="id">UBL-CR-180</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-180]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity CompanyLegalFormCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:SoleProprietorshipIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:SoleProprietorshipIndicator)">
+          <xsl:attribute name="id">UBL-CR-181</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-181]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity SoleProprietorshipIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLiquidationStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLiquidationStatusCode)">
+          <xsl:attribute name="id">UBL-CR-182</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-182]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity CompanyLiquidationStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CorporateStockAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CorporateStockAmount)">
+          <xsl:attribute name="id">UBL-CR-183</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-183]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity CorporateStockAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:FullyPaidSharesIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:FullyPaidSharesIndicator)">
+          <xsl:attribute name="id">UBL-CR-184</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-184]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity FullyPaidSharesIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cac:RegistrationAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cac:RegistrationAddress)">
+          <xsl:attribute name="id">UBL-CR-185</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-185]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity RegistrationAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cac:CorporateRegistrationScheme)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cac:CorporateRegistrationScheme)">
+          <xsl:attribute name="id">UBL-CR-186</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-186]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity CorporateRegistrationScheme</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cac:HeadOfficeParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cac:HeadOfficeParty)">
+          <xsl:attribute name="id">UBL-CR-187</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-187]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity HeadOfficeParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cac:ShareholderParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cac:ShareholderParty)">
+          <xsl:attribute name="id">UBL-CR-188</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-188]-A UBL invoice should not include the AccountingSupplierParty Party PartyLegalEntity ShareholderParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-189</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-189]-A UBL invoice should not include the AccountingSupplierParty Party Contact ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:Telefax)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:Telefax)">
+          <xsl:attribute name="id">UBL-CR-190</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-190]-A UBL invoice should not include the AccountingSupplierParty Party Contact Telefax</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:Note)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:Contact/cbc:Note)">
+          <xsl:attribute name="id">UBL-CR-191</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-191]-A UBL invoice should not include the AccountingSupplierParty Party Contact Note</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:Contact/cac:OtherCommunication)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:Contact/cac:OtherCommunication)">
+          <xsl:attribute name="id">UBL-CR-192</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-192]-A UBL invoice should not include the AccountingSupplierParty Party Contact OtherCommunication</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:Person)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:Person)">
+          <xsl:attribute name="id">UBL-CR-193</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-193]-A UBL invoice should not include the AccountingSupplierParty Party Person</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:AgentParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:AgentParty)">
+          <xsl:attribute name="id">UBL-CR-194</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-194]-A UBL invoice should not include the AccountingSupplierParty Party AgentParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:ServiceProviderParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:ServiceProviderParty)">
+          <xsl:attribute name="id">UBL-CR-195</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-195]-A UBL invoice should not include the AccountingSupplierParty Party ServiceProviderParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:PowerOfAttorney)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:PowerOfAttorney)">
+          <xsl:attribute name="id">UBL-CR-196</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-196]-A UBL invoice should not include the AccountingSupplierParty Party PowerOfAttorney</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:Party/cac:FinancialAccount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:Party/cac:FinancialAccount)">
+          <xsl:attribute name="id">UBL-CR-197</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-197]-A UBL invoice should not include the AccountingSupplierParty Party FinancialAccount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:DespatchContact)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:DespatchContact)">
+          <xsl:attribute name="id">UBL-CR-198</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-198]-A UBL invoice should not include the AccountingSupplierParty DespatchContact</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:AccountingContact)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:AccountingContact)">
+          <xsl:attribute name="id">UBL-CR-199</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-199]-A UBL invoice should not include the AccountingSupplierParty AccountingContact</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingSupplierParty/cac:SellerContact)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingSupplierParty/cac:SellerContact)">
+          <xsl:attribute name="id">UBL-CR-200</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-200]-A UBL invoice should not include the AccountingSupplierParty SellerContact</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cbc:CustomerAssignedAccountID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cbc:CustomerAssignedAccountID)">
+          <xsl:attribute name="id">UBL-CR-201</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-201]-A UBL invoice should not include the AccountingCustomerParty CustomerAssignedAccountID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cbc:SupplierAssignedAccountID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cbc:SupplierAssignedAccountID)">
+          <xsl:attribute name="id">UBL-CR-202</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-202]-A UBL invoice should not include the AccountingCustomerParty SupplierAssignedAccountID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cbc:AdditionalAccountID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cbc:AdditionalAccountID)">
+          <xsl:attribute name="id">UBL-CR-203</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-203]-A UBL invoice should not include the AccountingCustomerParty AdditionalAccountID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cbc:MarkCareIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cbc:MarkCareIndicator)">
+          <xsl:attribute name="id">UBL-CR-204</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-204]-A UBL invoice should not include the AccountingCustomerParty Party MarkCareIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cbc:MarkAttentionIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cbc:MarkAttentionIndicator)">
+          <xsl:attribute name="id">UBL-CR-205</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-205]-A UBL invoice should not include the AccountingCustomerParty Party MarkAttentionIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cbc:WebsiteURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cbc:WebsiteURI)">
+          <xsl:attribute name="id">UBL-CR-206</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-206]-A UBL invoice should not include the AccountingCustomerParty Party WebsiteURI</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cbc:LogoReferenceID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cbc:LogoReferenceID)">
+          <xsl:attribute name="id">UBL-CR-207</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-207]-A UBL invoice should not include the AccountingCustomerParty Party LogoReferenceID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cbc:IndustryClassificationCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cbc:IndustryClassificationCode)">
+          <xsl:attribute name="id">UBL-CR-208</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-208]-A UBL invoice should not include the AccountingCustomerParty Party IndustryClassificationCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:Language)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:Language)">
+          <xsl:attribute name="id">UBL-CR-209</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-209]-A UBL invoice should not include the AccountingCustomerParty Party Language</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-210</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-210]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:AddressTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:AddressTypeCode)">
+          <xsl:attribute name="id">UBL-CR-211</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-211]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress AddressTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:AddressFormatCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:AddressFormatCode)">
+          <xsl:attribute name="id">UBL-CR-212</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-212]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress AddressFormatCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:Postbox)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:Postbox)">
+          <xsl:attribute name="id">UBL-CR-213</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-213]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress Postbox</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:Floor)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:Floor)">
+          <xsl:attribute name="id">UBL-CR-214</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-214]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress Floor</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:Room)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:Room)">
+          <xsl:attribute name="id">UBL-CR-215</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-215]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress Room</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:BlockName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:BlockName)">
+          <xsl:attribute name="id">UBL-CR-216</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-216]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress BlockName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:BuildingName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:BuildingName)">
+          <xsl:attribute name="id">UBL-CR-217</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-217]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress BuildingName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:BuildingNumber)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:BuildingNumber)">
+          <xsl:attribute name="id">UBL-CR-218</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-218]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress BuildingNumber</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:InhouseMail)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:InhouseMail)">
+          <xsl:attribute name="id">UBL-CR-219</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-219]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress InhouseMail</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:Department)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:Department)">
+          <xsl:attribute name="id">UBL-CR-220</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-220]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress Department</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:MarkAttention)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:MarkAttention)">
+          <xsl:attribute name="id">UBL-CR-221</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-221]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress MarkAttention</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:MarkCare)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:MarkCare)">
+          <xsl:attribute name="id">UBL-CR-222</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-222]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress MarkCare</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:PlotIdentification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:PlotIdentification)">
+          <xsl:attribute name="id">UBL-CR-223</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-223]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress PlotIdentification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:CitySubdivisionName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:CitySubdivisionName)">
+          <xsl:attribute name="id">UBL-CR-224</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-224]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress CitySubdivisionName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:CountrySubentityCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:CountrySubentityCode)">
+          <xsl:attribute name="id">UBL-CR-225</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-225]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress CountrySubentityCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:Region)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:Region)">
+          <xsl:attribute name="id">UBL-CR-226</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-226]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress Region</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:District)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:District)">
+          <xsl:attribute name="id">UBL-CR-227</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-227]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress District</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:TimezoneOffset)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cbc:TimezoneOffset)">
+          <xsl:attribute name="id">UBL-CR-228</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-228]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress TimezoneOffset</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-229</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-229]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress Country Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:LocationCoordinate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:LocationCoordinate)">
+          <xsl:attribute name="id">UBL-CR-230</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-230]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress LocationCoordinate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PhysicalLocation)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PhysicalLocation)">
+          <xsl:attribute name="id">UBL-CR-231</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-231]-A UBL invoice should not include the AccountingCustomerParty Party PhysicalLocation</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cbc:RegistrationName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cbc:RegistrationName)">
+          <xsl:attribute name="id">UBL-CR-232</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-232]-A UBL invoice should not include the AccountingCustomerParty Party PartyTaxScheme RegistrationName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cbc:TaxLevelCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cbc:TaxLevelCode)">
+          <xsl:attribute name="id">UBL-CR-233</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-233]-A UBL invoice should not include the AccountingCustomerParty Party PartyTaxScheme TaxLevelCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cbc:ExemptionReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cbc:ExemptionReasonCode)">
+          <xsl:attribute name="id">UBL-CR-234</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-234]-A UBL invoice should not include the AccountingCustomerParty Party PartyTaxScheme ExemptionReasonCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cbc:ExemptionReason)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cbc:ExemptionReason)">
+          <xsl:attribute name="id">UBL-CR-235</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-235]-A UBL invoice should not include the AccountingCustomerParty Party PartyTaxScheme ExemptionReason</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cac:RegistrationAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cac:RegistrationAddress)">
+          <xsl:attribute name="id">UBL-CR-236</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-236]-A UBL invoice should not include the AccountingCustomerParty Party PartyTaxScheme RegistrationAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-237</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-237]-A UBL invoice should not include the AccountingCustomerParty Party PartyTaxScheme TaxScheme Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:TaxTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:TaxTypeCode)">
+          <xsl:attribute name="id">UBL-CR-238</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-238]-A UBL invoice should not include the AccountingCustomerParty Party PartyTaxScheme TaxScheme TaxTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:CurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cbc:CurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-239</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-239]-A UBL invoice should not include the AccountingCustomerParty Party PartyTaxScheme TaxScheme CurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cac:JurisdictionRegionAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme/cac:TaxScheme/cac:JurisdictionRegionAddress)">
+          <xsl:attribute name="id">UBL-CR-240</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-240]-A UBL invoice should not include the AccountingCustomerParty Party PartyTaxScheme TaxScheme JurisdictionRegionAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationDate)">
+          <xsl:attribute name="id">UBL-CR-241</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-241]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity RegistrationDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationExpirationDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationExpirationDate)">
+          <xsl:attribute name="id">UBL-CR-242</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-242]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity RegistrationExpirationDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLegalFormCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLegalFormCode)">
+          <xsl:attribute name="id">UBL-CR-243</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-243]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity CompanyLegalFormCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLegalForm)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLegalForm)">
+          <xsl:attribute name="id">UBL-CR-244</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-244]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity CompanyLegalForm</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:SoleProprietorshipIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:SoleProprietorshipIndicator)">
+          <xsl:attribute name="id">UBL-CR-245</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-245]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity SoleProprietorshipIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLiquidationStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLiquidationStatusCode)">
+          <xsl:attribute name="id">UBL-CR-246</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-246]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity CompanyLiquidationStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CorporateStockAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CorporateStockAmount)">
+          <xsl:attribute name="id">UBL-CR-247</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-247]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity CorporateStockAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:FullyPaidSharesIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:FullyPaidSharesIndicator)">
+          <xsl:attribute name="id">UBL-CR-248</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-248]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity FullyPaidSharesIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cac:RegistrationAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cac:RegistrationAddress)">
+          <xsl:attribute name="id">UBL-CR-249</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-249]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity RegistrationAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cac:CorporateRegistrationScheme)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cac:CorporateRegistrationScheme)">
+          <xsl:attribute name="id">UBL-CR-250</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-250]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity CorporateRegistrationScheme</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cac:HeadOfficeParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cac:HeadOfficeParty)">
+          <xsl:attribute name="id">UBL-CR-251</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-251]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity HeadOfficeParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cac:ShareholderParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cac:ShareholderParty)">
+          <xsl:attribute name="id">UBL-CR-252</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-252]-A UBL invoice should not include the AccountingCustomerParty Party PartyLegalEntity ShareholderParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-253</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-253]-A UBL invoice should not include the AccountingCustomerParty Party Contact ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:Telefax)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:Telefax)">
+          <xsl:attribute name="id">UBL-CR-254</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-254]-A UBL invoice should not include the AccountingCustomerParty Party Contact Telefax</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:Note)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:Contact/cbc:Note)">
+          <xsl:attribute name="id">UBL-CR-255</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-255]-A UBL invoice should not include the AccountingCustomerParty Party Contact Note</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:Contact/cac:OtherCommunication)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:Contact/cac:OtherCommunication)">
+          <xsl:attribute name="id">UBL-CR-256</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-256]-A UBL invoice should not include the AccountingCustomerParty Party Contact OtherCommunication</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:Person)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:Person)">
+          <xsl:attribute name="id">UBL-CR-257</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-257]-A UBL invoice should not include the AccountingCustomerParty Party Person</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:AgentParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:AgentParty)">
+          <xsl:attribute name="id">UBL-CR-258</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-258]-A UBL invoice should not include the AccountingCustomerParty Party AgentParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:ServiceProviderParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:ServiceProviderParty)">
+          <xsl:attribute name="id">UBL-CR-259</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-259]-A UBL invoice should not include the AccountingCustomerParty Party ServiceProviderParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:PowerOfAttorney)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:PowerOfAttorney)">
+          <xsl:attribute name="id">UBL-CR-260</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-260]-A UBL invoice should not include the AccountingCustomerParty Party PowerOfAttorney</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:Party/cac:FinancialAccount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:Party/cac:FinancialAccount)">
+          <xsl:attribute name="id">UBL-CR-261</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-261]-A UBL invoice should not include the AccountingCustomerParty Party FinancialAccount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:DeliveryContact)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:DeliveryContact)">
+          <xsl:attribute name="id">UBL-CR-262</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-262]-A UBL invoice should not include the AccountingCustomerParty DeliveryContact</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:AccountingContact)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:AccountingContact)">
+          <xsl:attribute name="id">UBL-CR-263</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-263]-A UBL invoice should not include the AccountingCustomerParty AccountingContact</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AccountingCustomerParty/cac:BuyerContact)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AccountingCustomerParty/cac:BuyerContact)">
+          <xsl:attribute name="id">UBL-CR-264</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-264]-A UBL invoice should not include the AccountingCustomerParty BuyerContact</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cbc:MarkCareIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cbc:MarkCareIndicator)">
+          <xsl:attribute name="id">UBL-CR-265</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-265]-A UBL invoice should not include the PayeeParty MarkCareIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cbc:MarkAttentionIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cbc:MarkAttentionIndicator)">
+          <xsl:attribute name="id">UBL-CR-266</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-266]-A UBL invoice should not include the PayeeParty MarkAttentionIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cbc:WebsiteURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cbc:WebsiteURI)">
+          <xsl:attribute name="id">UBL-CR-267</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-267]-A UBL invoice should not include the PayeeParty WebsiteURI</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cbc:LogoReferenceID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cbc:LogoReferenceID)">
+          <xsl:attribute name="id">UBL-CR-268</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-268]-A UBL invoice should not include the PayeeParty LogoReferenceID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cbc:EndpointID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cbc:EndpointID)">
+          <xsl:attribute name="id">UBL-CR-269</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-269]-A UBL invoice should not include the PayeeParty EndpointID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cbc:IndustryClassificationCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cbc:IndustryClassificationCode)">
+          <xsl:attribute name="id">UBL-CR-270</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-270]-A UBL invoice should not include the PayeeParty IndustryClassificationCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:Language)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:Language)">
+          <xsl:attribute name="id">UBL-CR-271</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-271]-A UBL invoice should not include the PayeeParty Language</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PostalAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PostalAddress)">
+          <xsl:attribute name="id">UBL-CR-272</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-272]-A UBL invoice should not include the PayeeParty PostalAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PhysicalLocation)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PhysicalLocation)">
+          <xsl:attribute name="id">UBL-CR-273</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-273]-A UBL invoice should not include the PayeeParty PhysicalLocation</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyTaxScheme)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyTaxScheme)">
+          <xsl:attribute name="id">UBL-CR-274</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-274]-A UBL invoice should not include the PayeeParty PartyTaxScheme</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:RegistrationName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:RegistrationName)">
+          <xsl:attribute name="id">UBL-CR-275</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-275]-A UBL invoice should not include the PayeeParty PartyLegalEntity RegistrationName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:RegistrationDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:RegistrationDate)">
+          <xsl:attribute name="id">UBL-CR-276</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-276]-A UBL invoice should not include the PayeeParty PartyLegalEntity RegistrationDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:RegistrationExpirationDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:RegistrationExpirationDate)">
+          <xsl:attribute name="id">UBL-CR-277</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-277]-A UBL invoice should not include the PayeeParty PartyLegalEntity RegistrationExpirationDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:CompanyLegalFormCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:CompanyLegalFormCode)">
+          <xsl:attribute name="id">UBL-CR-278</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-278]-A UBL invoice should not include the PayeeParty PartyLegalEntity CompanyLegalFormCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:CompanyLegalForm)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:CompanyLegalForm)">
+          <xsl:attribute name="id">UBL-CR-279</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-279]-A UBL invoice should not include the PayeeParty PartyLegalEntity CompanyLegalForm</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:SoleProprietorshipIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:SoleProprietorshipIndicator)">
+          <xsl:attribute name="id">UBL-CR-280</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-280]-A UBL invoice should not include the PayeeParty PartyLegalEntity SoleProprietorshipIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:CompanyLiquidationStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:CompanyLiquidationStatusCode)">
+          <xsl:attribute name="id">UBL-CR-281</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-281]-A UBL invoice should not include the PayeeParty PartyLegalEntity CompanyLiquidationStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:CorporateStockAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:CorporateStockAmount)">
+          <xsl:attribute name="id">UBL-CR-282</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-282]-A UBL invoice should not include the PayeeParty PartyLegalEntity CorporateStockAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:FullyPaidSharesIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cbc:FullyPaidSharesIndicator)">
+          <xsl:attribute name="id">UBL-CR-283</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-283]-A UBL invoice should not include the PayeeParty PartyLegalEntity FullyPaidSharesIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cac:RegistrationAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cac:RegistrationAddress)">
+          <xsl:attribute name="id">UBL-CR-284</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-284]-A UBL invoice should not include the PayeeParty PartyLegalEntity RegistrationAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cac:CorporateRegistrationScheme)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cac:CorporateRegistrationScheme)">
+          <xsl:attribute name="id">UBL-CR-285</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-285]-A UBL invoice should not include the PayeeParty PartyLegalEntity CorporateRegistrationScheme</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cac:HeadOfficeParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cac:HeadOfficeParty)">
+          <xsl:attribute name="id">UBL-CR-286</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-286]-A UBL invoice should not include the PayeeParty PartyLegalEntity HeadOfficeParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PartyLegalEntity/cac:ShareholderParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PartyLegalEntity/cac:ShareholderParty)">
+          <xsl:attribute name="id">UBL-CR-287</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-287]-A UBL invoice should not include the PayeeParty PartyLegalEntity ShareholderParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:Contact)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:Contact)">
+          <xsl:attribute name="id">UBL-CR-288</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-288]-A UBL invoice should not include the PayeeParty Contact</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:Person)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:Person)">
+          <xsl:attribute name="id">UBL-CR-289</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-289]-A UBL invoice should not include the PayeeParty Person</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:AgentParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:AgentParty)">
+          <xsl:attribute name="id">UBL-CR-290</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-290]-A UBL invoice should not include the PayeeParty AgentParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:ServiceProviderParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:ServiceProviderParty)">
+          <xsl:attribute name="id">UBL-CR-291</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-291]-A UBL invoice should not include the PayeeParty ServiceProviderParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:PowerOfAttorney)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:PowerOfAttorney)">
+          <xsl:attribute name="id">UBL-CR-292</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-292]-A UBL invoice should not include the PayeeParty PowerOfAttorney</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeParty/cac:FinancialAccount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeParty/cac:FinancialAccount)">
+          <xsl:attribute name="id">UBL-CR-293</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-293]-A UBL invoice should not include the PayeeParty FinancialAccount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:BuyerCustomerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:BuyerCustomerParty)">
+          <xsl:attribute name="id">UBL-CR-294</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-294]-A UBL invoice should not include the BuyerCustomerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:SellerSupplierParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:SellerSupplierParty)">
+          <xsl:attribute name="id">UBL-CR-295</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-295]-A UBL invoice should not include the SellerSupplierParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cbc:MarkCareIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cbc:MarkCareIndicator)">
+          <xsl:attribute name="id">UBL-CR-296</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-296]-A UBL invoice should not include the TaxRepresentativeParty MarkCareIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cbc:MarkAttentionIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cbc:MarkAttentionIndicator)">
+          <xsl:attribute name="id">UBL-CR-297</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-297]-A UBL invoice should not include the TaxRepresentativeParty MarkAttentionIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cbc:WebsiteURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cbc:WebsiteURI)">
+          <xsl:attribute name="id">UBL-CR-298</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-298]-A UBL invoice should not include the TaxRepresentativeParty WebsiteURI</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cbc:LogoReferenceID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cbc:LogoReferenceID)">
+          <xsl:attribute name="id">UBL-CR-299</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-299]-A UBL invoice should not include the TaxRepresentativeParty LogoReferenceID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cbc:EndpointID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cbc:EndpointID)">
+          <xsl:attribute name="id">UBL-CR-300</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-300]-A UBL invoice should not include the TaxRepresentativeParty EndpointID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cbc:IndustryClassificationCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cbc:IndustryClassificationCode)">
+          <xsl:attribute name="id">UBL-CR-301</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-301]-A UBL invoice should not include the TaxRepresentativeParty IndustryClassificationCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyIdentification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyIdentification)">
+          <xsl:attribute name="id">UBL-CR-302</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-302]-A UBL invoice should not include the TaxRepresentativeParty PartyIdentification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:Language)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:Language)">
+          <xsl:attribute name="id">UBL-CR-303</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-303]-A UBL invoice should not include the TaxRepresentativeParty Language</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-304</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-304]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:AddressTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:AddressTypeCode)">
+          <xsl:attribute name="id">UBL-CR-305</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-305]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress AddressTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:AddressFormatCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:AddressFormatCode)">
+          <xsl:attribute name="id">UBL-CR-306</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-306]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress AddressFormatCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:Postbox)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:Postbox)">
+          <xsl:attribute name="id">UBL-CR-307</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-307]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress Postbox</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:Floor)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:Floor)">
+          <xsl:attribute name="id">UBL-CR-308</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-308]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress Floor</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:Room)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:Room)">
+          <xsl:attribute name="id">UBL-CR-309</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-309]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress Room</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:BlockName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:BlockName)">
+          <xsl:attribute name="id">UBL-CR-310</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-310]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress BlockName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:BuildingName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:BuildingName)">
+          <xsl:attribute name="id">UBL-CR-311</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-311]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress BuildingName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:BuildingNumber)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:BuildingNumber)">
+          <xsl:attribute name="id">UBL-CR-312</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-312]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress BuildingNumber</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:InhouseMail)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:InhouseMail)">
+          <xsl:attribute name="id">UBL-CR-313</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-313]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress InhouseMail</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:Department)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:Department)">
+          <xsl:attribute name="id">UBL-CR-314</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-314]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress Department</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:MarkAttention)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:MarkAttention)">
+          <xsl:attribute name="id">UBL-CR-315</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-315]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress MarkAttention</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:MarkCare)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:MarkCare)">
+          <xsl:attribute name="id">UBL-CR-316</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-316]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress MarkCare</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:PlotIdentification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:PlotIdentification)">
+          <xsl:attribute name="id">UBL-CR-317</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-317]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress PlotIdentification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:CitySubdivisionName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:CitySubdivisionName)">
+          <xsl:attribute name="id">UBL-CR-318</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-318]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress CitySubdivisionName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:CountrySubentityCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:CountrySubentityCode)">
+          <xsl:attribute name="id">UBL-CR-319</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-319]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress CountrySubentityCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:Region)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:Region)">
+          <xsl:attribute name="id">UBL-CR-320</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-320]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress Region</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:District)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:District)">
+          <xsl:attribute name="id">UBL-CR-321</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-321]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress District</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:TimezoneOffset)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cbc:TimezoneOffset)">
+          <xsl:attribute name="id">UBL-CR-322</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-322]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress TimezoneOffset</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cac:Country/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cac:Country/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-323</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-323]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress Country Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cac:LocationCoordinate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PostalAddress/cac:LocationCoordinate)">
+          <xsl:attribute name="id">UBL-CR-324</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-324]-A UBL invoice should not include the TaxRepresentativeParty PostalAddress LocationCoordinate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PhysicalLocation)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PhysicalLocation)">
+          <xsl:attribute name="id">UBL-CR-325</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-325]-A UBL invoice should not include the TaxRepresentativeParty PhysicalLocation</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cbc:RegistrationName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cbc:RegistrationName)">
+          <xsl:attribute name="id">UBL-CR-326</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-326]-A UBL invoice should not include the TaxRepresentativeParty PartyTaxScheme RegistrationName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cbc:TaxLevelCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cbc:TaxLevelCode)">
+          <xsl:attribute name="id">UBL-CR-327</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-327]-A UBL invoice should not include the TaxRepresentativeParty PartyTaxScheme TaxLevelCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cbc:ExemptionReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cbc:ExemptionReasonCode)">
+          <xsl:attribute name="id">UBL-CR-328</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-328]-A UBL invoice should not include the TaxRepresentativeParty PartyTaxScheme ExemptionReasonCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cbc:ExemptionReason)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cbc:ExemptionReason)">
+          <xsl:attribute name="id">UBL-CR-329</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-329]-A UBL invoice should not include the TaxRepresentativeParty PartyTaxScheme ExemptionReason</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cac:RegistrationAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cac:RegistrationAddress)">
+          <xsl:attribute name="id">UBL-CR-330</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-330]-A UBL invoice should not include the TaxRepresentativeParty PartyTaxScheme RegistrationAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cac:TaxScheme/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cac:TaxScheme/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-331</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-331]-A UBL invoice should not include the TaxRepresentativeParty PartyTaxScheme TaxScheme Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cac:TaxScheme/cbc:TaxTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cac:TaxScheme/cbc:TaxTypeCode)">
+          <xsl:attribute name="id">UBL-CR-332</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-332]-A UBL invoice should not include the TaxRepresentativeParty PartyTaxScheme TaxScheme TaxTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cac:TaxScheme/cbc:CurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cac:TaxScheme/cbc:CurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-333</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-333]-A UBL invoice should not include the TaxRepresentativeParty PartyTaxScheme TaxScheme CurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cac:TaxScheme/cac:JurisdictionRegionAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyTaxScheme/cac:TaxScheme/cac:JurisdictionRegionAddress)">
+          <xsl:attribute name="id">UBL-CR-334</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-334]-A UBL invoice should not include the TaxRepresentativeParty PartyTaxScheme TaxScheme JurisdictionRegionAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PartyLegalEntity)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PartyLegalEntity)">
+          <xsl:attribute name="id">UBL-CR-335</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-335]-A UBL invoice should not include the TaxRepresentativeParty PartyLegalEntity</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:Contact)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:Contact)">
+          <xsl:attribute name="id">UBL-CR-336</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-336]-A UBL invoice should not include the TaxRepresentativeParty Contact</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:Person)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:Person)">
+          <xsl:attribute name="id">UBL-CR-337</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-337]-A UBL invoice should not include the TaxRepresentativeParty Person</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:AgentParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:AgentParty)">
+          <xsl:attribute name="id">UBL-CR-338</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-338]-A UBL invoice should not include the TaxRepresentativeParty AgentParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:ServiceProviderParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:ServiceProviderParty)">
+          <xsl:attribute name="id">UBL-CR-339</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-339]-A UBL invoice should not include the TaxRepresentativeParty ServiceProviderParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:PowerOfAttorney)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:PowerOfAttorney)">
+          <xsl:attribute name="id">UBL-CR-340</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-340]-A UBL invoice should not include the TaxRepresentativeParty PowerOfAttorney</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxRepresentativeParty/cac:FinancialAccount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxRepresentativeParty/cac:FinancialAccount)">
+          <xsl:attribute name="id">UBL-CR-341</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-341]-A UBL invoice should not include the TaxRepresentativeParty FinancialAccount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-342</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-342]-A UBL invoice should not include the Delivery ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cbc:Quantity)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cbc:Quantity)">
+          <xsl:attribute name="id">UBL-CR-343</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-343]-A UBL invoice should not include the Delivery Quantity</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cbc:MinimumQuantity)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cbc:MinimumQuantity)">
+          <xsl:attribute name="id">UBL-CR-344</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-344]-A UBL invoice should not include the Delivery MinimumQuantity</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cbc:MaximumQuantity)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cbc:MaximumQuantity)">
+          <xsl:attribute name="id">UBL-CR-345</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-345]-A UBL invoice should not include the Delivery MaximumQuantity</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cbc:ActualDeliveryTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cbc:ActualDeliveryTime)">
+          <xsl:attribute name="id">UBL-CR-346</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-346]-A UBL invoice should not include the Delivery ActualDeliveryTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cbc:LatestDeliveryDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cbc:LatestDeliveryDate)">
+          <xsl:attribute name="id">UBL-CR-347</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-347]-A UBL invoice should not include the Delivery LatestDeliveryDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cbc:LatestDeliveryTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cbc:LatestDeliveryTime)">
+          <xsl:attribute name="id">UBL-CR-348</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-348]-A UBL invoice should not include the Delivery LatestDeliveryTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cbc:ReleaseID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cbc:ReleaseID)">
+          <xsl:attribute name="id">UBL-CR-349</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-349]-A UBL invoice should not include the Delivery ReleaseID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cbc:TrackingID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cbc:TrackingID)">
+          <xsl:attribute name="id">UBL-CR-350</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-350]-A UBL invoice should not include the Delivery TrackingID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cbc:Description)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cbc:Description)">
+          <xsl:attribute name="id">UBL-CR-351</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-351]-A UBL invoice should not include the Delivery DeliveryLocation Description</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cbc:Conditions)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cbc:Conditions)">
+          <xsl:attribute name="id">UBL-CR-352</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-352]-A UBL invoice should not include the Delivery DeliveryLocation Conditions</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cbc:CountrySubentity)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cbc:CountrySubentity)">
+          <xsl:attribute name="id">UBL-CR-353</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-353]-A UBL invoice should not include the Delivery DeliveryLocation CountrySubentity</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cbc:CountrySubentityCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cbc:CountrySubentityCode)">
+          <xsl:attribute name="id">UBL-CR-354</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-354]-A UBL invoice should not include the Delivery DeliveryLocation CountrySubentityCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cbc:LocationTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cbc:LocationTypeCode)">
+          <xsl:attribute name="id">UBL-CR-355</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-355]-A UBL invoice should not include the Delivery DeliveryLocation LocationTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cbc:InformationURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cbc:InformationURI)">
+          <xsl:attribute name="id">UBL-CR-356</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-356]-A UBL invoice should not include the Delivery DeliveryLocation InformationURI</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-357</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-357]-A UBL invoice should not include the Delivery DeliveryLocation Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-358</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-358]-A UBL invoice should not include the Delivery DeliveryLocation ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-359</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-359]-A UBL invoice should not include the Delivery DeliveryLocation Address ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:AddressTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:AddressTypeCode)">
+          <xsl:attribute name="id">UBL-CR-360</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-360]-A UBL invoice should not include the Delivery DeliveryLocation Address AddressTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:AddressFormatCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:AddressFormatCode)">
+          <xsl:attribute name="id">UBL-CR-361</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-361]-A UBL invoice should not include the Delivery DeliveryLocation Address AddressFormatCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:Postbox)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:Postbox)">
+          <xsl:attribute name="id">UBL-CR-362</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-362]-A UBL invoice should not include the Delivery DeliveryLocation Address Postbox</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:Floor)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:Floor)">
+          <xsl:attribute name="id">UBL-CR-363</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-363]-A UBL invoice should not include the Delivery DeliveryLocation Address Floor</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:Room)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:Room)">
+          <xsl:attribute name="id">UBL-CR-364</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-364]-A UBL invoice should not include the Delivery DeliveryLocation Address Room</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:BlockName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:BlockName)">
+          <xsl:attribute name="id">UBL-CR-365</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-365]-A UBL invoice should not include the Delivery DeliveryLocation Address BlockName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:BuildingName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:BuildingName)">
+          <xsl:attribute name="id">UBL-CR-366</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-366]-A UBL invoice should not include the Delivery DeliveryLocation Address BuildingName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:BuildingNumber)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:BuildingNumber)">
+          <xsl:attribute name="id">UBL-CR-367</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-367]-A UBL invoice should not include the Delivery DeliveryLocation Address BuildingNumber</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:InhouseMail)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:InhouseMail)">
+          <xsl:attribute name="id">UBL-CR-368</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-368]-A UBL invoice should not include the Delivery DeliveryLocation Address InhouseMail</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:Department)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:Department)">
+          <xsl:attribute name="id">UBL-CR-369</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-369]-A UBL invoice should not include the Delivery DeliveryLocation Address Department</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:MarkAttention)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:MarkAttention)">
+          <xsl:attribute name="id">UBL-CR-370</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-370]-A UBL invoice should not include the Delivery DeliveryLocation Address MarkAttention</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:MarkCare)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:MarkCare)">
+          <xsl:attribute name="id">UBL-CR-371</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-371]-A UBL invoice should not include the Delivery DeliveryLocation Address MarkCare</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:PlotIdentification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:PlotIdentification)">
+          <xsl:attribute name="id">UBL-CR-372</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-372]-A UBL invoice should not include the Delivery DeliveryLocation Address PlotIdentification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:CitySubdivisionName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:CitySubdivisionName)">
+          <xsl:attribute name="id">UBL-CR-373</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-373]-A UBL invoice should not include the Delivery DeliveryLocation Address CitySubdivisionName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:CountrySubentityCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:CountrySubentityCode)">
+          <xsl:attribute name="id">UBL-CR-374</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-374]-A UBL invoice should not include the Delivery DeliveryLocation Address CountrySubentityCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:Region)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:Region)">
+          <xsl:attribute name="id">UBL-CR-375</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-375]-A UBL invoice should not include the Delivery DeliveryLocation Address Region</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:District)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:District)">
+          <xsl:attribute name="id">UBL-CR-376</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-376]-A UBL invoice should not include the Delivery DeliveryLocation Address District</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:TimezoneOffset)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cbc:TimezoneOffset)">
+          <xsl:attribute name="id">UBL-CR-377</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-377]-A UBL invoice should not include the Delivery DeliveryLocation Address TimezoneOffset</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cac:Country/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cac:Country/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-378</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-378]-A UBL invoice should not include the Delivery DeliveryLocation Address Country Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cac:LocationCoordinate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:Address/cac:LocationCoordinate)">
+          <xsl:attribute name="id">UBL-CR-379</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-379]-A UBL invoice should not include the Delivery DeliveryLocation Address LocationCoordinate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:SubsidiaryLocation)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:SubsidiaryLocation)">
+          <xsl:attribute name="id">UBL-CR-380</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-380]-A UBL invoice should not include the Delivery DeliveryLocation SubsidiaryLocation</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryLocation/cac:LocationCoordinate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryLocation/cac:LocationCoordinate)">
+          <xsl:attribute name="id">UBL-CR-381</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-381]-A UBL invoice should not include the Delivery DeliveryLocation LocationCoordinate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:AlternativeDeliveryLocation)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:AlternativeDeliveryLocation)">
+          <xsl:attribute name="id">UBL-CR-382</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-382]-A UBL invoice should not include the Delivery AlternativeDeliveryLocation</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:RequestedDeliveryPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:RequestedDeliveryPeriod)">
+          <xsl:attribute name="id">UBL-CR-383</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-383]-A UBL invoice should not include the Delivery RequestedDeliveryPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:EstimatedDeliveryPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:EstimatedDeliveryPeriod)">
+          <xsl:attribute name="id">UBL-CR-384</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-384]-A UBL invoice should not include the Delivery EstimatedDeliveryPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:CarrierParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:CarrierParty)">
+          <xsl:attribute name="id">UBL-CR-385</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-385]-A UBL invoice should not include the Delivery CarrierParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cbc:MarkCareIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cbc:MarkCareIndicator)">
+          <xsl:attribute name="id">UBL-CR-386</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-386]-A UBL invoice should not include the DeliveryParty MarkCareIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cbc:MarkAttentionIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cbc:MarkAttentionIndicator)">
+          <xsl:attribute name="id">UBL-CR-387</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-387]-A UBL invoice should not include the DeliveryParty MarkAttentionIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cbc:WebsiteURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cbc:WebsiteURI)">
+          <xsl:attribute name="id">UBL-CR-388</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-388]-A UBL invoice should not include the DeliveryParty WebsiteURI</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cbc:LogoReferenceID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cbc:LogoReferenceID)">
+          <xsl:attribute name="id">UBL-CR-389</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-389]-A UBL invoice should not include the DeliveryParty LogoReferenceID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cbc:EndpointID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cbc:EndpointID)">
+          <xsl:attribute name="id">UBL-CR-390</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-390]-A UBL invoice should not include the DeliveryParty EndpointID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cbc:IndustryClassificationCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cbc:IndustryClassificationCode)">
+          <xsl:attribute name="id">UBL-CR-391</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-391]-A UBL invoice should not include the DeliveryParty IndustryClassificationCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:PartyIdentification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:PartyIdentification)">
+          <xsl:attribute name="id">UBL-CR-392</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-392]-A UBL invoice should not include the DeliveryParty PartyIdentification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:Language)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:Language)">
+          <xsl:attribute name="id">UBL-CR-393</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-393]-A UBL invoice should not include the DeliveryParty Language</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:PostalAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:PostalAddress)">
+          <xsl:attribute name="id">UBL-CR-394</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-394]-A UBL invoice should not include the DeliveryParty PostalAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:PhysicalLocation)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:PhysicalLocation)">
+          <xsl:attribute name="id">UBL-CR-395</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-395]-A UBL invoice should not include the DeliveryParty PhysicalLocation</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:PartyTaxScheme)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:PartyTaxScheme)">
+          <xsl:attribute name="id">UBL-CR-396</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-396]-A UBL invoice should not include the DeliveryParty PartyTaxScheme</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:PartyLegalEntity)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:PartyLegalEntity)">
+          <xsl:attribute name="id">UBL-CR-397</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-397]-A UBL invoice should not include the DeliveryParty PartyLegalEntity</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:Contact)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:Contact)">
+          <xsl:attribute name="id">UBL-CR-398</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-398]-A UBL invoice should not include the DeliveryParty Contact</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:Person)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:Person)">
+          <xsl:attribute name="id">UBL-CR-399</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-399]-A UBL invoice should not include the DeliveryParty Person</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:AgentParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:AgentParty)">
+          <xsl:attribute name="id">UBL-CR-400</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-400]-A UBL invoice should not include the DeliveryParty AgentParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:ServiceProviderParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:ServiceProviderParty)">
+          <xsl:attribute name="id">UBL-CR-401</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-401]-A UBL invoice should not include the DeliveryParty ServiceProviderParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:PowerOfAttorney)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:PowerOfAttorney)">
+          <xsl:attribute name="id">UBL-CR-402</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-402]-A UBL invoice should not include the DeliveryParty PowerOfAttorney</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryParty/cac:FinancialAccount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryParty/cac:FinancialAccount)">
+          <xsl:attribute name="id">UBL-CR-403</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-403]-A UBL invoice should not include the DeliveryParty FinancialAccount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:NotifyParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:NotifyParty)">
+          <xsl:attribute name="id">UBL-CR-404</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-404]-A UBL invoice should not include the Delivery NotifyParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:Despatch)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:Despatch)">
+          <xsl:attribute name="id">UBL-CR-405</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-405]-A UBL invoice should not include the Delivery Despatch</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryTerms)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryTerms)">
+          <xsl:attribute name="id">UBL-CR-406</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-406]-A UBL invoice should not include the Delivery DeliveryTerms</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:MinimumDeliveryUnit)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:MinimumDeliveryUnit)">
+          <xsl:attribute name="id">UBL-CR-407</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-407]-A UBL invoice should not include the Delivery MinimumDeliveryUnit</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:MaximumDeliveryUnit)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:MaximumDeliveryUnit)">
+          <xsl:attribute name="id">UBL-CR-408</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-408]-A UBL invoice should not include the Delivery MaximumDeliveryUnit</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:Shipment)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:Shipment)">
+          <xsl:attribute name="id">UBL-CR-409</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-409]-A UBL invoice should not include the Delivery Shipment</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:DeliveryTerms)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:DeliveryTerms)">
+          <xsl:attribute name="id">UBL-CR-410</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-410]-A UBL invoice should not include the DeliveryTerms</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-411</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-411]-A UBL invoice should not include the PaymentMeans ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cbc:PaymentDueDate) or ../cn:CreditNote" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cbc:PaymentDueDate) or ../cn:CreditNote">
+          <xsl:attribute name="id">UBL-CR-412</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-412]-A UBL invoice should not include the PaymentMeans PaymentDueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cbc:PaymentChannelCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cbc:PaymentChannelCode)">
+          <xsl:attribute name="id">UBL-CR-413</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-413]-A UBL invoice should not include the PaymentMeans PaymentChannelCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cbc:InstructionID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cbc:InstructionID)">
+          <xsl:attribute name="id">UBL-CR-414</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-414]-A UBL invoice should not include the PaymentMeans InstructionID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:CardAccount/cbc:CardTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:CardAccount/cbc:CardTypeCode)">
+          <xsl:attribute name="id">UBL-CR-415</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-415]-A UBL invoice should not include the PaymentMeans CardAccount CardTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:CardAccount/cbc:ValidityStartDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:CardAccount/cbc:ValidityStartDate)">
+          <xsl:attribute name="id">UBL-CR-416</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-416]-A UBL invoice should not include the PaymentMeans CardAccount ValidityStartDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:CardAccount/cbc:ExpiryDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:CardAccount/cbc:ExpiryDate)">
+          <xsl:attribute name="id">UBL-CR-417</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-417]-A UBL invoice should not include the PaymentMeans CardAccount ExpiryDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:CardAccount/cbc:IssuerID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:CardAccount/cbc:IssuerID)">
+          <xsl:attribute name="id">UBL-CR-418</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-418]-A UBL invoice should not include the PaymentMeans CardAccount IssuerID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:CardAccount/cbc:IssueNumberID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:CardAccount/cbc:IssueNumberID)">
+          <xsl:attribute name="id">UBL-CR-419</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-419]-A UBL invoice should not include the PaymentMeans CardAccount IssueNumberID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:CardAccount/cbc:CV2ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:CardAccount/cbc:CV2ID)">
+          <xsl:attribute name="id">UBL-CR-420</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-420]-A UBL invoice should not include the PaymentMeans CardAccount CV2ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:CardAccount/cbc:CardChipCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:CardAccount/cbc:CardChipCode)">
+          <xsl:attribute name="id">UBL-CR-421</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-421]-A UBL invoice should not include the PaymentMeans CardAccount CardChipCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:CardAccount/cbc:ChipApplicationID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:CardAccount/cbc:ChipApplicationID)">
+          <xsl:attribute name="id">UBL-CR-422</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-422]-A UBL invoice should not include the PaymentMeans CardAccount ChipApplicationID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:AliasName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:AliasName)">
+          <xsl:attribute name="id">UBL-CR-424</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-424]-A UBL invoice should not include the PaymentMeans PayeeFinancialAccount AliasName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:AccountTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:AccountTypeCode)">
+          <xsl:attribute name="id">UBL-CR-425</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-425]-A UBL invoice should not include the PaymentMeans PayeeFinancialAccount AccountTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:AccountFormatCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:AccountFormatCode)">
+          <xsl:attribute name="id">UBL-CR-426</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-426]-A UBL invoice should not include the PaymentMeans PayeeFinancialAccount AccountFormatCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:CurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:CurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-427</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-427]-A UBL invoice should not include the PaymentMeans PayeeFinancialAccount CurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:PaymentNote)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:PaymentNote)">
+          <xsl:attribute name="id">UBL-CR-428</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-428]-A UBL invoice should not include the PaymentMeans PayeeFinancialAccount PaymentNote</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-429</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-429]-A UBL invoice should not include the PaymentMeans PayeeFinancialAccount FinancialInstitutionBranch Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cac:FinancialInstitution/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cac:FinancialInstitution/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-430</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-430]-A UBL invoice should not include the PaymentMeans PayeeFinancialAccount FinancialInstitutionBranch FinancialInstitution Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cac:FinancialInstitution/cac:Address)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cac:FinancialInstitution/cac:Address)">
+          <xsl:attribute name="id">UBL-CR-431</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-431]-A UBL invoice should not include the PaymentMeans PayeeFinancialAccount FinancialInstitutionBranch FinancialInstitution Address</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cac:Address)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cac:Address)">
+          <xsl:attribute name="id">UBL-CR-432</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-432]-A UBL invoice should not include the PaymentMeans PayeeFinancialAccount FinancialInstitutionBranch Address</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:Country)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:Country)">
+          <xsl:attribute name="id">UBL-CR-433</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-433]-A UBL invoice should not include the PaymentMeans PayeeFinancialAccount Country</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:CreditAccount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:CreditAccount)">
+          <xsl:attribute name="id">UBL-CR-434</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-434]-A UBL invoice should not include the PaymentMeans CreditAccount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cbc:MandateTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cbc:MandateTypeCode)">
+          <xsl:attribute name="id">UBL-CR-435</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-435]-A UBL invoice should not include the PaymentMeans PaymentMandate MandateTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cbc:MaximumPaymentInstructionsNumeric)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cbc:MaximumPaymentInstructionsNumeric)">
+          <xsl:attribute name="id">UBL-CR-436</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-436]-A UBL invoice should not include the PaymentMeans PaymentMandate MaximumPaymentInstructionsNumeric</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cbc:MaximumPaidAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cbc:MaximumPaidAmount)">
+          <xsl:attribute name="id">UBL-CR-437</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-437]-A UBL invoice should not include the PaymentMeans PaymentMandate MaximumPaidAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cbc:SignatureID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cbc:SignatureID)">
+          <xsl:attribute name="id">UBL-CR-438</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-438]-A UBL invoice should not include the PaymentMeans PaymentMandate SignatureID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerParty)">
+          <xsl:attribute name="id">UBL-CR-439</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-439]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-440</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-440]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerFinancialAccount Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:AliasName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:AliasName)">
+          <xsl:attribute name="id">UBL-CR-441</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-441]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerFinancialAccount AliasName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:AccountTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:AccountTypeCode)">
+          <xsl:attribute name="id">UBL-CR-442</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-442]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerFinancialAccount AccountTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:AccountFormatCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:AccountFormatCode)">
+          <xsl:attribute name="id">UBL-CR-443</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-443]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerFinancialAccount AccountFormatCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:CurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:CurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-444</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-444]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerFinancialAccount CurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:PaymentNote)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:PaymentNote)">
+          <xsl:attribute name="id">UBL-CR-445</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-445]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerFinancialAccount PaymentNote</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cac:FinancialInstitutionBranch)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cac:FinancialInstitutionBranch)">
+          <xsl:attribute name="id">UBL-CR-446</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-446]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerFinancialAccount FinancialInstitutionBranch</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cac:Country)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cac:Country)">
+          <xsl:attribute name="id">UBL-CR-447</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-447]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerFinancialAccount Country</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-448</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-448]-A UBL invoice should not include the PaymentMeans PaymentMandate ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PaymentReversalPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:PaymentReversalPeriod)">
+          <xsl:attribute name="id">UBL-CR-449</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-449]-A UBL invoice should not include the PaymentMeans PaymentMandate PaymentReversalPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate/cac:Clause)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate/cac:Clause)">
+          <xsl:attribute name="id">UBL-CR-450</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-450]-A UBL invoice should not include the PaymentMeans PaymentMandate Clause</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:TradeFinancing)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:TradeFinancing)">
+          <xsl:attribute name="id">UBL-CR-451</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-451]-A UBL invoice should not include the PaymentMeans TradeFinancing</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-452</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-452]-A UBL invoice should not include the PaymentTerms ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:PaymentMeansID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:PaymentMeansID)">
+          <xsl:attribute name="id">UBL-CR-453</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-453]-A UBL invoice should not include the PaymentTerms PaymentMeansID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:PrepaidPaymentReferenceID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:PrepaidPaymentReferenceID)">
+          <xsl:attribute name="id">UBL-CR-454</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-454]-A UBL invoice should not include the PaymentTerms PrepaidPaymentReferenceID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:ReferenceEventCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:ReferenceEventCode)">
+          <xsl:attribute name="id">UBL-CR-455</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-455]-A UBL invoice should not include the PaymentTerms ReferenceEventCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:SettlementDiscountPercent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:SettlementDiscountPercent)">
+          <xsl:attribute name="id">UBL-CR-456</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-456]-A UBL invoice should not include the PaymentTerms SettlementDiscountPercent</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:PenaltySurchargePercent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:PenaltySurchargePercent)">
+          <xsl:attribute name="id">UBL-CR-457</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-457]-A UBL invoice should not include the PaymentTerms PenaltySurchargePercent</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:PaymentPercent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:PaymentPercent)">
+          <xsl:attribute name="id">UBL-CR-458</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-458]-A UBL invoice should not include the PaymentTerms PaymentPercent</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:Amount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:Amount)">
+          <xsl:attribute name="id">UBL-CR-459</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-459]-A UBL invoice should not include the PaymentTerms Amount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:SettlementDiscountAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:SettlementDiscountAmount)">
+          <xsl:attribute name="id">UBL-CR-460</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-460]-A UBL invoice should not include the PaymentTerms SettlementDiscountAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:PenaltyAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:PenaltyAmount)">
+          <xsl:attribute name="id">UBL-CR-461</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-461]-A UBL invoice should not include the PaymentTerms PenaltyAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:PaymentTermsDetailsURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:PaymentTermsDetailsURI)">
+          <xsl:attribute name="id">UBL-CR-462</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-462]-A UBL invoice should not include the PaymentTerms PaymentTermsDetailsURI</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:PaymentDueDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:PaymentDueDate)">
+          <xsl:attribute name="id">UBL-CR-463</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-463]-A UBL invoice should not include the PaymentTerms PaymentDueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:InstallmentDueDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:InstallmentDueDate)">
+          <xsl:attribute name="id">UBL-CR-464</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-464]-A UBL invoice should not include the PaymentTerms InstallmentDueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cbc:InvoicingPartyReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cbc:InvoicingPartyReference)">
+          <xsl:attribute name="id">UBL-CR-465</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-465]-A UBL invoice should not include the PaymentTerms InvoicingPartyReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cac:SettlementPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cac:SettlementPeriod)">
+          <xsl:attribute name="id">UBL-CR-466</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-466]-A UBL invoice should not include the PaymentTerms SettlementPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cac:PenaltyPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cac:PenaltyPeriod)">
+          <xsl:attribute name="id">UBL-CR-467</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-467]-A UBL invoice should not include the PaymentTerms PenaltyPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cac:ExchangeRate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cac:ExchangeRate)">
+          <xsl:attribute name="id">UBL-CR-468</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-468]-A UBL invoice should not include the PaymentTerms ExchangeRate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentTerms/cac:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentTerms/cac:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-469</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-469]-A UBL invoice should not include the PaymentTerms ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PrepaidPayment)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PrepaidPayment)">
+          <xsl:attribute name="id">UBL-CR-470</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-470]-A UBL invoice should not include the PrepaidPayment</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-471</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-471]-A UBL invoice should not include the AllowanceCharge ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cbc:PrepaidIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cbc:PrepaidIndicator)">
+          <xsl:attribute name="id">UBL-CR-472</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-472]-A UBL invoice should not include the AllowanceCharge PrepaidIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cbc:SequenceNumeric)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cbc:SequenceNumeric)">
+          <xsl:attribute name="id">UBL-CR-473</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-473]-A UBL invoice should not include the AllowanceCharge SequenceNumeric</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cbc:AccountingCostCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cbc:AccountingCostCode)">
+          <xsl:attribute name="id">UBL-CR-474</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-474]-A UBL invoice should not include the AllowanceCharge AccountingCostCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cbc:AccountingCost)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cbc:AccountingCost)">
+          <xsl:attribute name="id">UBL-CR-475</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-475]-A UBL invoice should not include the AllowanceCharge AccountingCost</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cbc:PerUnitAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cbc:PerUnitAmount)">
+          <xsl:attribute name="id">UBL-CR-476</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-476]-A UBL invoice should not include the AllowanceCharge PerUnitAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-477</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-477]-A UBL invoice should not include the AllowanceCharge TaxCategory Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:BaseUnitMeasure)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:BaseUnitMeasure)">
+          <xsl:attribute name="id">UBL-CR-478</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-478]-A UBL invoice should not include the AllowanceCharge TaxCategory BaseUnitMeasure</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:PerUnitAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:PerUnitAmount)">
+          <xsl:attribute name="id">UBL-CR-479</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-479]-A UBL invoice should not include the AllowanceCharge TaxCategory PerUnitAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:TaxExemptionReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:TaxExemptionReasonCode)">
+          <xsl:attribute name="id">UBL-CR-480</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-480]-A UBL invoice should not include the AllowanceCharge TaxCategory TaxExemptionReasonCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:TaxExemptionReason)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:TaxExemptionReason)">
+          <xsl:attribute name="id">UBL-CR-481</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-481]-A UBL invoice should not include the AllowanceCharge TaxCategory TaxExemptionReason</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:TierRange)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:TierRange)">
+          <xsl:attribute name="id">UBL-CR-482</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-482]-A UBL invoice should not include the AllowanceCharge TaxCategory TierRange</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:TierRatePercent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cbc:TierRatePercent)">
+          <xsl:attribute name="id">UBL-CR-483</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-483]-A UBL invoice should not include the AllowanceCharge TaxCategory TierRatePercent</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cac:TaxScheme/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cac:TaxScheme/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-484</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-484]-A UBL invoice should not include the AllowanceCharge TaxCategory TaxScheme Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cac:TaxScheme/cbc:TaxTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cac:TaxScheme/cbc:TaxTypeCode)">
+          <xsl:attribute name="id">UBL-CR-485</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-485]-A UBL invoice should not include the AllowanceCharge TaxCategory TaxScheme TaxTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cac:TaxScheme/cbc:CurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cac:TaxScheme/cbc:CurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-486</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-486]-A UBL invoice should not include the AllowanceCharge TaxCategory TaxScheme CurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxCategory/cac:TaxScheme/cac:JurisdictionRegionAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxCategory/cac:TaxScheme/cac:JurisdictionRegionAddress)">
+          <xsl:attribute name="id">UBL-CR-487</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-487]-A UBL invoice should not include the AllowanceCharge TaxCategory TaxScheme JurisdictionRegionAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:TaxTotal)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:TaxTotal)">
+          <xsl:attribute name="id">UBL-CR-488</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-488]-A UBL invoice should not include the AllowanceCharge TaxTotal</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AllowanceCharge/cac:PaymentMeans)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AllowanceCharge/cac:PaymentMeans)">
+          <xsl:attribute name="id">UBL-CR-489</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-489]-A UBL invoice should not include the AllowanceCharge PaymentMeans</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxExchangeRate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxExchangeRate)">
+          <xsl:attribute name="id">UBL-CR-490</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-490]-A UBL invoice should not include the TaxExchangeRate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PricingExchangeRate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PricingExchangeRate)">
+          <xsl:attribute name="id">UBL-CR-491</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-491]-A UBL invoice should not include the PricingExchangeRate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentExchangeRate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentExchangeRate)">
+          <xsl:attribute name="id">UBL-CR-492</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-492]-A UBL invoice should not include the PaymentExchangeRate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentAlternativeExchangeRate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentAlternativeExchangeRate)">
+          <xsl:attribute name="id">UBL-CR-493</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-493]-A UBL invoice should not include the PaymentAlternativeExchangeRate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cbc:RoundingAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cbc:RoundingAmount)">
+          <xsl:attribute name="id">UBL-CR-494</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-494]-A UBL invoice should not include the TaxTotal RoundingAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cbc:TaxEvidenceIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cbc:TaxEvidenceIndicator)">
+          <xsl:attribute name="id">UBL-CR-495</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-495]-A UBL invoice should not include the TaxTotal TaxEvidenceIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cbc:TaxIncludedIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cbc:TaxIncludedIndicator)">
+          <xsl:attribute name="id">UBL-CR-496</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-496]-A UBL invoice should not include the TaxTotal TaxIncludedIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:CalculationSequenceNumeric)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:CalculationSequenceNumeric)">
+          <xsl:attribute name="id">UBL-CR-497</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-497]-A UBL invoice should not include the TaxTotal TaxSubtotal CalulationSequenceNumeric</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:TransactionCurrencyTaxAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:TransactionCurrencyTaxAmount)">
+          <xsl:attribute name="id">UBL-CR-498</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-498]-A UBL invoice should not include the TaxTotal TaxSubtotal TransactionCurrencyTaxAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:Percent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:Percent)">
+          <xsl:attribute name="id">UBL-CR-499</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-499]-A UBL invoice should not include the TaxTotal TaxSubtotal Percent</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:BaseUnitMeasure)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:BaseUnitMeasure)">
+          <xsl:attribute name="id">UBL-CR-500</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-500]-A UBL invoice should not include the TaxTotal TaxSubtotal BaseUnitMeasure</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:PerUnitAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:PerUnitAmount)">
+          <xsl:attribute name="id">UBL-CR-501</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-501]-A UBL invoice should not include the TaxTotal TaxSubtotal PerUnitAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:TierRange)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:TierRange)">
+          <xsl:attribute name="id">UBL-CR-502</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-502]-A UBL invoice should not include the TaxTotal TaxSubtotal TierRange</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:TierRatePercent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cbc:TierRatePercent)">
+          <xsl:attribute name="id">UBL-CR-503</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-503]-A UBL invoice should not include the TaxTotal TaxSubtotal TierRatePercent</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-504</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-504]-A UBL invoice should not include the TaxTotal TaxSubtotal TaxCategory Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:BaseUnitMeasure)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:BaseUnitMeasure)">
+          <xsl:attribute name="id">UBL-CR-505</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-505]-A UBL invoice should not include the TaxTotal TaxSubtotal TaxCategory BaseUnitMeasure</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:PerUnitAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:PerUnitAmount)">
+          <xsl:attribute name="id">UBL-CR-506</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-506]-A UBL invoice should not include the TaxTotal TaxSubtotal TaxCategory PerUnitAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:TierRange)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:TierRange)">
+          <xsl:attribute name="id">UBL-CR-507</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-507]-A UBL invoice should not include the TaxTotal TaxSubtotal TaxCategory TierRange</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:TierRatePercent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:TierRatePercent)">
+          <xsl:attribute name="id">UBL-CR-508</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-508]-A UBL invoice should not include the TaxTotal TaxSubtotal TaxCategory TierRatePercent</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-509</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-509]-A UBL invoice should not include the TaxTotal TaxSubtotal TaxCategory TaxScheme Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cbc:TaxTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cbc:TaxTypeCode)">
+          <xsl:attribute name="id">UBL-CR-510</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-510]-A UBL invoice should not include the TaxTotal TaxSubtotal TaxCategory TaxScheme TaxTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cbc:CurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cbc:CurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-511</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-511]-A UBL invoice should not include the TaxTotal TaxSubtotal TaxCategory TaxScheme CurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cac:JurisdictionRegionAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cac:JurisdictionRegionAddress)">
+          <xsl:attribute name="id">UBL-CR-512</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-512]-A UBL invoice should not include the TaxTotal TaxSubtotal TaxCategory TaxScheme JurisdictionRegionAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:WithholdingTaxTotal)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:WithholdingTaxTotal)">
+          <xsl:attribute name="id">UBL-CR-513</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-513]-A UBL invoice should not include the WithholdingTaxTotal</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:LegalMonetaryTotal/cbc:PayableAlternativeAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:LegalMonetaryTotal/cbc:PayableAlternativeAmount)">
+          <xsl:attribute name="id">UBL-CR-514</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-514]-A UBL invoice should not include the LegalMonetaryTotal PayableAlternativeAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-515</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-515]-A UBL invoice should not include the InvoiceLine UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cbc:TaxPointDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cbc:TaxPointDate)">
+          <xsl:attribute name="id">UBL-CR-516</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-516]-A UBL invoice should not include the InvoiceLine TaxPointDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cbc:AccountingCostCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cbc:AccountingCostCode)">
+          <xsl:attribute name="id">UBL-CR-517</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-517]-A UBL invoice should not include the InvoiceLine AccountingCostCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cbc:PaymentPurposeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cbc:PaymentPurposeCode)">
+          <xsl:attribute name="id">UBL-CR-518</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-518]-A UBL invoice should not include the InvoiceLine PaymentPurposeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cbc:FreeOfChargeIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cbc:FreeOfChargeIndicator)">
+          <xsl:attribute name="id">UBL-CR-519</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-519]-A UBL invoice should not include the InvoiceLine FreeOfChargeIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:InvoicePeriod/cbc:StartTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:InvoicePeriod/cbc:StartTime)">
+          <xsl:attribute name="id">UBL-CR-520</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-520]-A UBL invoice should not include the InvoiceLine InvoicePeriod StartTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:InvoicePeriod/cbc:EndTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:InvoicePeriod/cbc:EndTime)">
+          <xsl:attribute name="id">UBL-CR-521</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-521]-A UBL invoice should not include the InvoiceLine InvoicePeriod EndTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:InvoicePeriod/cbc:DurationMeasure)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:InvoicePeriod/cbc:DurationMeasure)">
+          <xsl:attribute name="id">UBL-CR-522</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-522]-A UBL invoice should not include the InvoiceLine InvoicePeriod DurationMeasure</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:InvoicePeriod/cbc:DescriptionCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:InvoicePeriod/cbc:DescriptionCode)">
+          <xsl:attribute name="id">UBL-CR-523</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-523]-A UBL invoice should not include the InvoiceLine InvoicePeriod DescriptionCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:InvoicePeriod/cbc:Description)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:InvoicePeriod/cbc:Description)">
+          <xsl:attribute name="id">UBL-CR-524</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-524]-A UBL invoice should not include the InvoiceLine InvoicePeriod Description</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:OrderLineReference/cbc:SalesOrderLineID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:OrderLineReference/cbc:SalesOrderLineID)">
+          <xsl:attribute name="id">UBL-CR-525</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-525]-A UBL invoice should not include the InvoiceLine OrderLineReference SalesOrderLineID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:OrderLineReference/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:OrderLineReference/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-526</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-526]-A UBL invoice should not include the InvoiceLine OrderLineReference UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:OrderLineReference/cbc:LineStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:OrderLineReference/cbc:LineStatusCode)">
+          <xsl:attribute name="id">UBL-CR-527</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-527]-A UBL invoice should not include the InvoiceLine OrderLineReference LineStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:OrderLineReference/cac:OrderReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:OrderLineReference/cac:OrderReference)">
+          <xsl:attribute name="id">UBL-CR-528</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-528]-A UBL invoice should not include the InvoiceLine OrderLineReference OrderReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DespatchLineReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DespatchLineReference)">
+          <xsl:attribute name="id">UBL-CR-529</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-529]-A UBL invoice should not include the InvoiceLine DespatchLineReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:ReceiptLineReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:ReceiptLineReference)">
+          <xsl:attribute name="id">UBL-CR-530</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-530]-A UBL invoice should not include the InvoiceLine ReceiptLineReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:BillingReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:BillingReference)">
+          <xsl:attribute name="id">UBL-CR-531</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-531]-A UBL invoice should not include the InvoiceLine BillingReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:CopyIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:CopyIndicator)">
+          <xsl:attribute name="id">UBL-CR-532</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-532]-A UBL invoice should not include the InvoiceLine DocumentReference CopyIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:UUID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:UUID)">
+          <xsl:attribute name="id">UBL-CR-533</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-533]-A UBL invoice should not include the InvoiceLine DocumentReference UUID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:IssueDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:IssueDate)">
+          <xsl:attribute name="id">UBL-CR-534</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-534]-A UBL invoice should not include the InvoiceLine DocumentReference IssueDate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:IssueTime)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:IssueTime)">
+          <xsl:attribute name="id">UBL-CR-535</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-535]-A UBL invoice should not include the InvoiceLine DocumentReference IssueTime</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:DocumentType)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:DocumentType)">
+          <xsl:attribute name="id">UBL-CR-537</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-537]-A UBL invoice should not include the InvoiceLine DocumentReference DocumentType</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:XPath)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:XPath)">
+          <xsl:attribute name="id">UBL-CR-538</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-538]-A UBL invoice should not include the InvoiceLine DocumentReference Xpath</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:LanguageID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:LanguageID)">
+          <xsl:attribute name="id">UBL-CR-539</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-539]-A UBL invoice should not include the InvoiceLine DocumentReference LanguageID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:LocaleCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:LocaleCode)">
+          <xsl:attribute name="id">UBL-CR-540</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-540]-A UBL invoice should not include the InvoiceLine DocumentReference LocaleCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:VersionID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:VersionID)">
+          <xsl:attribute name="id">UBL-CR-541</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-541]-A UBL invoice should not include the InvoiceLine DocumentReference VersionID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:DocumentStatusCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:DocumentStatusCode)">
+          <xsl:attribute name="id">UBL-CR-542</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-542]-A UBL invoice should not include the InvoiceLine DocumentReference DocumentStatusCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:DocumentDescription)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cbc:DocumentDescription)">
+          <xsl:attribute name="id">UBL-CR-543</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-543]-A UBL invoice should not include the InvoiceLine DocumentReference DocumentDescription</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cac:Attachment)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cac:Attachment)">
+          <xsl:attribute name="id">UBL-CR-544</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-544]-A UBL invoice should not include the InvoiceLine DocumentReference Attachment</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cac:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cac:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-545</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-545]-A UBL invoice should not include the InvoiceLine DocumentReference ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cac:IssuerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cac:IssuerParty)">
+          <xsl:attribute name="id">UBL-CR-546</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-546]-A UBL invoice should not include the InvoiceLine DocumentReference IssuerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cac:ResultOfVerification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DocumentReference/cac:ResultOfVerification)">
+          <xsl:attribute name="id">UBL-CR-547</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-547]-A UBL invoice should not include the InvoiceLine DocumentReference ResultOfVerification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:PricingReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:PricingReference)">
+          <xsl:attribute name="id">UBL-CR-548</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-548]-A UBL invoice should not include the InvoiceLine PricingReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:OriginatorParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:OriginatorParty)">
+          <xsl:attribute name="id">UBL-CR-549</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-549]-A UBL invoice should not include the InvoiceLine OriginatorParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Delivery)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Delivery)">
+          <xsl:attribute name="id">UBL-CR-550</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-550]-A UBL invoice should not include the InvoiceLine Delivery</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:PaymentTerms)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:PaymentTerms)">
+          <xsl:attribute name="id">UBL-CR-551</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-551]-A UBL invoice should not include the InvoiceLine PaymentTerms</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-552</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-552]-A UBL invoice should not include the InvoiceLine AllowanceCharge ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:PrepaidIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:PrepaidIndicator)">
+          <xsl:attribute name="id">UBL-CR-553</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-553]-A UBL invoice should not include the InvoiceLine AllowanceCharge PrepaidIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:SequenceNumeric)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:SequenceNumeric)">
+          <xsl:attribute name="id">UBL-CR-554</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-554]-A UBL invoice should not include the InvoiceLine AllowanceCharge SequenceNumeric</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:AccountingCostCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:AccountingCostCode)">
+          <xsl:attribute name="id">UBL-CR-555</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-555]-A UBL invoice should not include the InvoiceLine AllowanceCharge AccountingCostCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:AccountingCost)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:AccountingCost)">
+          <xsl:attribute name="id">UBL-CR-556</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-556]-A UBL invoice should not include the InvoiceLine AllowanceCharge AccountingCost</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:PerUnitAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cbc:PerUnitAmount)">
+          <xsl:attribute name="id">UBL-CR-557</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-557]-A UBL invoice should not include the InvoiceLine AllowanceCharge PerUnitAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cac:TaxCategory)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cac:TaxCategory)">
+          <xsl:attribute name="id">UBL-CR-558</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-558]-A UBL invoice should not include the InvoiceLine AllowanceCharge TaxCategory</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cac:TaxTotal)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cac:TaxTotal)">
+          <xsl:attribute name="id">UBL-CR-559</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-559]-A UBL invoice should not include the InvoiceLine AllowanceCharge TaxTotal</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cac:PaymentMeans)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:AllowanceCharge/cac:PaymentMeans)">
+          <xsl:attribute name="id">UBL-CR-560</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-560]-A UBL invoice should not include the InvoiceLine AllowanceCharge PaymentMeans</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:TaxTotal)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:TaxTotal)">
+          <xsl:attribute name="id">UBL-CR-561</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-561]-A UBL invoice should not include the InvoiceLine TaxTotal</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:WithholdingTaxTotal)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:WithholdingTaxTotal)">
+          <xsl:attribute name="id">UBL-CR-562</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-562]-A UBL invoice should not include the InvoiceLine WithholdingTaxTotal</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:PackQuantity)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:PackQuantity)">
+          <xsl:attribute name="id">UBL-CR-563</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-563]-A UBL invoice should not include the InvoiceLine Item PackQuantity</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:PackSizeNumeric)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:PackSizeNumeric)">
+          <xsl:attribute name="id">UBL-CR-564</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-564]-A UBL invoice should not include the InvoiceLine Item PackSizeNumeric</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:CatalogueIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:CatalogueIndicator)">
+          <xsl:attribute name="id">UBL-CR-565</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-565]-A UBL invoice should not include the InvoiceLine Item CatalogueIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:HazardousRiskIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:HazardousRiskIndicator)">
+          <xsl:attribute name="id">UBL-CR-566</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-566]-A UBL invoice should not include the InvoiceLine Item HazardousRiskIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:AdditionalInformation)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:AdditionalInformation)">
+          <xsl:attribute name="id">UBL-CR-567</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-567]-A UBL invoice should not include the InvoiceLine Item AdditionalInformation</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:Keyword)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:Keyword)">
+          <xsl:attribute name="id">UBL-CR-568</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-568]-A UBL invoice should not include the InvoiceLine Item Keyword</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:BrandName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:BrandName)">
+          <xsl:attribute name="id">UBL-CR-569</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-569]-A UBL invoice should not include the InvoiceLine Item BrandName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:ModelName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cbc:ModelName)">
+          <xsl:attribute name="id">UBL-CR-570</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-570]-A UBL invoice should not include the InvoiceLine Item ModelName</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:BuyersItemIdentification/cbc:ExtendedID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:BuyersItemIdentification/cbc:ExtendedID)">
+          <xsl:attribute name="id">UBL-CR-571</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-571]-A UBL invoice should not include the InvoiceLine Item BuyersItemIdentification ExtendedID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:BuyersItemIdentification/cbc:BarcodeSymbologyID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:BuyersItemIdentification/cbc:BarcodeSymbologyID)">
+          <xsl:attribute name="id">UBL-CR-572</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-572]-A UBL invoice should not include the InvoiceLine Item BuyersItemIdentification BarcodeSymbologyID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:BuyersItemIdentification/cac:PhysicalAttribute)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:BuyersItemIdentification/cac:PhysicalAttribute)">
+          <xsl:attribute name="id">UBL-CR-573</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-573]-A UBL invoice should not include the InvoiceLine Item BuyersItemIdentification PhysicalAttribute</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:BuyersItemIdentification/cac:MeasurementDimension)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:BuyersItemIdentification/cac:MeasurementDimension)">
+          <xsl:attribute name="id">UBL-CR-574</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-574]-A UBL invoice should not include the InvoiceLine Item BuyersItemIdentification MeasurementDimension</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:BuyersItemIdentification/cac:IssuerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:BuyersItemIdentification/cac:IssuerParty)">
+          <xsl:attribute name="id">UBL-CR-575</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-575]-A UBL invoice should not include the InvoiceLine Item BuyersItemIdentification IssuerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:SellersItemIdentification/cbc:ExtendedID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:SellersItemIdentification/cbc:ExtendedID)">
+          <xsl:attribute name="id">UBL-CR-576</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-576]-A UBL invoice should not include the InvoiceLine Item SellersItemIdentification ExtendedID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:SellersItemIdentification/cbc:BarcodeSymbologyID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:SellersItemIdentification/cbc:BarcodeSymbologyID)">
+          <xsl:attribute name="id">UBL-CR-577</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-577]-A UBL invoice should not include the InvoiceLine Item SellersItemIdentification BarcodeSymbologyID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:SellersItemIdentification/cac:PhysicalAttribute)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:SellersItemIdentification/cac:PhysicalAttribute)">
+          <xsl:attribute name="id">UBL-CR-578</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-578]-A UBL invoice should not include the InvoiceLine Item SellersItemIdentification PhysicalAttribute</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:SellersItemIdentification/cac:MeasurementDimension)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:SellersItemIdentification/cac:MeasurementDimension)">
+          <xsl:attribute name="id">UBL-CR-579</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-579]-A UBL invoice should not include the InvoiceLine Item SellersItemIdentification MeasurementDimension</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:SellersItemIdentification/cac:IssuerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:SellersItemIdentification/cac:IssuerParty)">
+          <xsl:attribute name="id">UBL-CR-580</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-580]-A UBL invoice should not include the InvoiceLine Item SellersItemIdentification IssuerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ManufacturersItemIdentification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ManufacturersItemIdentification)">
+          <xsl:attribute name="id">UBL-CR-581</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-581]-A UBL invoice should not include the InvoiceLine Item ManufacturersItemIdentification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:StandardItemIdentification/cbc:ExtendedID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:StandardItemIdentification/cbc:ExtendedID)">
+          <xsl:attribute name="id">UBL-CR-582</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-582]-A UBL invoice should not include the InvoiceLine Item StandardItemIdentification ExtendedID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:StandardItemIdentification/cbc:BarcodeSymbologyID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:StandardItemIdentification/cbc:BarcodeSymbologyID)">
+          <xsl:attribute name="id">UBL-CR-583</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-583]-A UBL invoice should not include the InvoiceLine Item StandardItemIdentification BarcodeSymbologyID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:StandardItemIdentification/cac:PhysicalAttribute)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:StandardItemIdentification/cac:PhysicalAttribute)">
+          <xsl:attribute name="id">UBL-CR-584</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-584]-A UBL invoice should not include the InvoiceLine Item StandardItemIdentification PhysicalAttribute</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:StandardItemIdentification/cac:MeasurementDimension)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:StandardItemIdentification/cac:MeasurementDimension)">
+          <xsl:attribute name="id">UBL-CR-585</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-585]-A UBL invoice should not include the InvoiceLine Item StandardItemIdentification MeasurementDimension</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:StandardItemIdentification/cac:IssuerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:StandardItemIdentification/cac:IssuerParty)">
+          <xsl:attribute name="id">UBL-CR-586</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-586]-A UBL invoice should not include the InvoiceLine Item StandardItemIdentification IssuerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:CatalogueItemIdentification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:CatalogueItemIdentification)">
+          <xsl:attribute name="id">UBL-CR-587</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-587]-A UBL invoice should not include the InvoiceLine Item CatalogueItemIdentification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemIdentification)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemIdentification)">
+          <xsl:attribute name="id">UBL-CR-588</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-588]-A UBL invoice should not include the InvoiceLine Item AdditionalItemIdentification</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:CatalogueDocumentReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:CatalogueDocumentReference)">
+          <xsl:attribute name="id">UBL-CR-589</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-589]-A UBL invoice should not include the InvoiceLine Item CatalogueDocumentReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ItemSpecificationDocumentReference)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ItemSpecificationDocumentReference)">
+          <xsl:attribute name="id">UBL-CR-590</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-590]-A UBL invoice should not include the InvoiceLine Item ItemSpecificationDocumentReference</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:OriginCountry/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:OriginCountry/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-591</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-591]-A UBL invoice should not include the InvoiceLine Item OriginCountry Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:CommodityClassification/cbc:NatureCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:CommodityClassification/cbc:NatureCode)">
+          <xsl:attribute name="id">UBL-CR-592</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-592]-A UBL invoice should not include the InvoiceLine Item CommodityClassification NatureCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:CommodityClassification/cbc:CargoTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:CommodityClassification/cbc:CargoTypeCode)">
+          <xsl:attribute name="id">UBL-CR-593</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-593]-A UBL invoice should not include the InvoiceLine Item CommodityClassification CargoTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:CommodityClassification/cbc:CommodityCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:CommodityClassification/cbc:CommodityCode)">
+          <xsl:attribute name="id">UBL-CR-594</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-594]-A UBL invoice should not include the InvoiceLine Item CommodityClassification CommodityCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:TransactionConditions)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:TransactionConditions)">
+          <xsl:attribute name="id">UBL-CR-595</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-595]-A UBL invoice should not include the InvoiceLine Item TransactionConditions</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:HazardousItem)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:HazardousItem)">
+          <xsl:attribute name="id">UBL-CR-596</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-596]-A UBL invoice should not include the InvoiceLine Item HazardousItem</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-597</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-597]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:BaseUnitMeasure)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:BaseUnitMeasure)">
+          <xsl:attribute name="id">UBL-CR-598</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-598]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory BaseUnitMeasure</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:PerUnitAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:PerUnitAmount)">
+          <xsl:attribute name="id">UBL-CR-599</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-599]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory PerUnitAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:TaxExemptionReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:TaxExemptionReasonCode)">
+          <xsl:attribute name="id">UBL-CR-600</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-600]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory TaxExemptionReasonCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:TaxExemptionReason)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:TaxExemptionReason)">
+          <xsl:attribute name="id">UBL-CR-601</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-601]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory TaxExemptionReason</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:TierRange)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:TierRange)">
+          <xsl:attribute name="id">UBL-CR-602</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-602]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory TierRange</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:TierRatePercent)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:TierRatePercent)">
+          <xsl:attribute name="id">UBL-CR-603</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-603]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory TierRatePercent</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cbc:Name)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cbc:Name)">
+          <xsl:attribute name="id">UBL-CR-604</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-604]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory TaxScheme Name</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cbc:TaxTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cbc:TaxTypeCode)">
+          <xsl:attribute name="id">UBL-CR-605</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-605]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory TaxScheme TaxTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cbc:CurrencyCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cbc:CurrencyCode)">
+          <xsl:attribute name="id">UBL-CR-606</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-606]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory TaxScheme CurrencyCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cac:JurisdictionRegionAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cac:JurisdictionRegionAddress)">
+          <xsl:attribute name="id">UBL-CR-607</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-607]-A UBL invoice should not include the InvoiceLine Item ClassifiedTaxCategory TaxScheme JurisdictionRegionAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-608</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-608]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:NameCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:NameCode)">
+          <xsl:attribute name="id">UBL-CR-609</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-609]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty NameCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:TestMethod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:TestMethod)">
+          <xsl:attribute name="id">UBL-CR-610</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-610]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty TestMethod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:ValueQuantity)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:ValueQuantity)">
+          <xsl:attribute name="id">UBL-CR-611</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-611]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty ValueQuantity</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:ValueQualifier)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:ValueQualifier)">
+          <xsl:attribute name="id">UBL-CR-612</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-612]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty ValueQualifier</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:ImportanceCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:ImportanceCode)">
+          <xsl:attribute name="id">UBL-CR-613</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-613]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty ImportanceCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:ListValue)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cbc:ListValue)">
+          <xsl:attribute name="id">UBL-CR-614</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-614]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty ListValue</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cac:UsabilityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cac:UsabilityPeriod)">
+          <xsl:attribute name="id">UBL-CR-615</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-615]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty UsabilityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cac:ItemPropertyGroup)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cac:ItemPropertyGroup)">
+          <xsl:attribute name="id">UBL-CR-616</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-616]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty ItemPropertyGroup</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cac:RangeDimension)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cac:RangeDimension)">
+          <xsl:attribute name="id">UBL-CR-617</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-617]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty RangeDimension</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cac:ItemPropertyRange)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:AdditionalItemProperty/cac:ItemPropertyRange)">
+          <xsl:attribute name="id">UBL-CR-618</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-618]-A UBL invoice should not include the InvoiceLine Item AdditionalItemProperty ItemPropertyRange</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ManufacturerParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ManufacturerParty)">
+          <xsl:attribute name="id">UBL-CR-619</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-619]-A UBL invoice should not include the InvoiceLine Item ManufacturerParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:InformationContentProviderParty)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:InformationContentProviderParty)">
+          <xsl:attribute name="id">UBL-CR-620</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-620]-A UBL invoice should not include the InvoiceLine Item InformationContentProviderParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:OriginAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:OriginAddress)">
+          <xsl:attribute name="id">UBL-CR-621</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-621]-A UBL invoice should not include the InvoiceLine Item OriginAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ItemInstance)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:ItemInstance)">
+          <xsl:attribute name="id">UBL-CR-622</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-622]-A UBL invoice should not include the InvoiceLine Item ItemInstance</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:Certificate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:Certificate)">
+          <xsl:attribute name="id">UBL-CR-623</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-623]-A UBL invoice should not include the InvoiceLine Item Certificate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:Dimension)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Item/cac:Dimension)">
+          <xsl:attribute name="id">UBL-CR-624</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-624]-A UBL invoice should not include the InvoiceLine Item Dimension</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:PriceChangeReason)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:PriceChangeReason)">
+          <xsl:attribute name="id">UBL-CR-625</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-625]-A UBL invoice should not include the InvoiceLine Item Price PriceChangeReason</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:PriceTypeCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:PriceTypeCode)">
+          <xsl:attribute name="id">UBL-CR-626</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-626]-A UBL invoice should not include the InvoiceLine Item Price PriceTypeCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:PriceType)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:PriceType)">
+          <xsl:attribute name="id">UBL-CR-627</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-627]-A UBL invoice should not include the InvoiceLine Item Price PriceType</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:OrderableUnitFactorRate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:OrderableUnitFactorRate)">
+          <xsl:attribute name="id">UBL-CR-628</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-628]-A UBL invoice should not include the InvoiceLine Item Price OrderableUnitFactorRate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:ValidityPeriod)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:ValidityPeriod)">
+          <xsl:attribute name="id">UBL-CR-629</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-629]-A UBL invoice should not include the InvoiceLine Item Price ValidityPeriod</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:PriceList)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:PriceList)">
+          <xsl:attribute name="id">UBL-CR-630</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-630]-A UBL invoice should not include the InvoiceLine Item Price PriceList</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:OrderableUnitFactorRate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cbc:OrderableUnitFactorRate)">
+          <xsl:attribute name="id">UBL-CR-631</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-631]-A UBL invoice should not include the InvoiceLine Item Price OrderableUnitFactorRate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:ID)">
+          <xsl:attribute name="id">UBL-CR-632</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-632]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge ID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:AllowanceChargeReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:AllowanceChargeReasonCode)">
+          <xsl:attribute name="id">UBL-CR-633</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-633]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge AllowanceChargeReasonCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:AllowanceChargeReason)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:AllowanceChargeReason)">
+          <xsl:attribute name="id">UBL-CR-634</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-634]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge AllowanceChargeReason</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:MultiplierFactorNumeric)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:MultiplierFactorNumeric)">
+          <xsl:attribute name="id">UBL-CR-635</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-635]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge MultiplierFactorNumeric</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:PrepaidIndicator)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:PrepaidIndicator)">
+          <xsl:attribute name="id">UBL-CR-636</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-636]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge PrepaidIndicator</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:SequenceNumeric)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:SequenceNumeric)">
+          <xsl:attribute name="id">UBL-CR-637</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-637]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge SequenceNumeric</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:AccountingCostCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:AccountingCostCode)">
+          <xsl:attribute name="id">UBL-CR-638</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-638]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge AccountingCostCode</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:AccountingCost)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:AccountingCost)">
+          <xsl:attribute name="id">UBL-CR-639</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-639]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge AccountingCost</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:PerUnitAmount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cbc:PerUnitAmount)">
+          <xsl:attribute name="id">UBL-CR-640</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-640]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge PerUnitAmount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cac:TaxCategory)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cac:TaxCategory)">
+          <xsl:attribute name="id">UBL-CR-641</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-641]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge TaxCategory</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cac:TaxTotal)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cac:TaxTotal)">
+          <xsl:attribute name="id">UBL-CR-642</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-642]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge TaxTotal</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cac:PaymentMeans)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:AllowanceCharge/cac:PaymentMeans)">
+          <xsl:attribute name="id">UBL-CR-643</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-643]-A UBL invoice should not include the InvoiceLine Item Price AllowanceCharge PaymentMeans</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:PricingExchangeRate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:Price/cac:PricingExchangeRate)">
+          <xsl:attribute name="id">UBL-CR-644</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-644]-A UBL invoice should not include the InvoiceLine Item Price PricingExchangeRate</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DeliveryTerms)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:DeliveryTerms)">
+          <xsl:attribute name="id">UBL-CR-645</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-645]-A UBL invoice should not include the InvoiceLine DeliveryTerms</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:SubInvoiceLine)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:SubInvoiceLine)">
+          <xsl:attribute name="id">UBL-CR-646</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-646]-A UBL invoice should not include the InvoiceLine SubInvoiceLine</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:ItemPriceExtension)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:InvoiceLine|cac:CreditNoteLine)/cac:ItemPriceExtension)">
+          <xsl:attribute name="id">UBL-CR-647</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-647]-A UBL invoice should not include the InvoiceLine ItemPriceExtension</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:CustomizationID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:CustomizationID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-648</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-648]-A UBL invoice should not include the CustomizationID scheme identifier</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:ProfileID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:ProfileID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-649</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-649]-A UBL invoice should not include the ProfileID scheme identifier</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:ID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:ID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-650</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-650]-A UBL invoice shall not include the Invoice ID scheme identifier</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:SalesOrderID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:SalesOrderID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-651</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-651]-A UBL invoice should not include the SalesOrderID scheme identifier</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:PartyTaxScheme/cbc:CompanyID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:PartyTaxScheme/cbc:CompanyID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-652</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-652]-A UBL invoice should not include the PartyTaxScheme CompanyID scheme identifier</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cbc:PaymentID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cbc:PaymentID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-653</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-653]-A UBL invoice should not include the PaymentID scheme identifier</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:ID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:ID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-654</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-654]-A UBL invoice should not include the PayeeFinancialAccount scheme identifier</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cbc:ID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cbc:ID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-655</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-655]-A UBL invoice shall not include the FinancialInstitutionBranch ID scheme identifier</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:InvoiceTypeCode/@listID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:InvoiceTypeCode/@listID)">
+          <xsl:attribute name="id">UBL-CR-656</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-656]-A UBL invoice should not include the InvoiceTypeCode listID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:DocumentCurrencyCode/@listID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:DocumentCurrencyCode/@listID)">
+          <xsl:attribute name="id">UBL-CR-657</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-657]-A UBL invoice should not include the DocumentCurrencyCode listID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:TaxCurrencyCode/@listID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:TaxCurrencyCode/@listID)">
+          <xsl:attribute name="id">UBL-CR-658</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-658]-A UBL invoice should not include the TaxCurrencyCode listID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:AdditionalDocumentReference/cbc:DocumentTypeCode/@listID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:AdditionalDocumentReference/cbc:DocumentTypeCode/@listID)">
+          <xsl:attribute name="id">UBL-CR-659</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-659]-A UBL invoice shall not include the AdditionalDocumentReference DocumentTypeCode listID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:Country/cbc:IdentificationCode/@listID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:Country/cbc:IdentificationCode/@listID)">
+          <xsl:attribute name="id">UBL-CR-660</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-660]-A UBL invoice should not include the Country Identification code listID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cbc:PaymentMeansCode/@listID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cbc:PaymentMeansCode/@listID)">
+          <xsl:attribute name="id">UBL-CR-661</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-661]-A UBL invoice should not include the PaymentMeansCode listID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cbc:AllowanceChargeReasonCode/@listID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cbc:AllowanceChargeReasonCode/@listID)">
+          <xsl:attribute name="id">UBL-CR-662</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-662]-A UBL invoice should not include the AllowanceChargeReasonCode listID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@unitCodeListID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@unitCodeListID)">
+          <xsl:attribute name="id">UBL-CR-663</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-663]-A UBL invoice should not include the unitCodeListID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:FinancialInstitution)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:FinancialInstitution)">
+          <xsl:attribute name="id">UBL-CR-664</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-664]-A UBL invoice should not include the FinancialInstitutionBranch FinancialInstitution</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:AdditionalDocumentReference[cbc:DocumentTypeCode != '130' or not(cbc:DocumentTypeCode)]/cbc:ID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:AdditionalDocumentReference[cbc:DocumentTypeCode != '130' or not(cbc:DocumentTypeCode)]/cbc:ID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-665</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-665]-A UBL invoice should not include the AdditionalDocumentReference ID schemeID unless the DocumentTypeCode equals '130'</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:AdditionalDocumentReference[cbc:DocumentTypeCode = '130']/cac:Attachment)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:AdditionalDocumentReference[cbc:DocumentTypeCode = '130']/cac:Attachment)">
+          <xsl:attribute name="id">UBL-CR-666</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-666]-A UBL invoice shall not include an AdditionalDocumentReference simultaneously referring an Invoice Object Identifier and an Attachment</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:BuyersItemIdentification/cbc:ID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:BuyersItemIdentification/cbc:ID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-667</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-667]-A UBL invoice should not include a Buyer Item Identification schemeID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:SellersItemIdentification/cbc:ID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:SellersItemIdentification/cbc:ID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-668</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-668]-A UBL invoice should not include a Sellers Item Identification schemeID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:Price/cac:AllowanceCharge/cbc:AllowanceChargeReasonCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:Price/cac:AllowanceCharge/cbc:AllowanceChargeReasonCode)">
+          <xsl:attribute name="id">UBL-CR-669</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-669]-A UBL invoice should not include a Price Allowance Reason Code</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:Price/cac:AllowanceCharge/cbc:AllowanceChargeReason)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:Price/cac:AllowanceCharge/cbc:AllowanceChargeReason)">
+          <xsl:attribute name="id">UBL-CR-670</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-670]-A UBL invoice should not include a Price Allowance Reason</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:Price/cac:AllowanceCharge/cbc:MultiplierFactorNumeric)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:Price/cac:AllowanceCharge/cbc:MultiplierFactorNumeric)">
+          <xsl:attribute name="id">UBL-CR-671</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-671]-A UBL invoice should not include a Price Allowance Multiplier Factor</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:CreditNoteTypeCode/@listID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:CreditNoteTypeCode/@listID)">
+          <xsl:attribute name="id">UBL-CR-672</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-672]-A UBL credit note should not include the CreditNoteTypeCode listID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:AdditionalDocumentReference[cbc:DocumentTypeCode  = '130']/cbc:DocumentDescription)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:AdditionalDocumentReference[cbc:DocumentTypeCode = '130']/cbc:DocumentDescription)">
+          <xsl:attribute name="id">UBL-CR-673</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-673]-A UBL invoice shall not include an AdditionalDocumentReference simultaneously referring an Invoice Object Identifier and an Document Description</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cbc:PrimaryAccountNumber/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cbc:PrimaryAccountNumber/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-674</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-674]-A UBL invoice should not include the PrimaryAccountNumber schemeID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:CardAccount/cbc:NetworkID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:CardAccount/cbc:NetworkID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-675</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-675]-A UBL invoice should not include the NetworkID schemeID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:PaymentMandate/cbc:ID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:PaymentMandate/cbc:ID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-676</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-676]-A UBL invoice should not include the PaymentMandate/ID schemeID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-677</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-677]-A UBL invoice should not include the PayerFinancialAccount/ID schemeID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:TaxCategory/cbc:ID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:TaxCategory/cbc:ID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-678</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-678]-A UBL invoice should not include the TaxCategory/ID schemeID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:ClassifiedTaxCategory/cbc:ID/@schemeID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:ClassifiedTaxCategory/cbc:ID/@schemeID)">
+          <xsl:attribute name="id">UBL-CR-679</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-679]-A UBL invoice should not include the ClassifiedTaxCategory/ID schemeID</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//cac:PaymentMeans/cac:PayerFinancialAccount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//cac:PaymentMeans/cac:PayerFinancialAccount)">
+          <xsl:attribute name="id">UBL-CR-680</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-680]-A UBL invoice should not include the PaymentMeans/PayerFinancialAccount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cbc:InstructionNote)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cbc:InstructionNote)">
+          <xsl:attribute name="id">UBL-CR-681</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-681]-A UBL invoice should not include the PaymentMeans InstructionNote</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Delivery/cac:DeliveryAddress)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Delivery/cac:DeliveryAddress)">
+          <xsl:attribute name="id">UBL-CR-682</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-CR-682]-A UBL invoice should not include the Delivery DeliveryAddress</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@schemeName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@schemeName)">
+          <xsl:attribute name="id">UBL-DT-08</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-08]-Scheme name attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@schemeAgencyName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@schemeAgencyName)">
+          <xsl:attribute name="id">UBL-DT-09</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-09]-Scheme agency name attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@schemeDataURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@schemeDataURI)">
+          <xsl:attribute name="id">UBL-DT-10</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-10]-Scheme data uri attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@schemeURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@schemeURI)">
+          <xsl:attribute name="id">UBL-DT-11</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-11]-Scheme uri attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@format)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@format)">
+          <xsl:attribute name="id">UBL-DT-12</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-12]-Format attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@unitCodeListIdentifier)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@unitCodeListIdentifier)">
+          <xsl:attribute name="id">UBL-DT-13</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-13]-Unit code list identifier attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@unitCodeListAgencyIdentifier)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@unitCodeListAgencyIdentifier)">
+          <xsl:attribute name="id">UBL-DT-14</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-14]-Unit code list agency identifier attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@unitCodeListAgencyName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@unitCodeListAgencyName)">
+          <xsl:attribute name="id">UBL-DT-15</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-15]-Unit code list agency name attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@listAgencyName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@listAgencyName)">
+          <xsl:attribute name="id">UBL-DT-16</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-16]-List agency name attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@listName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@listName)">
+          <xsl:attribute name="id">UBL-DT-17</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-17]-List name attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(//@name) - count(//cbc:PaymentMeansCode/@name) &lt;= 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(//@name) - count(//cbc:PaymentMeansCode/@name) &lt;= 0">
+          <xsl:attribute name="id">UBL-DT-18</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-18]-Name attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@languageID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@languageID)">
+          <xsl:attribute name="id">UBL-DT-19</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-19]-Language identifier attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@listURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@listURI)">
+          <xsl:attribute name="id">UBL-DT-20</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-20]-List uri attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@listSchemeURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@listSchemeURI)">
+          <xsl:attribute name="id">UBL-DT-21</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-21]-List scheme uri attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@languageLocaleID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@languageLocaleID)">
+          <xsl:attribute name="id">UBL-DT-22</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-22]-Language local identifier attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@uri)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@uri)">
+          <xsl:attribute name="id">UBL-DT-23</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-23]-Uri attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@currencyCodeListVersionID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@currencyCodeListVersionID)">
+          <xsl:attribute name="id">UBL-DT-24</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-24]-Currency code list version id should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@characterSetCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@characterSetCode)">
+          <xsl:attribute name="id">UBL-DT-25</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-25]-CharacterSetCode attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@encodingCode)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@encodingCode)">
+          <xsl:attribute name="id">UBL-DT-26</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-26]-EncodingCode attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@schemeAgencyID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@schemeAgencyID)">
+          <xsl:attribute name="id">UBL-DT-27</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-27]-Scheme Agency ID attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(//@listAgencyID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(//@listAgencyID)">
+          <xsl:attribute name="id">UBL-DT-28</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-DT-28]-List Agency ID attribute should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:ContractDocumentReference/cbc:ID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:ContractDocumentReference/cbc:ID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-01]-Contract identifier shall occur maximum once.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:ReceiptDocumentReference/cbc:ID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:ReceiptDocumentReference/cbc:ID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-02</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-02]-Receive advice identifier shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:DespatchDocumentReference/cbc:ID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:DespatchDocumentReference/cbc:ID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-03]-Despatch advice identifier shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AdditionalDocumentReference[cbc:DocumentTypeCode='130']/cbc:ID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AdditionalDocumentReference[cbc:DocumentTypeCode='130']/cbc:ID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-04]-Invoice object identifier shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:PaymentTerms/cbc:Note) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:PaymentTerms/cbc:Note) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-05]-Payment terms shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:InvoicePeriod) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:InvoicePeriod) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-08</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-08]-Invoice period shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-09</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-09]-Seller name shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyName/cbc:Name) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyName/cbc:Name) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-10]-Seller trader name shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-11</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-11]-Seller legal registration identifier shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/upper-case(cbc:ID)='VAT']/cbc:CompanyID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/upper-case(cbc:ID)='VAT']/cbc:CompanyID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-12</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-12]-Seller VAT identifier shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/upper-case(cbc:ID)!='VAT']/cbc:CompanyID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/upper-case(cbc:ID)!='VAT']/cbc:CompanyID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-13</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-13]-Seller tax registration shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLegalForm) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyLegalForm) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-14</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-14]-Seller additional legal information shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-15</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-15]-Buyer name shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification/cbc:ID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification/cbc:ID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-16</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-16]-Buyer identifier shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-17</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-17]-Buyer legal registration identifier shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/upper-case(cbc:ID)='VAT']/cbc:CompanyID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/upper-case(cbc:ID)='VAT']/cbc:CompanyID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-18</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-18]-Buyer VAT identifier shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:Delivery) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:Delivery) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-24</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-24]-Deliver to information shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(//cac:PartyIdentification/cbc:ID[upper-case(@schemeID) = 'SEPA']) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(//cac:PartyIdentification/cbc:ID[upper-case(@schemeID) = 'SEPA']) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-29</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-29]-Bank creditor reference shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:ProjectReference/cbc:ID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:ProjectReference/cbc:ID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-39</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-39]-Project reference shall occur maximum once.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyName/cbc:Name) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyName/cbc:Name) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-40</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-40]-Buyer trade name shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(//cbc:PaymentID[not(preceding::cbc:PaymentID/. = .)]) &lt;= 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(//cbc:PaymentID[not(preceding::cbc:PaymentID/. = .)]) &lt;= 1">
+          <xsl:attribute name="id">UBL-SR-44</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-44]-An Invoice may only have one unique PaymentID, but the PaymentID may be used for multiple PaymentMeans</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:PaymentMeans/cbc:PaymentDueDate) &lt;=1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:PaymentMeans/cbc:PaymentDueDate) &lt;=1)">
+          <xsl:attribute name="id">UBL-SR-45</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-45]-Due Date shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:PaymentMeans/cbc:PaymentMeansCode/@name) &lt;=1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:PaymentMeans/cbc:PaymentMeansCode/@name) &lt;=1)">
+          <xsl:attribute name="id">UBL-SR-46</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-46]-Payment means text shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(//cbc:PaymentMeansCode[not(preceding::cbc:PaymentMeansCode/. = .)]) &lt;= 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(//cbc:PaymentMeansCode[not(preceding::cbc:PaymentMeansCode/. = .)]) &lt;= 1">
+          <xsl:attribute name="id">UBL-SR-47</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-47]-When there are more than one payment means code, they shall be equal</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:InvoicePeriod/cbc:DescriptionCode) &lt;=1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:InvoicePeriod/cbc:DescriptionCode) &lt;=1)">
+          <xsl:attribute name="id">UBL-SR-49</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-49]-Value tax point date shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine | cac:CreditNoteLine" mode="M12" priority="1005">
+    <svrl:fired-rule context="cac:InvoiceLine | cac:CreditNoteLine" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cbc:Note) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cbc:Note) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-34</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-34]-Invoice line note shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:OrderLineReference/cbc:LineID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:OrderLineReference/cbc:LineID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-35</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-35]-Referenced purchase order line identifier shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:InvoicePeriod) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:InvoicePeriod) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-36</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-36]-Invoice line period shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:Price/cac:AllowanceCharge/cbc:Amount) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:Price/cac:AllowanceCharge/cbc:Amount) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-37</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-37]-Item price discount shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:Item/cac:ClassifiedTaxCategory) = 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:Item/cac:ClassifiedTaxCategory) = 1">
+          <xsl:attribute name="id">UBL-SR-48</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-48]-Invoice lines shall have one and only one classified tax category.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:Item/cbc:Description) &lt;= 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:Item/cbc:Description) &lt;= 1">
+          <xsl:attribute name="id">UBL-SR-50</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-50]-Item description shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:DocumentReference) &lt;= 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:DocumentReference) &lt;= 1">
+          <xsl:attribute name="id">UBL-SR-52</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-52]-Document reference shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PayeeParty" mode="M12" priority="1004">
+    <svrl:fired-rule context="cac:PayeeParty" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:PartyName/cbc:Name) &lt;= 1) and ((cac:PartyName/cbc:Name) != (../cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:PartyName/cbc:Name) &lt;= 1) and ((cac:PartyName/cbc:Name) != (../cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName))">
+          <xsl:attribute name="id">UBL-SR-19</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-19]-Payee name shall occur maximum once, if the Payee is different from the Seller</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:PartyIdentification/cbc:ID[upper-case(@schemeID) != 'SEPA']) &lt;= 1) and ((cac:PartyName/cbc:Name) != (../cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:PartyIdentification/cbc:ID[upper-case(@schemeID) != 'SEPA']) &lt;= 1) and ((cac:PartyName/cbc:Name) != (../cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName))">
+          <xsl:attribute name="id">UBL-SR-20</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-20]-Payee identifier shall occur maximum once, if the Payee is different from the Seller</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:PartyLegalEntity/cbc:CompanyID) &lt;= 1) and ((cac:PartyName/cbc:Name) != (../cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:PartyLegalEntity/cbc:CompanyID) &lt;= 1) and ((cac:PartyName/cbc:Name) != (../cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName))">
+          <xsl:attribute name="id">UBL-SR-21</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-21]-Payee legal registration identifier shall occur maximum once, if the Payee is different from the Seller</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PaymentMeans" mode="M12" priority="1003">
+    <svrl:fired-rule context="cac:PaymentMeans" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cbc:PaymentID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cbc:PaymentID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-26</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-26]-Payment reference shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cbc:PaymentMeansCode) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cbc:PaymentMeansCode) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-27</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-27]-Payment means text shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:PaymentMandate/cbc:ID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:PaymentMandate/cbc:ID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-28</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-28]-Mandate reference identifier shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:BillingReference" mode="M12" priority="1002">
+    <svrl:fired-rule context="cac:BillingReference" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:InvoiceDocumentReference) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:InvoiceDocumentReference) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-06]-Preceding invoice reference shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(cac:InvoiceDocumentReference/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(cac:InvoiceDocumentReference/cbc:ID)">
+          <xsl:attribute name="id">UBL-SR-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-07]-If there is a preceding invoice reference, the preceding invoice number shall be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxRepresentativeParty" mode="M12" priority="1001">
+    <svrl:fired-rule context="cac:TaxRepresentativeParty" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:PartyName/cbc:Name) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:PartyName/cbc:Name) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-22</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-22]-Seller tax representative name shall occur maximum once, if the Seller has a tax representative</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:Party/cac:PartyTaxScheme/cbc:CompanyID) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:Party/cac:PartyTaxScheme/cbc:CompanyID) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-23</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-23]-Seller tax representative VAT identifier shall occur maximum once, if the Seller has a tax representative</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxSubtotal" mode="M12" priority="1000">
+    <svrl:fired-rule context="cac:TaxSubtotal" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:TaxCategory/cbc:TaxExemptionReason) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:TaxCategory/cbc:TaxExemptionReason) &lt;= 1)">
+          <xsl:attribute name="id">UBL-SR-32</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[UBL-SR-32]-VAT exemption reason text shall occur maximum once</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M12" priority="-1" />
+  <xsl:template match="@*|node()" mode="M12" priority="-2">
+    <xsl:apply-templates mode="M12" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN Codesmodel-->
+
+
+	<!--RULE -->
+<xsl:template match="cbc:InvoiceTypeCode | cbc:CreditNoteTypeCode" mode="M13" priority="1021">
+    <svrl:fired-rule context="cbc:InvoiceTypeCode | cbc:CreditNoteTypeCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(self::cbc:InvoiceTypeCode and ((not(contains(normalize-space(.), ' ')) and contains(' 71 80 81 82 84 102 130 202 203 204 211 218 219 295 325 326 331 380 382 383 384 385 386 387 388 389 390 393 394 395 456 457 471 472 473 500 501 502 503 527 553 575 623 633 751 780 817 870 875 876 877 935 ', concat(' ', normalize-space(.), ' '))))) or (self::cbc:CreditNoteTypeCode and ((not(contains(normalize-space(.), ' ')) and contains(' 81 83 261 262 296 308 381 396 420 458 532 ', concat(' ', normalize-space(.), ' ')))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(self::cbc:InvoiceTypeCode and ((not(contains(normalize-space(.), ' ')) and contains(' 71 80 81 82 84 102 130 202 203 204 211 218 219 295 325 326 331 380 382 383 384 385 386 387 388 389 390 393 394 395 456 457 471 472 473 500 501 502 503 527 553 575 623 633 751 780 817 870 875 876 877 935 ', concat(' ', normalize-space(.), ' '))))) or (self::cbc:CreditNoteTypeCode and ((not(contains(normalize-space(.), ' ')) and contains(' 81 83 261 262 296 308 381 396 420 458 532 ', concat(' ', normalize-space(.), ' ')))))">
+          <xsl:attribute name="id">BR-CL-01</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-01]-The document type code MUST be coded by the invoice and credit note related code lists of UNTDID 1001.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:Amount | cbc:BaseAmount | cbc:PriceAmount | cbc:TaxAmount | cbc:TaxableAmount | cbc:LineExtensionAmount | cbc:TaxExclusiveAmount | cbc:TaxInclusiveAmount | cbc:AllowanceTotalAmount | cbc:ChargeTotalAmount | cbc:PrepaidAmount | cbc:PayableRoundingAmount | cbc:PayableAmount" mode="M13" priority="1020">
+    <svrl:fired-rule context="cbc:Amount | cbc:BaseAmount | cbc:PriceAmount | cbc:TaxAmount | cbc:TaxableAmount | cbc:LineExtensionAmount | cbc:TaxExclusiveAmount | cbc:TaxInclusiveAmount | cbc:AllowanceTotalAmount | cbc:ChargeTotalAmount | cbc:PrepaidAmount | cbc:PayableRoundingAmount | cbc:PayableAmount" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(@currencyID), ' ')) and contains(' AED AFN ALL AMD ANG AOA ARS AUD AWG AZN BAM BBD BDT BGN BHD BIF BMD BND BOB BOV BRL BSD BTN BWP BYN BZD CAD CDF CHE CHF CHW CLF CLP CNY COP COU CRC CUC CUP CVE CZK DJF DKK DOP DZD EGP ERN ETB EUR FJD FKP GBP GEL GHS GIP GMD GNF GTQ GYD HKD HNL HTG HUF IDR ILS INR IQD IRR ISK JMD JOD JPY KES KGS KHR KMF KPW KRW KWD KYD KZT LAK LBP LKR LRD LSL LYD MAD MDL MGA MKD MMK MNT MOP MRO MUR MVR MWK MXN MXV MYR MZN NAD NGN NIO NOK NPR NZD OMR PAB PEN PGK PHP PKR PLN PYG QAR RON RSD RUB RWF SAR SBD SCR SDG SEK SGD SHP SLE SOS SRD SSP STD SVC SYP SZL THB TJS TMT TND TOP TRY TTD TWD TZS UAH UGX USD USN UYI UYU UZS VES VED VND VUV WST XAF XAG XAU XBA XBB XBC XBD XCD XDR XOF XPD XPF XPT XSU XTS XUA XXX YER ZAR ZMW ZWG ', concat(' ', normalize-space(@currencyID), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(@currencyID), ' ')) and contains(' AED AFN ALL AMD ANG AOA ARS AUD AWG AZN BAM BBD BDT BGN BHD BIF BMD BND BOB BOV BRL BSD BTN BWP BYN BZD CAD CDF CHE CHF CHW CLF CLP CNY COP COU CRC CUC CUP CVE CZK DJF DKK DOP DZD EGP ERN ETB EUR FJD FKP GBP GEL GHS GIP GMD GNF GTQ GYD HKD HNL HTG HUF IDR ILS INR IQD IRR ISK JMD JOD JPY KES KGS KHR KMF KPW KRW KWD KYD KZT LAK LBP LKR LRD LSL LYD MAD MDL MGA MKD MMK MNT MOP MRO MUR MVR MWK MXN MXV MYR MZN NAD NGN NIO NOK NPR NZD OMR PAB PEN PGK PHP PKR PLN PYG QAR RON RSD RUB RWF SAR SBD SCR SDG SEK SGD SHP SLE SOS SRD SSP STD SVC SYP SZL THB TJS TMT TND TOP TRY TTD TWD TZS UAH UGX USD USN UYI UYU UZS VES VED VND VUV WST XAF XAG XAU XBA XBB XBC XBD XCD XDR XOF XPD XPF XPT XSU XTS XUA XXX YER ZAR ZMW ZWG ', concat(' ', normalize-space(@currencyID), ' '))))">
+          <xsl:attribute name="id">BR-CL-03</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-03]-currencyID MUST be coded using ISO code list 4217 alpha-3</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:DocumentCurrencyCode" mode="M13" priority="1019">
+    <svrl:fired-rule context="cbc:DocumentCurrencyCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(.), ' ')) and contains(' AED AFN ALL AMD ANG AOA ARS AUD AWG AZN BAM BBD BDT BGN BHD BIF BMD BND BOB BOV BRL BSD BTN BWP BYN BZD CAD CDF CHE CHF CHW CLF CLP CNY COP COU CRC CUC CUP CVE CZK DJF DKK DOP DZD EGP ERN ETB EUR FJD FKP GBP GEL GHS GIP GMD GNF GTQ GYD HKD HNL HTG HUF IDR ILS INR IQD IRR ISK JMD JOD JPY KES KGS KHR KMF KPW KRW KWD KYD KZT LAK LBP LKR LRD LSL LYD MAD MDL MGA MKD MMK MNT MOP MRO MUR MVR MWK MXN MXV MYR MZN NAD NGN NIO NOK NPR NZD OMR PAB PEN PGK PHP PKR PLN PYG QAR RON RSD RUB RWF SAR SBD SCR SDG SEK SGD SHP SLE SOS SRD SSP STD SVC SYP SZL THB TJS TMT TND TOP TRY TTD TWD TZS UAH UGX USD USN UYI UYU UZS VES VED VND VUV WST XAF XAG XAU XBA XBB XBC XBD XCD XDR XOF XPD XPF XPT XSU XTS XUA XXX YER ZAR ZMW ZWG ', concat(' ', normalize-space(.), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(.), ' ')) and contains(' AED AFN ALL AMD ANG AOA ARS AUD AWG AZN BAM BBD BDT BGN BHD BIF BMD BND BOB BOV BRL BSD BTN BWP BYN BZD CAD CDF CHE CHF CHW CLF CLP CNY COP COU CRC CUC CUP CVE CZK DJF DKK DOP DZD EGP ERN ETB EUR FJD FKP GBP GEL GHS GIP GMD GNF GTQ GYD HKD HNL HTG HUF IDR ILS INR IQD IRR ISK JMD JOD JPY KES KGS KHR KMF KPW KRW KWD KYD KZT LAK LBP LKR LRD LSL LYD MAD MDL MGA MKD MMK MNT MOP MRO MUR MVR MWK MXN MXV MYR MZN NAD NGN NIO NOK NPR NZD OMR PAB PEN PGK PHP PKR PLN PYG QAR RON RSD RUB RWF SAR SBD SCR SDG SEK SGD SHP SLE SOS SRD SSP STD SVC SYP SZL THB TJS TMT TND TOP TRY TTD TWD TZS UAH UGX USD USN UYI UYU UZS VES VED VND VUV WST XAF XAG XAU XBA XBB XBC XBD XCD XDR XOF XPD XPF XPT XSU XTS XUA XXX YER ZAR ZMW ZWG ', concat(' ', normalize-space(.), ' '))))">
+          <xsl:attribute name="id">BR-CL-04</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-04]-Invoice currency code MUST be coded using ISO code list 4217 alpha-3</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:TaxCurrencyCode" mode="M13" priority="1018">
+    <svrl:fired-rule context="cbc:TaxCurrencyCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(.), ' ')) and contains(' AED AFN ALL AMD ANG AOA ARS AUD AWG AZN BAM BBD BDT BGN BHD BIF BMD BND BOB BOV BRL BSD BTN BWP BYN BZD CAD CDF CHE CHF CHW CLF CLP CNY COP COU CRC CUC CUP CVE CZK DJF DKK DOP DZD EGP ERN ETB EUR FJD FKP GBP GEL GHS GIP GMD GNF GTQ GYD HKD HNL HTG HUF IDR ILS INR IQD IRR ISK JMD JOD JPY KES KGS KHR KMF KPW KRW KWD KYD KZT LAK LBP LKR LRD LSL LYD MAD MDL MGA MKD MMK MNT MOP MRO MUR MVR MWK MXN MXV MYR MZN NAD NGN NIO NOK NPR NZD OMR PAB PEN PGK PHP PKR PLN PYG QAR RON RSD RUB RWF SAR SBD SCR SDG SEK SGD SHP SLE SOS SRD SSP STD SVC SYP SZL THB TJS TMT TND TOP TRY TTD TWD TZS UAH UGX USD USN UYI UYU UZS VES VED VND VUV WST XAF XAG XAU XBA XBB XBC XBD XCD XDR XOF XPD XPF XPT XSU XTS XUA XXX YER ZAR ZMW ZWG ', concat(' ', normalize-space(.), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(.), ' ')) and contains(' AED AFN ALL AMD ANG AOA ARS AUD AWG AZN BAM BBD BDT BGN BHD BIF BMD BND BOB BOV BRL BSD BTN BWP BYN BZD CAD CDF CHE CHF CHW CLF CLP CNY COP COU CRC CUC CUP CVE CZK DJF DKK DOP DZD EGP ERN ETB EUR FJD FKP GBP GEL GHS GIP GMD GNF GTQ GYD HKD HNL HTG HUF IDR ILS INR IQD IRR ISK JMD JOD JPY KES KGS KHR KMF KPW KRW KWD KYD KZT LAK LBP LKR LRD LSL LYD MAD MDL MGA MKD MMK MNT MOP MRO MUR MVR MWK MXN MXV MYR MZN NAD NGN NIO NOK NPR NZD OMR PAB PEN PGK PHP PKR PLN PYG QAR RON RSD RUB RWF SAR SBD SCR SDG SEK SGD SHP SLE SOS SRD SSP STD SVC SYP SZL THB TJS TMT TND TOP TRY TTD TWD TZS UAH UGX USD USN UYI UYU UZS VES VED VND VUV WST XAF XAG XAU XBA XBB XBC XBD XCD XDR XOF XPD XPF XPT XSU XTS XUA XXX YER ZAR ZMW ZWG ', concat(' ', normalize-space(.), ' '))))">
+          <xsl:attribute name="id">BR-CL-05</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-05]-Tax currency code MUST be coded using ISO code list 4217 alpha-3</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoicePeriod/cbc:DescriptionCode" mode="M13" priority="1017">
+    <svrl:fired-rule context="cac:InvoicePeriod/cbc:DescriptionCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(.), ' ')) and contains(' 3 35 432 ', concat(' ', normalize-space(.), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(.), ' ')) and contains(' 3 35 432 ', concat(' ', normalize-space(.), ' '))))">
+          <xsl:attribute name="id">BR-CL-06</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-06]-Value added tax point date code MUST be coded using a restriction of UNTDID 2005.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AdditionalDocumentReference[cbc:DocumentTypeCode = '130']/cbc:ID[@schemeID] | cac:DocumentReference[cbc:DocumentTypeCode = '130']/cbc:ID[@schemeID]" mode="M13" priority="1016">
+    <svrl:fired-rule context="cac:AdditionalDocumentReference[cbc:DocumentTypeCode = '130']/cbc:ID[@schemeID] | cac:DocumentReference[cbc:DocumentTypeCode = '130']/cbc:ID[@schemeID]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' AAA AAB AAC AAD AAE AAF AAG AAH AAI AAJ AAK AAL AAM AAN AAO AAP AAQ AAR AAS AAT AAU AAV AAW AAX AAY AAZ ABA ABB ABC ABD ABE ABF ABG ABH ABI ABJ ABK ABL ABM ABN ABO ABP ABQ ABR ABS ABT ABU ABV ABW ABX ABY ABZ AC ACA ACB ACC ACD ACE ACF ACG ACH ACI ACJ ACK ACL ACN ACO ACP ACQ ACR ACT ACU ACV ACW ACX ACY ACZ ADA ADB ADC ADD ADE ADF ADG ADI ADJ ADK ADL ADM ADN ADO ADP ADQ ADT ADU ADV ADW ADX ADY ADZ AE AEA AEB AEC AED AEE AEF AEG AEH AEI AEJ AEK AEL AEM AEN AEO AEP AEQ AER AES AET AEU AEV AEW AEX AEY AEZ AF AFA AFB AFC AFD AFE AFF AFG AFH AFI AFJ AFK AFL AFM AFN AFO AFP AFQ AFR AFS AFT AFU AFV AFW AFX AFY AFZ AGA AGB AGC AGD AGE AGF AGG AGH AGI AGJ AGK AGL AGM AGN AGO AGP AGQ AGR AGS AGT AGU AGV AGW AGX AGY AGZ AHA AHB AHC AHD AHE AHF AHG AHH AHI AHJ AHK AHL AHM AHN AHO AHP AHQ AHR AHS AHT AHU AHV AHX AHY AHZ AIA AIB AIC AID AIE AIF AIG AIH AII AIJ AIK AIL AIM AIN AIO AIP AIQ AIR AIS AIT AIU AIV AIW AIX AIY AIZ AJA AJB AJC AJD AJE AJF AJG AJH AJI AJJ AJK AJL AJM AJN AJO AJP AJQ AJR AJS AJT AJU AJV AJW AJX AJY AJZ AKA AKB AKC AKD AKE AKF AKG AKH AKI AKJ AKK AKL AKM AKN AKO AKP AKQ AKR AKS AKT AKU AKV AKW AKX AKY AKZ ALA ALB ALC ALD ALE ALF ALG ALH ALI ALJ ALK ALL ALM ALN ALO ALP ALQ ALR ALS ALT ALU ALV ALW ALX ALY ALZ AMA AMB AMC AMD AME AMF AMG AMH AMI AMJ AMK AML AMM AMN AMO AMP AMQ AMR AMS AMT AMU AMV AMW AMX AMY AMZ ANA ANB ANC AND ANE ANF ANG ANH ANI ANJ ANK ANL ANM ANN ANO ANP ANQ ANR ANS ANT ANU ANV ANW ANX ANY AOA AOD AOE AOF AOG AOH AOI AOJ AOK AOL AOM AON AOO AOP AOQ AOR AOS AOT AOU AOV AOW AOX AOY AOZ AP APA APB APC APD APE APF APG APH API APJ APK APL APM APN APO APP APQ APR APS APT APU APV APW APX APY APZ AQA AQB AQC AQD AQE AQF AQG AQH AQI AQJ AQK AQL AQM AQN AQO AQP AQQ AQR AQS AQT AQU AQV AQW AQX AQY AQZ ARA ARB ARC ARD ARE ARF ARG ARH ARI ARJ ARK ARL ARM ARN ARO ARP ARQ ARR ARS ART ARU ARV ARW ARX ARY ARZ ASA ASB ASC ASD ASE ASF ASG ASH ASI ASJ ASK ASL ASM ASN ASO ASP ASQ ASR ASS AST ASU ASV ASW ASX ASY ASZ ATA ATB ATC ATD ATE ATF ATG ATH ATI ATJ ATK ATL ATM ATN ATO ATP ATQ ATR ATS ATT ATU ATV ATW ATX ATY ATZ AU AUA AUB AUC AUD AUE AUF AUG AUH AUI AUJ AUK AUL AUM AUN AUO AUP AUQ AUR AUS AUT AUU AUV AUW AUX AUY AUZ AV AVA AVB AVC AVD AVE AVF AVG AVH AVI AVJ AVK AVL AVM AVN AVO AVP AVQ AVR AVS AVT AVU AVV AVW AVX AVY AVZ AWA AWB AWC AWD AWE AWF AWG AWH AWI AWJ AWK AWL AWM AWN AWO AWP AWQ AWR AWS AWT AWU AWV AWW AWX AWY AWZ AXA AXB AXC AXD AXE AXF AXG AXH AXI AXJ AXK AXL AXM AXN AXO AXP AXQ AXR AXS AXU BA BC BD BE BH BM BN BO BR BT BTP BW CAS CAT CAU CAV CAW CAX CAY CAZ CBA CBB CD CEC CED CFE CFF CFO CG CH CK CKN CM CMR CN CNO COF CP CR CRN CS CST CT CU CV CW CZ DA DAN DB DI DL DM DQ DR EA EB ED EE EEP EI EN EQ ER ERN ET EX FC FF FI FLW FN FO FS FT FV FX GA GC GD GDN GN HS HWB IA IB ICA ICE ICO II IL INB INN INO IP IS IT IV JB JE LA LAN LAR LB LC LI LO LRC LS MA MB MF MG MH MR MRN MS MSS MWB NA NF OH OI ON OP OR PB PC PD PE PF PI PK PL POR PP PQ PR PS PW PY RA RC RCN RE REN RF RR RT SA SB SD SE SEA SF SH SI SM SN SP SQ SRN SS STA SW SZ TB TCR TE TF TI TIN TL TN TP UAR UC UCN UN UO URI VA VC VGR VM VN VON VOR VP VR VS VT VV WE WM WN WR WS WY XA XC XP ZZZ ', concat(' ', normalize-space(@schemeID), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' AAA AAB AAC AAD AAE AAF AAG AAH AAI AAJ AAK AAL AAM AAN AAO AAP AAQ AAR AAS AAT AAU AAV AAW AAX AAY AAZ ABA ABB ABC ABD ABE ABF ABG ABH ABI ABJ ABK ABL ABM ABN ABO ABP ABQ ABR ABS ABT ABU ABV ABW ABX ABY ABZ AC ACA ACB ACC ACD ACE ACF ACG ACH ACI ACJ ACK ACL ACN ACO ACP ACQ ACR ACT ACU ACV ACW ACX ACY ACZ ADA ADB ADC ADD ADE ADF ADG ADI ADJ ADK ADL ADM ADN ADO ADP ADQ ADT ADU ADV ADW ADX ADY ADZ AE AEA AEB AEC AED AEE AEF AEG AEH AEI AEJ AEK AEL AEM AEN AEO AEP AEQ AER AES AET AEU AEV AEW AEX AEY AEZ AF AFA AFB AFC AFD AFE AFF AFG AFH AFI AFJ AFK AFL AFM AFN AFO AFP AFQ AFR AFS AFT AFU AFV AFW AFX AFY AFZ AGA AGB AGC AGD AGE AGF AGG AGH AGI AGJ AGK AGL AGM AGN AGO AGP AGQ AGR AGS AGT AGU AGV AGW AGX AGY AGZ AHA AHB AHC AHD AHE AHF AHG AHH AHI AHJ AHK AHL AHM AHN AHO AHP AHQ AHR AHS AHT AHU AHV AHX AHY AHZ AIA AIB AIC AID AIE AIF AIG AIH AII AIJ AIK AIL AIM AIN AIO AIP AIQ AIR AIS AIT AIU AIV AIW AIX AIY AIZ AJA AJB AJC AJD AJE AJF AJG AJH AJI AJJ AJK AJL AJM AJN AJO AJP AJQ AJR AJS AJT AJU AJV AJW AJX AJY AJZ AKA AKB AKC AKD AKE AKF AKG AKH AKI AKJ AKK AKL AKM AKN AKO AKP AKQ AKR AKS AKT AKU AKV AKW AKX AKY AKZ ALA ALB ALC ALD ALE ALF ALG ALH ALI ALJ ALK ALL ALM ALN ALO ALP ALQ ALR ALS ALT ALU ALV ALW ALX ALY ALZ AMA AMB AMC AMD AME AMF AMG AMH AMI AMJ AMK AML AMM AMN AMO AMP AMQ AMR AMS AMT AMU AMV AMW AMX AMY AMZ ANA ANB ANC AND ANE ANF ANG ANH ANI ANJ ANK ANL ANM ANN ANO ANP ANQ ANR ANS ANT ANU ANV ANW ANX ANY AOA AOD AOE AOF AOG AOH AOI AOJ AOK AOL AOM AON AOO AOP AOQ AOR AOS AOT AOU AOV AOW AOX AOY AOZ AP APA APB APC APD APE APF APG APH API APJ APK APL APM APN APO APP APQ APR APS APT APU APV APW APX APY APZ AQA AQB AQC AQD AQE AQF AQG AQH AQI AQJ AQK AQL AQM AQN AQO AQP AQQ AQR AQS AQT AQU AQV AQW AQX AQY AQZ ARA ARB ARC ARD ARE ARF ARG ARH ARI ARJ ARK ARL ARM ARN ARO ARP ARQ ARR ARS ART ARU ARV ARW ARX ARY ARZ ASA ASB ASC ASD ASE ASF ASG ASH ASI ASJ ASK ASL ASM ASN ASO ASP ASQ ASR ASS AST ASU ASV ASW ASX ASY ASZ ATA ATB ATC ATD ATE ATF ATG ATH ATI ATJ ATK ATL ATM ATN ATO ATP ATQ ATR ATS ATT ATU ATV ATW ATX ATY ATZ AU AUA AUB AUC AUD AUE AUF AUG AUH AUI AUJ AUK AUL AUM AUN AUO AUP AUQ AUR AUS AUT AUU AUV AUW AUX AUY AUZ AV AVA AVB AVC AVD AVE AVF AVG AVH AVI AVJ AVK AVL AVM AVN AVO AVP AVQ AVR AVS AVT AVU AVV AVW AVX AVY AVZ AWA AWB AWC AWD AWE AWF AWG AWH AWI AWJ AWK AWL AWM AWN AWO AWP AWQ AWR AWS AWT AWU AWV AWW AWX AWY AWZ AXA AXB AXC AXD AXE AXF AXG AXH AXI AXJ AXK AXL AXM AXN AXO AXP AXQ AXR AXS AXU BA BC BD BE BH BM BN BO BR BT BTP BW CAS CAT CAU CAV CAW CAX CAY CAZ CBA CBB CD CEC CED CFE CFF CFO CG CH CK CKN CM CMR CN CNO COF CP CR CRN CS CST CT CU CV CW CZ DA DAN DB DI DL DM DQ DR EA EB ED EE EEP EI EN EQ ER ERN ET EX FC FF FI FLW FN FO FS FT FV FX GA GC GD GDN GN HS HWB IA IB ICA ICE ICO II IL INB INN INO IP IS IT IV JB JE LA LAN LAR LB LC LI LO LRC LS MA MB MF MG MH MR MRN MS MSS MWB NA NF OH OI ON OP OR PB PC PD PE PF PI PK PL POR PP PQ PR PS PW PY RA RC RCN RE REN RF RR RT SA SB SD SE SEA SF SH SI SM SN SP SQ SRN SS STA SW SZ TB TCR TE TF TI TIN TL TN TP UAR UC UCN UN UO URI VA VC VGR VM VN VON VOR VP VR VS VT VV WE WM WN WR WS WY XA XC XP ZZZ ', concat(' ', normalize-space(@schemeID), ' '))))">
+          <xsl:attribute name="id">BR-CL-07</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-07]-Object identifier identification scheme identifier MUST be coded using a restriction of UNTDID 1153.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PartyIdentification/cbc:ID[@schemeID]" mode="M13" priority="1015">
+    <svrl:fired-rule context="cac:PartyIdentification/cbc:ID[@schemeID]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' 0002 0003 0004 0005 0006 0007 0008 0009 0010 0011 0012 0013 0014 0015 0016 0017 0018 0019 0020 0021 0022 0023 0024 0025 0026 0027 0028 0029 0030 0031 0032 0033 0034 0035 0036 0037 0038 0039 0040 0041 0042 0043 0044 0045 0046 0047 0048 0049 0050 0051 0052 0053 0054 0055 0056 0057 0058 0059 0060 0061 0062 0063 0064 0065 0066 0067 0068 0069 0070 0071 0072 0073 0074 0075 0076 0077 0078 0079 0080 0081 0082 0083 0084 0085 0086 0087 0088 0089 0090 0091 0093 0094 0095 0096 0097 0098 0099 0100 0101 0102 0104 0105 0106 0107 0108 0109 0110 0111 0112 0113 0114 0115 0116 0117 0118 0119 0120 0121 0122 0123 0124 0125 0126 0127 0128 0129 0130 0131 0132 0133 0134 0135 0136 0137 0138 0139 0140 0141 0142 0143 0144 0145 0146 0147 0148 0149 0150 0151 0152 0153 0154 0155 0156 0157 0158 0159 0160 0161 0162 0163 0164 0165 0166 0167 0168 0169 0170 0171 0172 0173 0174 0175 0176 0177 0178 0179 0180 0183 0184 0185 0186 0187 0188 0189 0190 0191 0192 0193 0194 0195 0196 0197 0198 0199 0200 0201 0202 0203 0204 0205 0206 0207 0208 0209 0210 0211 0212 0213 0214 0215 0216 0217 0218 0219 0220 0221 0222 0223 0224 0225 0226 0227 0228 0229 0230 0231 0232 0233 0234 0235 0236 0237 0238 0239 0240 ', concat(' ', normalize-space(@schemeID), ' '))))  or ((not(contains(normalize-space(@schemeID), ' ')) and contains(' SEPA ', concat(' ', normalize-space(@schemeID), ' '))) and ((ancestor::cac:AccountingSupplierParty) or (ancestor::cac:PayeeParty)))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' 0002 0003 0004 0005 0006 0007 0008 0009 0010 0011 0012 0013 0014 0015 0016 0017 0018 0019 0020 0021 0022 0023 0024 0025 0026 0027 0028 0029 0030 0031 0032 0033 0034 0035 0036 0037 0038 0039 0040 0041 0042 0043 0044 0045 0046 0047 0048 0049 0050 0051 0052 0053 0054 0055 0056 0057 0058 0059 0060 0061 0062 0063 0064 0065 0066 0067 0068 0069 0070 0071 0072 0073 0074 0075 0076 0077 0078 0079 0080 0081 0082 0083 0084 0085 0086 0087 0088 0089 0090 0091 0093 0094 0095 0096 0097 0098 0099 0100 0101 0102 0104 0105 0106 0107 0108 0109 0110 0111 0112 0113 0114 0115 0116 0117 0118 0119 0120 0121 0122 0123 0124 0125 0126 0127 0128 0129 0130 0131 0132 0133 0134 0135 0136 0137 0138 0139 0140 0141 0142 0143 0144 0145 0146 0147 0148 0149 0150 0151 0152 0153 0154 0155 0156 0157 0158 0159 0160 0161 0162 0163 0164 0165 0166 0167 0168 0169 0170 0171 0172 0173 0174 0175 0176 0177 0178 0179 0180 0183 0184 0185 0186 0187 0188 0189 0190 0191 0192 0193 0194 0195 0196 0197 0198 0199 0200 0201 0202 0203 0204 0205 0206 0207 0208 0209 0210 0211 0212 0213 0214 0215 0216 0217 0218 0219 0220 0221 0222 0223 0224 0225 0226 0227 0228 0229 0230 0231 0232 0233 0234 0235 0236 0237 0238 0239 0240 ', concat(' ', normalize-space(@schemeID), ' ')))) or ((not(contains(normalize-space(@schemeID), ' ')) and contains(' SEPA ', concat(' ', normalize-space(@schemeID), ' '))) and ((ancestor::cac:AccountingSupplierParty) or (ancestor::cac:PayeeParty)))">
+          <xsl:attribute name="id">BR-CL-10</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-10]-Any identifier identification scheme identifier MUST be coded using one of the ISO 6523 ICD list.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PartyLegalEntity/cbc:CompanyID[@schemeID]" mode="M13" priority="1014">
+    <svrl:fired-rule context="cac:PartyLegalEntity/cbc:CompanyID[@schemeID]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' 0002 0003 0004 0005 0006 0007 0008 0009 0010 0011 0012 0013 0014 0015 0016 0017 0018 0019 0020 0021 0022 0023 0024 0025 0026 0027 0028 0029 0030 0031 0032 0033 0034 0035 0036 0037 0038 0039 0040 0041 0042 0043 0044 0045 0046 0047 0048 0049 0050 0051 0052 0053 0054 0055 0056 0057 0058 0059 0060 0061 0062 0063 0064 0065 0066 0067 0068 0069 0070 0071 0072 0073 0074 0075 0076 0077 0078 0079 0080 0081 0082 0083 0084 0085 0086 0087 0088 0089 0090 0091 0093 0094 0095 0096 0097 0098 0099 0100 0101 0102 0104 0105 0106 0107 0108 0109 0110 0111 0112 0113 0114 0115 0116 0117 0118 0119 0120 0121 0122 0123 0124 0125 0126 0127 0128 0129 0130 0131 0132 0133 0134 0135 0136 0137 0138 0139 0140 0141 0142 0143 0144 0145 0146 0147 0148 0149 0150 0151 0152 0153 0154 0155 0156 0157 0158 0159 0160 0161 0162 0163 0164 0165 0166 0167 0168 0169 0170 0171 0172 0173 0174 0175 0176 0177 0178 0179 0180 0183 0184 0185 0186 0187 0188 0189 0190 0191 0192 0193 0194 0195 0196 0197 0198 0199 0200 0201 0202 0203 0204 0205 0206 0207 0208 0209 0210 0211 0212 0213 0214 0215 0216 0217 0218 0219 0220 0221 0222 0223 0224 0225 0226 0227 0228 0229 0230 0231 0232 0233 0234 0235 0236 0237 0238 0239 0240 ', concat(' ', normalize-space(@schemeID), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' 0002 0003 0004 0005 0006 0007 0008 0009 0010 0011 0012 0013 0014 0015 0016 0017 0018 0019 0020 0021 0022 0023 0024 0025 0026 0027 0028 0029 0030 0031 0032 0033 0034 0035 0036 0037 0038 0039 0040 0041 0042 0043 0044 0045 0046 0047 0048 0049 0050 0051 0052 0053 0054 0055 0056 0057 0058 0059 0060 0061 0062 0063 0064 0065 0066 0067 0068 0069 0070 0071 0072 0073 0074 0075 0076 0077 0078 0079 0080 0081 0082 0083 0084 0085 0086 0087 0088 0089 0090 0091 0093 0094 0095 0096 0097 0098 0099 0100 0101 0102 0104 0105 0106 0107 0108 0109 0110 0111 0112 0113 0114 0115 0116 0117 0118 0119 0120 0121 0122 0123 0124 0125 0126 0127 0128 0129 0130 0131 0132 0133 0134 0135 0136 0137 0138 0139 0140 0141 0142 0143 0144 0145 0146 0147 0148 0149 0150 0151 0152 0153 0154 0155 0156 0157 0158 0159 0160 0161 0162 0163 0164 0165 0166 0167 0168 0169 0170 0171 0172 0173 0174 0175 0176 0177 0178 0179 0180 0183 0184 0185 0186 0187 0188 0189 0190 0191 0192 0193 0194 0195 0196 0197 0198 0199 0200 0201 0202 0203 0204 0205 0206 0207 0208 0209 0210 0211 0212 0213 0214 0215 0216 0217 0218 0219 0220 0221 0222 0223 0224 0225 0226 0227 0228 0229 0230 0231 0232 0233 0234 0235 0236 0237 0238 0239 0240 ', concat(' ', normalize-space(@schemeID), ' '))))">
+          <xsl:attribute name="id">BR-CL-11</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-11]-Any registration identifier identification scheme identifier MUST be coded using one of the ISO 6523 ICD list.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:CommodityClassification/cbc:ItemClassificationCode[@listID]" mode="M13" priority="1013">
+    <svrl:fired-rule context="cac:CommodityClassification/cbc:ItemClassificationCode[@listID]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(@listID), ' ')) and contains(' AA AB AC AD AE AF AG AH AI AJ AK AL AM AN AO AP AQ AR AS AT AU AV AW AX AY AZ BA BB BC BD BE BF BG BH BI BJ BK BL BM BN BO BP BQ BR BS BT BU BV BW BX BY BZ CC CG CL CR CV DR DW EC EF EMD EN FS GB GN GMN GS HS IB IN IS IT IZ MA MF MN MP NB ON PD PL PO PPI PV QS RC RN RU RY SA SG SK SN SRS SRT SRU SRV SRW SRX SRY SRZ SS SSA SSB SSC SSD SSE SSF SSG SSH SSI SSJ SSK SSL SSM SSN SSO SSP SSQ SSR SSS SST SSU SSV SSW SSX SSY SSZ ST STA STB STC STD STE STF STG STH STI STJ STK STL STM STN STO STP STQ STR STS STT STU STV STW STX STY STZ SUA SUB SUC SUD SUE SUF SUG SUH SUI SUJ SUK SUL SUM TG TSN TSO TSP TSQ TSR TSS TST TSU UA UP VN VP VS VX ZZZ ', concat(' ', normalize-space(@listID), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(@listID), ' ')) and contains(' AA AB AC AD AE AF AG AH AI AJ AK AL AM AN AO AP AQ AR AS AT AU AV AW AX AY AZ BA BB BC BD BE BF BG BH BI BJ BK BL BM BN BO BP BQ BR BS BT BU BV BW BX BY BZ CC CG CL CR CV DR DW EC EF EMD EN FS GB GN GMN GS HS IB IN IS IT IZ MA MF MN MP NB ON PD PL PO PPI PV QS RC RN RU RY SA SG SK SN SRS SRT SRU SRV SRW SRX SRY SRZ SS SSA SSB SSC SSD SSE SSF SSG SSH SSI SSJ SSK SSL SSM SSN SSO SSP SSQ SSR SSS SST SSU SSV SSW SSX SSY SSZ ST STA STB STC STD STE STF STG STH STI STJ STK STL STM STN STO STP STQ STR STS STT STU STV STW STX STY STZ SUA SUB SUC SUD SUE SUF SUG SUH SUI SUJ SUK SUL SUM TG TSN TSO TSP TSQ TSR TSS TST TSU UA UP VN VP VS VX ZZZ ', concat(' ', normalize-space(@listID), ' '))))">
+          <xsl:attribute name="id">BR-CL-13</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-13]-Item classification identifier identification scheme identifier MUST be
+      coded using one of the UNTDID 7143 list.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:Country/cbc:IdentificationCode" mode="M13" priority="1012">
+    <svrl:fired-rule context="cac:Country/cbc:IdentificationCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(.), ' ')) and contains(' 1A AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS XI YE YT ZA ZM ZW ', concat(' ', normalize-space(.), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(.), ' ')) and contains(' 1A AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS XI YE YT ZA ZM ZW ', concat(' ', normalize-space(.), ' '))))">
+          <xsl:attribute name="id">BR-CL-14</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-14]-Country codes in an invoice MUST be coded using ISO code list 3166-1</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:OriginCountry/cbc:IdentificationCode" mode="M13" priority="1011">
+    <svrl:fired-rule context="cac:OriginCountry/cbc:IdentificationCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(.), ' ')) and contains(' 1A AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS XI YE YT ZA ZM ZW ', concat(' ', normalize-space(.), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(.), ' ')) and contains(' 1A AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS XI YE YT ZA ZM ZW ', concat(' ', normalize-space(.), ' '))))">
+          <xsl:attribute name="id">BR-CL-15</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-15]-Country codes in an invoice MUST be coded using ISO code list 3166-1</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PaymentMeans/cbc:PaymentMeansCode" mode="M13" priority="1010">
+    <svrl:fired-rule context="cac:PaymentMeans/cbc:PaymentMeansCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="( ( not(contains(normalize-space(.),' ')) and contains( ' 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 74 75 76 77 78 91 92 93 94 95 96 97 98 ZZZ ',concat(' ',normalize-space(.),' ') ) ) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="( ( not(contains(normalize-space(.),' ')) and contains( ' 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 74 75 76 77 78 91 92 93 94 95 96 97 98 ZZZ ',concat(' ',normalize-space(.),' ') ) ) )">
+          <xsl:attribute name="id">BR-CL-16</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-16]-Payment means in an invoice MUST be coded using UNCL4461 code list</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxCategory/cbc:ID" mode="M13" priority="1009">
+    <svrl:fired-rule context="cac:TaxCategory/cbc:ID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="( ( not(contains(normalize-space(.),' ')) and contains( ' AE L M E S Z G O K B ',concat(' ',normalize-space(.),' ') ) ) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="( ( not(contains(normalize-space(.),' ')) and contains( ' AE L M E S Z G O K B ',concat(' ',normalize-space(.),' ') ) ) )">
+          <xsl:attribute name="id">BR-CL-17</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-17]-Invoice tax categories MUST be coded using UNCL5305 code list</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:ClassifiedTaxCategory/cbc:ID" mode="M13" priority="1008">
+    <svrl:fired-rule context="cac:ClassifiedTaxCategory/cbc:ID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="( ( not(contains(normalize-space(.),' ')) and contains( ' AE L M E S Z G O K B ',concat(' ',normalize-space(.),' ') ) ) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="( ( not(contains(normalize-space(.),' ')) and contains( ' AE L M E S Z G O K B ',concat(' ',normalize-space(.),' ') ) ) )">
+          <xsl:attribute name="id">BR-CL-18</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-18]-Invoice tax categories MUST be coded using UNCL5305 code list</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator = false()]/cbc:AllowanceChargeReasonCode" mode="M13" priority="1007">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator = false()]/cbc:AllowanceChargeReasonCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(.), ' ')) and contains(' 41 42 60 62 63 64 65 66 67 68 70 71 88 95 100 102 103 104 105 ', concat(' ', normalize-space(.), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(.), ' ')) and contains(' 41 42 60 62 63 64 65 66 67 68 70 71 88 95 100 102 103 104 105 ', concat(' ', normalize-space(.), ' '))))">
+          <xsl:attribute name="id">BR-CL-19</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-19]-Coded allowance reasons MUST belong to the UNCL 5189 code list</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator = true()]/cbc:AllowanceChargeReasonCode" mode="M13" priority="1006">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator = true()]/cbc:AllowanceChargeReasonCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(.), ' ')) and contains(' AA AAA AAC AAD AAE AAF AAH AAI AAS AAT AAV AAY AAZ ABA ABB ABC ABD ABF ABK ABL ABN ABR ABS ABT ABU ACF ACG ACH ACI ACJ ACK ACL ACM ACS ADC ADE ADJ ADK ADL ADM ADN ADO ADP ADQ ADR ADT ADW ADY ADZ AEA AEB AEC AED AEF AEH AEI AEJ AEK AEL AEM AEN AEO AEP AES AET AEU AEV AEW AEX AEY AEZ AJ AU CA CAB CAD CAE CAF CAI CAJ CAK CAL CAM CAN CAO CAP CAQ CAR CAS CAT CAU CAV CAW CAX CAY CAZ CD CG CS CT DAB DAD DAC DAF DAG DAH DAI DAJ DAK DAL DAM DAN DAO DAP DAQ DL EG EP ER FAA FAB FAC FC FH FI GAA HAA HD HH IAA IAB ID IF IR IS KO L1 LA LAA LAB LF MAE MI ML NAA OA PA PAA PC PL PRV RAB RAC RAD RAF RE RF RH RV SA SAA SAD SAE SAI SG SH SM SU TAB TAC TT TV V1 V2 WH XAA YY ZZZ ', concat(' ', normalize-space(.), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(.), ' ')) and contains(' AA AAA AAC AAD AAE AAF AAH AAI AAS AAT AAV AAY AAZ ABA ABB ABC ABD ABF ABK ABL ABN ABR ABS ABT ABU ACF ACG ACH ACI ACJ ACK ACL ACM ACS ADC ADE ADJ ADK ADL ADM ADN ADO ADP ADQ ADR ADT ADW ADY ADZ AEA AEB AEC AED AEF AEH AEI AEJ AEK AEL AEM AEN AEO AEP AES AET AEU AEV AEW AEX AEY AEZ AJ AU CA CAB CAD CAE CAF CAI CAJ CAK CAL CAM CAN CAO CAP CAQ CAR CAS CAT CAU CAV CAW CAX CAY CAZ CD CG CS CT DAB DAD DAC DAF DAG DAH DAI DAJ DAK DAL DAM DAN DAO DAP DAQ DL EG EP ER FAA FAB FAC FC FH FI GAA HAA HD HH IAA IAB ID IF IR IS KO L1 LA LAA LAB LF MAE MI ML NAA OA PA PAA PC PL PRV RAB RAC RAD RAF RE RF RH RV SA SAA SAD SAE SAI SG SH SM SU TAB TAC TT TV V1 V2 WH XAA YY ZZZ ', concat(' ', normalize-space(.), ' '))))">
+          <xsl:attribute name="id">BR-CL-20</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-20]-Coded charge reasons MUST belong to the UNCL 7161 code list</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:StandardItemIdentification/cbc:ID[@schemeID]" mode="M13" priority="1005">
+    <svrl:fired-rule context="cac:StandardItemIdentification/cbc:ID[@schemeID]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' 0002 0003 0004 0005 0006 0007 0008 0009 0010 0011 0012 0013 0014 0015 0016 0017 0018 0019 0020 0021 0022 0023 0024 0025 0026 0027 0028 0029 0030 0031 0032 0033 0034 0035 0036 0037 0038 0039 0040 0041 0042 0043 0044 0045 0046 0047 0048 0049 0050 0051 0052 0053 0054 0055 0056 0057 0058 0059 0060 0061 0062 0063 0064 0065 0066 0067 0068 0069 0070 0071 0072 0073 0074 0075 0076 0077 0078 0079 0080 0081 0082 0083 0084 0085 0086 0087 0088 0089 0090 0091 0093 0094 0095 0096 0097 0098 0099 0100 0101 0102 0104 0105 0106 0107 0108 0109 0110 0111 0112 0113 0114 0115 0116 0117 0118 0119 0120 0121 0122 0123 0124 0125 0126 0127 0128 0129 0130 0131 0132 0133 0134 0135 0136 0137 0138 0139 0140 0141 0142 0143 0144 0145 0146 0147 0148 0149 0150 0151 0152 0153 0154 0155 0156 0157 0158 0159 0160 0161 0162 0163 0164 0165 0166 0167 0168 0169 0170 0171 0172 0173 0174 0175 0176 0177 0178 0179 0180 0183 0184 0185 0186 0187 0188 0189 0190 0191 0192 0193 0194 0195 0196 0197 0198 0199 0200 0201 0202 0203 0204 0205 0206 0207 0208 0209 0210 0211 0212 0213 0214 0215 0216 0217 0218 0219 0220 0221 0222 0223 0224 0225 0226 0227 0228 0229 0230 0231 0232 0233 0234 0235 0236 0237 0238 0239 0240 ', concat(' ', normalize-space(@schemeID), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' 0002 0003 0004 0005 0006 0007 0008 0009 0010 0011 0012 0013 0014 0015 0016 0017 0018 0019 0020 0021 0022 0023 0024 0025 0026 0027 0028 0029 0030 0031 0032 0033 0034 0035 0036 0037 0038 0039 0040 0041 0042 0043 0044 0045 0046 0047 0048 0049 0050 0051 0052 0053 0054 0055 0056 0057 0058 0059 0060 0061 0062 0063 0064 0065 0066 0067 0068 0069 0070 0071 0072 0073 0074 0075 0076 0077 0078 0079 0080 0081 0082 0083 0084 0085 0086 0087 0088 0089 0090 0091 0093 0094 0095 0096 0097 0098 0099 0100 0101 0102 0104 0105 0106 0107 0108 0109 0110 0111 0112 0113 0114 0115 0116 0117 0118 0119 0120 0121 0122 0123 0124 0125 0126 0127 0128 0129 0130 0131 0132 0133 0134 0135 0136 0137 0138 0139 0140 0141 0142 0143 0144 0145 0146 0147 0148 0149 0150 0151 0152 0153 0154 0155 0156 0157 0158 0159 0160 0161 0162 0163 0164 0165 0166 0167 0168 0169 0170 0171 0172 0173 0174 0175 0176 0177 0178 0179 0180 0183 0184 0185 0186 0187 0188 0189 0190 0191 0192 0193 0194 0195 0196 0197 0198 0199 0200 0201 0202 0203 0204 0205 0206 0207 0208 0209 0210 0211 0212 0213 0214 0215 0216 0217 0218 0219 0220 0221 0222 0223 0224 0225 0226 0227 0228 0229 0230 0231 0232 0233 0234 0235 0236 0237 0238 0239 0240 ', concat(' ', normalize-space(@schemeID), ' '))))">
+          <xsl:attribute name="id">BR-CL-21</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-21]-Item standard identifier scheme identifier MUST belong to the ISO 6523 ICD code list</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:TaxExemptionReasonCode" mode="M13" priority="1004">
+    <svrl:fired-rule context="cbc:TaxExemptionReasonCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(.), ' ')) and contains(' VATEX-EU-79-C VATEX-EU-132 VATEX-EU-132-1A VATEX-EU-132-1B VATEX-EU-132-1C VATEX-EU-132-1D VATEX-EU-132-1E VATEX-EU-132-1F VATEX-EU-132-1G VATEX-EU-132-1H VATEX-EU-132-1I VATEX-EU-132-1J VATEX-EU-132-1K VATEX-EU-132-1L VATEX-EU-132-1M VATEX-EU-132-1N VATEX-EU-132-1O VATEX-EU-132-1P VATEX-EU-132-1Q VATEX-EU-143 VATEX-EU-143-1A VATEX-EU-143-1B VATEX-EU-143-1C VATEX-EU-143-1D VATEX-EU-143-1E VATEX-EU-143-1F VATEX-EU-143-1FA VATEX-EU-143-1G VATEX-EU-143-1H VATEX-EU-143-1I VATEX-EU-143-1J VATEX-EU-143-1K VATEX-EU-143-1L VATEX-EU-144 VATEX-EU-146-1E VATEX-EU-159 VATEX-EU-309 VATEX-EU-148 VATEX-EU-148-A VATEX-EU-148-B VATEX-EU-148-C VATEX-EU-148-D VATEX-EU-148-E VATEX-EU-148-F VATEX-EU-148-G VATEX-EU-151 VATEX-EU-151-1A VATEX-EU-151-1AA VATEX-EU-151-1B VATEX-EU-151-1C VATEX-EU-151-1D VATEX-EU-151-1E VATEX-EU-G VATEX-EU-O VATEX-EU-IC VATEX-EU-AE VATEX-EU-D VATEX-EU-F VATEX-EU-I VATEX-EU-J VATEX-FR-FRANCHISE VATEX-FR-CNWVAT VATEX-EU-153 VATEX-FR-CGI261-1 VATEX-FR-CGI261-2 VATEX-FR-CGI261-3 VATEX-FR-CGI261-4 VATEX-FR-CGI261-5 VATEX-FR-CGI261-7 VATEX-FR-CGI261-8 VATEX-FR-CGI261A VATEX-FR-CGI261B VATEX-FR-CGI261C-1 VATEX-FR-CGI261C-2 VATEX-FR-CGI261C-3 VATEX-FR-CGI261D-1 VATEX-FR-CGI261D-1BIS VATEX-FR-CGI261D-2 VATEX-FR-CGI261D-3 VATEX-FR-CGI261D-4 VATEX-FR-CGI261E-1 VATEX-FR-CGI261E-2 VATEX-FR-CGI277A VATEX-FR-CGI275 VATEX-FR-298SEXDECIESA VATEX-FR-CGI295 VATEX-FR-AE ', concat(' ', normalize-space(upper-case(.)), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(.), ' ')) and contains(' VATEX-EU-79-C VATEX-EU-132 VATEX-EU-132-1A VATEX-EU-132-1B VATEX-EU-132-1C VATEX-EU-132-1D VATEX-EU-132-1E VATEX-EU-132-1F VATEX-EU-132-1G VATEX-EU-132-1H VATEX-EU-132-1I VATEX-EU-132-1J VATEX-EU-132-1K VATEX-EU-132-1L VATEX-EU-132-1M VATEX-EU-132-1N VATEX-EU-132-1O VATEX-EU-132-1P VATEX-EU-132-1Q VATEX-EU-143 VATEX-EU-143-1A VATEX-EU-143-1B VATEX-EU-143-1C VATEX-EU-143-1D VATEX-EU-143-1E VATEX-EU-143-1F VATEX-EU-143-1FA VATEX-EU-143-1G VATEX-EU-143-1H VATEX-EU-143-1I VATEX-EU-143-1J VATEX-EU-143-1K VATEX-EU-143-1L VATEX-EU-144 VATEX-EU-146-1E VATEX-EU-159 VATEX-EU-309 VATEX-EU-148 VATEX-EU-148-A VATEX-EU-148-B VATEX-EU-148-C VATEX-EU-148-D VATEX-EU-148-E VATEX-EU-148-F VATEX-EU-148-G VATEX-EU-151 VATEX-EU-151-1A VATEX-EU-151-1AA VATEX-EU-151-1B VATEX-EU-151-1C VATEX-EU-151-1D VATEX-EU-151-1E VATEX-EU-G VATEX-EU-O VATEX-EU-IC VATEX-EU-AE VATEX-EU-D VATEX-EU-F VATEX-EU-I VATEX-EU-J VATEX-FR-FRANCHISE VATEX-FR-CNWVAT VATEX-EU-153 VATEX-FR-CGI261-1 VATEX-FR-CGI261-2 VATEX-FR-CGI261-3 VATEX-FR-CGI261-4 VATEX-FR-CGI261-5 VATEX-FR-CGI261-7 VATEX-FR-CGI261-8 VATEX-FR-CGI261A VATEX-FR-CGI261B VATEX-FR-CGI261C-1 VATEX-FR-CGI261C-2 VATEX-FR-CGI261C-3 VATEX-FR-CGI261D-1 VATEX-FR-CGI261D-1BIS VATEX-FR-CGI261D-2 VATEX-FR-CGI261D-3 VATEX-FR-CGI261D-4 VATEX-FR-CGI261E-1 VATEX-FR-CGI261E-2 VATEX-FR-CGI277A VATEX-FR-CGI275 VATEX-FR-298SEXDECIESA VATEX-FR-CGI295 VATEX-FR-AE ', concat(' ', normalize-space(upper-case(.)), ' '))))">
+          <xsl:attribute name="id">BR-CL-22</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-22]-Tax exemption reason code identifier scheme identifier MUST belong to the CEF VATEX code list</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:InvoicedQuantity[@unitCode] | cbc:BaseQuantity[@unitCode] | cbc:CreditedQuantity[@unitCode]" mode="M13" priority="1003">
+    <svrl:fired-rule context="cbc:InvoicedQuantity[@unitCode] | cbc:BaseQuantity[@unitCode] | cbc:CreditedQuantity[@unitCode]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(@unitCode), ' ')) and contains(' 10 11 13 14 15 20 21 22 23 24 25 27 28 33 34 35 37 38 40 41 56 57 58 59 60 61 74 77 80 81 85 87 89 91 1I 2A 2B 2C 2G 2H 2I 2J 2K 2L 2M 2N 2P 2Q 2R 2U 2X 2Y 2Z 3B 3C 4C 4G 4H 4K 4L 4M 4N 4O 4P 4Q 4R 4T 4U 4W 4X 5A 5B 5E 5J A10 A11 A12 A13 A14 A15 A16 A17 A18 A19 A2 A20 A21 A22 A23 A24 A26 A27 A28 A29 A3 A30 A31 A32 A33 A34 A35 A36 A37 A38 A39 A4 A40 A41 A42 A43 A44 A45 A47 A48 A49 A5 A53 A54 A55 A56 A59 A6 A68 A69 A7 A70 A71 A73 A74 A75 A76 A8 A84 A85 A86 A87 A88 A89 A9 A90 A91 A93 A94 A95 A96 A97 A98 A99 AA AB ACR ACT AD AE AH AI AK AL AMH AMP ANN APZ AQ AS ASM ASU ATM AWG AY AZ B1 B10 B11 B12 B13 B14 B15 B16 B17 B18 B19 B20 B21 B22 B23 B24 B25 B26 B27 B28 B29 B3 B30 B31 B32 B33 B34 B35 B4 B41 B42 B43 B44 B45 B46 B47 B48 B49 B50 B52 B53 B54 B55 B56 B57 B58 B59 B60 B61 B62 B63 B64 B66 B67 B68 B69 B7 B70 B71 B72 B73 B74 B75 B76 B77 B78 B79 B8 B80 B81 B82 B83 B84 B85 B86 B87 B88 B89 B90 B91 B92 B93 B94 B95 B96 B97 B98 B99 BAR BB BFT BHP BIL BLD BLL BP BPM BQL BTU BUA BUI C0 C10 C11 C12 C13 C14 C15 C16 C17 C18 C19 C20 C21 C22 C23 C24 C25 C26 C27 C28 C29 C3 C30 C31 C32 C33 C34 C35 C36 C37 C38 C39 C40 C41 C42 C43 C44 C45 C46 C47 C48 C49 C50 C51 C52 C53 C54 C55 C56 C57 C58 C59 C60 C61 C62 C63 C64 C65 C66 C67 C68 C69 C7 C70 C71 C72 C73 C74 C75 C76 C78 C79 C8 C80 C81 C82 C83 C84 C85 C86 C87 C88 C89 C9 C90 C91 C92 C93 C94 C95 C96 C97 C99 CCT CDL CEL CEN CG CGM CKG CLF CLT CMK CMQ CMT CNP CNT COU CTG CTM CTN CUR CWA CWI D03 D04 D1 D10 D11 D12 D13 D15 D16 D17 D18 D19 D2 D20 D21 D22 D23 D24 D25 D26 D27 D29 D30 D31 D32 D33 D34 D36 D41 D42 D43 D44 D45 D46 D47 D48 D49 D5 D50 D51 D52 D53 D54 D55 D56 D57 D58 D59 D6 D60 D61 D62 D63 D65 D68 D69 D73 D74 D77 D78 D80 D81 D82 D83 D85 D86 D87 D88 D89 D91 D93 D94 D95 DAA DAD DAY DB DBM DBW DD DEC DG DJ DLT DMA DMK DMO DMQ DMT DN DPC DPR DPT DRA DRI DRL DT DTN DWT DZN DZP E01 E07 E08 E09 E10 E12 E14 E15 E16 E17 E18 E19 E20 E21 E22 E23 E25 E27 E28 E30 E31 E32 E33 E34 E35 E36 E37 E38 E39 E4 E40 E41 E42 E43 E44 E45 E46 E47 E48 E49 E50 E51 E52 E53 E54 E55 E56 E57 E58 E59 E60 E61 E62 E63 E64 E65 E66 E67 E68 E69 E70 E71 E72 E73 E74 E75 E76 E77 E78 E79 E80 E81 E82 E83 E84 E85 E86 E87 E88 E89 E90 E91 E92 E93 E94 E95 E96 E97 E98 E99 EA EB EQ F01 F02 F03 F04 F05 F06 F07 F08 F10 F11 F12 F13 F14 F15 F16 F17 F18 F19 F20 F21 F22 F23 F24 F25 F26 F27 F28 F29 F30 F31 F32 F33 F34 F35 F36 F37 F38 F39 F40 F41 F42 F43 F44 F45 F46 F47 F48 F49 F50 F51 F52 F53 F54 F55 F56 F57 F58 F59 F60 F61 F62 F63 F64 F65 F66 F67 F68 F69 F70 F71 F72 F73 F74 F75 F76 F77 F78 F79 F80 F81 F82 F83 F84 F85 F86 F87 F88 F89 F90 F91 F92 F93 F94 F95 F96 F97 F98 F99 FAH FAR FBM FC FF FH FIT FL FNU FOT FP FR FS FTK FTQ G01 G04 G05 G06 G08 G09 G10 G11 G12 G13 G14 G15 G16 G17 G18 G19 G2 G20 G21 G23 G24 G25 G26 G27 G28 G29 G3 G30 G31 G32 G33 G34 G35 G36 G37 G38 G39 G40 G41 G42 G43 G44 G45 G46 G47 G48 G49 G50 G51 G52 G53 G54 G55 G56 G57 G58 G59 G60 G61 G62 G63 G64 G65 G66 G67 G68 G69 G70 G71 G72 G73 G74 G75 G76 G77 G78 G79 G80 G81 G82 G83 G84 G85 G86 G87 G88 G89 G90 G91 G92 G93 G94 G95 G96 G97 G98 G99 GB GBQ GDW GE GF GFI GGR GIA GIC GII GIP GJ GL GLD GLI GLL GM GO GP GQ GRM GRN GRO GV GWH H03 H04 H05 H06 H07 H08 H09 H10 H11 H12 H13 H14 H15 H16 H18 H19 H20 H21 H22 H23 H24 H25 H26 H27 H28 H29 H30 H31 H32 H33 H34 H35 H36 H37 H38 H39 H40 H41 H42 H43 H44 H45 H46 H47 H48 H49 H50 H51 H52 H53 H54 H55 H56 H57 H58 H59 H60 H61 H62 H63 H64 H65 H66 H67 H68 H69 H70 H71 H72 H73 H74 H75 H76 H77 H79 H80 H81 H82 H83 H84 H85 H87 H88 H89 H90 H91 H92 H93 H94 H95 H96 H98 H99 HA HAD HBA HBX HC HDW HEA HGM HH HIU HKM HLT HM HMO HMQ HMT HPA HTZ HUR HWE IA IE INH INK INQ ISD IU IUG IV J10 J12 J13 J14 J15 J16 J17 J18 J19 J2 J20 J21 J22 J23 J24 J25 J26 J27 J28 J29 J30 J31 J32 J33 J34 J35 J36 J38 J39 J40 J41 J42 J43 J44 J45 J46 J47 J48 J49 J50 J51 J52 J53 J54 J55 J56 J57 J58 J59 J60 J61 J62 J63 J64 J65 J66 J67 J68 J69 J70 J71 J72 J73 J74 J75 J76 J78 J79 J81 J82 J83 J84 J85 J87 J90 J91 J92 J93 J95 J96 J97 J98 J99 JE JK JM JNT JOU JPS JWL K1 K10 K11 K12 K13 K14 K15 K16 K17 K18 K19 K2 K20 K21 K22 K23 K26 K27 K28 K3 K30 K31 K32 K33 K34 K35 K36 K37 K38 K39 K40 K41 K42 K43 K45 K46 K47 K48 K49 K50 K51 K52 K53 K54 K55 K58 K59 K6 K60 K61 K62 K63 K64 K65 K66 K67 K68 K69 K70 K71 K73 K74 K75 K76 K77 K78 K79 K80 K81 K82 K83 K84 K85 K86 K87 K88 K89 K90 K91 K92 K93 K94 K95 K96 K97 K98 K99 KA KAT KB KBA KCC KDW KEL KGM KGS KHY KHZ KI KIC KIP KJ KJO KL KLK KLX KMA KMH KMK KMQ KMT KNI KNM KNS KNT KO KPA KPH KPO KPP KR KSD KSH KT KTN KUR KVA KVR KVT KW KWH KWN KWO KWS KWT KWY KX L10 L11 L12 L13 L14 L15 L16 L17 L18 L19 L2 L20 L21 L23 L24 L25 L26 L27 L28 L29 L30 L31 L32 L33 L34 L35 L36 L37 L38 L39 L40 L41 L42 L43 L44 L45 L46 L47 L48 L49 L50 L51 L52 L53 L54 L55 L56 L57 L58 L59 L60 L63 L64 L65 L66 L67 L68 L69 L70 L71 L72 L73 L74 L75 L76 L77 L78 L79 L80 L81 L82 L83 L84 L85 L86 L87 L88 L89 L90 L91 L92 L93 L94 L95 L96 L98 L99 LA LAC LBR LBT LD LEF LF LH LK LM LN LO LP LPA LR LS LTN LTR LUB LUM LUX LY M1 M10 M11 M12 M13 M14 M15 M16 M17 M18 M19 M20 M21 M22 M23 M24 M25 M26 M27 M29 M30 M31 M32 M33 M34 M35 M36 M37 M38 M39 M4 M40 M41 M42 M43 M44 M45 M46 M47 M48 M49 M5 M50 M51 M52 M53 M55 M56 M57 M58 M59 M60 M61 M62 M63 M64 M65 M66 M67 M68 M69 M7 M70 M71 M72 M73 M74 M75 M76 M77 M78 M79 M80 M81 M82 M83 M84 M85 M86 M87 M88 M89 M9 M90 M91 M92 M93 M94 M95 M96 M97 M98 M99 MAH MAL MAM MAR MAW MBE MBF MBR MC MCU MD MGM MHZ MIK MIL MIN MIO MIU MKD MKM MKW MLD MLT MMK MMQ MMT MND MNJ MON MPA MQD MQH MQM MQS MQW MRD MRM MRW MSK MTK MTQ MTR MTS MTZ MVA MWH N1 N10 N11 N12 N13 N14 N15 N16 N17 N18 N19 N20 N21 N22 N23 N24 N25 N26 N27 N28 N29 N3 N30 N31 N32 N33 N34 N35 N36 N37 N38 N39 N40 N41 N42 N43 N44 N45 N46 N47 N48 N49 N50 N51 N52 N53 N54 N55 N56 N57 N58 N59 N60 N61 N62 N63 N64 N65 N66 N67 N68 N69 N70 N71 N72 N73 N74 N75 N76 N77 N78 N79 N80 N81 N82 N83 N84 N85 N86 N87 N88 N89 N90 N91 N92 N93 N94 N95 N96 N97 N98 N99 NA NAR NCL NEW NF NIL NIU NL NM3 NMI NMP NPT NT NTU NU NX OA ODE ODG ODK ODM OHM ON ONZ OPM OT OZA OZI P1 P10 P11 P12 P13 P14 P15 P16 P17 P18 P19 P2 P20 P21 P22 P23 P24 P25 P26 P27 P28 P29 P30 P31 P32 P33 P34 P35 P36 P37 P38 P39 P40 P41 P42 P43 P44 P45 P46 P47 P48 P49 P5 P50 P51 P52 P53 P54 P55 P56 P57 P58 P59 P60 P61 P62 P63 P64 P65 P66 P67 P68 P69 P70 P71 P72 P73 P74 P75 P76 P77 P78 P79 P80 P81 P82 P83 P84 P85 P86 P87 P88 P89 P90 P91 P92 P93 P94 P95 P96 P97 P98 P99 PAL PD PFL PGL PI PLA PO PQ PR PS PTD PTI PTL PTN Q10 Q11 Q12 Q13 Q14 Q15 Q16 Q17 Q18 Q19 Q20 Q21 Q22 Q23 Q24 Q25 Q26 Q27 Q28 Q29 Q3 Q30 Q31 Q32 Q33 Q34 Q35 Q36 Q37 Q38 Q39 Q40 Q41 Q42 QA QAN QB QR QTD QTI QTL QTR R1 R9 RH RM ROM RP RPM RPS RT S3 S4 SAN SCO SCR SEC SET SG SIE SM3 SMI SQ SQR SR STC STI STK STL STN STW SW SX SYR T0 T3 TAH TAN TI TIC TIP TKM TMS TNE TP TPI TPR TQD TRL TST TTS U1 U2 UB UC VA VLT VP W2 WA WB WCD WE WEB WEE WG WHR WM WSD WTT X1 YDK YDQ YRD Z11 Z9 ZP ZZ X1A X1B X1D X1F X1G X1W X2C X3A X3H X43 X44 X4A X4B X4C X4D X4F X4G X4H X5H X5L X5M X6H X6P X7A X7B X8A X8B X8C XAA XAB XAC XAD XAE XAF XAG XAH XAI XAJ XAL XAM XAP XAT XAV XB4 XBA XBB XBC XBD XBE XBF XBG XBH XBI XBJ XBK XBL XBM XBN XBO XBP XBQ XBR XBS XBT XBU XBV XBW XBX XBY XBZ XCA XCB XCC XCD XCE XCF XCG XCH XCI XCJ XCK XCL XCM XCN XCO XCP XCQ XCR XCS XCT XCU XCV XCW XCX XCY XCZ XDA XDB XDC XDG XDH XDI XDJ XDK XDL XDM XDN XDP XDR XDS XDT XDU XDV XDW XDX XDY XEC XED XEE XEF XEG XEH XEI XEN XFB XFC XFD XFE XFI XFL XFO XFP XFR XFT XFW XFX XGB XGI XGL XGR XGU XGY XGZ XHA XHB XHC XHG XHN XHR XIA XIB XIC XID XIE XIF XIG XIH XIK XIL XIN XIZ XJB XJC XJG XJR XJT XJY XKG XKI XLE XLG XLT XLU XLV XLZ XMA XMB XMC XME XMR XMS XMT XMW XMX XNA XNE XNF XNG XNS XNT XNU XNV XO1 XO2 XO3 XO4 XO5 XO6 XO7 XO8 XO9 XOA XOB XOC XOD XOE XOF XOG XOH XOI XOJ XOK XOL XOM XON XOP XOQ XOR XOS XOT XOU XOV XOW XOX XOY XOZ XP1 XP2 XP3 XP4 XPA XPB XPC XPD XPE XPF XPG XPH XPI XPJ XPK XPL XPN XPO XPP XPR XPT XPU XPV XPX XPY XPZ XQA XQB XQC XQD XQF XQG XQH XQJ XQK XQL XQM XQN XQP XQQ XQR XQS XRD XRG XRJ XRK XRL XRO XRT XRZ XSA XSB XSC XSD XSE XSH XSI XSK XSL XSM XSO XSP XSS XST XSU XSV XSW XSX XSY XSZ XT1 XTB XTC XTD XTE XTG XTI XTK XTL XTN XTO XTR XTS XTT XTU XTV XTW XTY XTZ XUC XUN XVA XVG XVI XVK XVL XVN XVO XVP XVQ XVR XVS XVY XWA XWB XWC XWD XWF XWG XWH XWJ XWK XWL XWM XWN XWP XWQ XWR XWS XWT XWU XWV XWW XWX XWY XWZ XXA XXB XXC XXD XXF XXG XXH XXJ XXK XYA XYB XYC XYD XYF XYG XYH XYJ XYK XYL XYM XYN XYP XYQ XYR XYS XYT XYV XYW XYX XYY XYZ XZA XZB XZC XZD XZF XZG XZH XZJ XZK XZL XZM XZN XZP XZQ XZR XZS XZT XZU XZV XZW XZX XZY XZZ ', concat(' ', normalize-space(@unitCode), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(@unitCode), ' ')) and contains(' 10 11 13 14 15 20 21 22 23 24 25 27 28 33 34 35 37 38 40 41 56 57 58 59 60 61 74 77 80 81 85 87 89 91 1I 2A 2B 2C 2G 2H 2I 2J 2K 2L 2M 2N 2P 2Q 2R 2U 2X 2Y 2Z 3B 3C 4C 4G 4H 4K 4L 4M 4N 4O 4P 4Q 4R 4T 4U 4W 4X 5A 5B 5E 5J A10 A11 A12 A13 A14 A15 A16 A17 A18 A19 A2 A20 A21 A22 A23 A24 A26 A27 A28 A29 A3 A30 A31 A32 A33 A34 A35 A36 A37 A38 A39 A4 A40 A41 A42 A43 A44 A45 A47 A48 A49 A5 A53 A54 A55 A56 A59 A6 A68 A69 A7 A70 A71 A73 A74 A75 A76 A8 A84 A85 A86 A87 A88 A89 A9 A90 A91 A93 A94 A95 A96 A97 A98 A99 AA AB ACR ACT AD AE AH AI AK AL AMH AMP ANN APZ AQ AS ASM ASU ATM AWG AY AZ B1 B10 B11 B12 B13 B14 B15 B16 B17 B18 B19 B20 B21 B22 B23 B24 B25 B26 B27 B28 B29 B3 B30 B31 B32 B33 B34 B35 B4 B41 B42 B43 B44 B45 B46 B47 B48 B49 B50 B52 B53 B54 B55 B56 B57 B58 B59 B60 B61 B62 B63 B64 B66 B67 B68 B69 B7 B70 B71 B72 B73 B74 B75 B76 B77 B78 B79 B8 B80 B81 B82 B83 B84 B85 B86 B87 B88 B89 B90 B91 B92 B93 B94 B95 B96 B97 B98 B99 BAR BB BFT BHP BIL BLD BLL BP BPM BQL BTU BUA BUI C0 C10 C11 C12 C13 C14 C15 C16 C17 C18 C19 C20 C21 C22 C23 C24 C25 C26 C27 C28 C29 C3 C30 C31 C32 C33 C34 C35 C36 C37 C38 C39 C40 C41 C42 C43 C44 C45 C46 C47 C48 C49 C50 C51 C52 C53 C54 C55 C56 C57 C58 C59 C60 C61 C62 C63 C64 C65 C66 C67 C68 C69 C7 C70 C71 C72 C73 C74 C75 C76 C78 C79 C8 C80 C81 C82 C83 C84 C85 C86 C87 C88 C89 C9 C90 C91 C92 C93 C94 C95 C96 C97 C99 CCT CDL CEL CEN CG CGM CKG CLF CLT CMK CMQ CMT CNP CNT COU CTG CTM CTN CUR CWA CWI D03 D04 D1 D10 D11 D12 D13 D15 D16 D17 D18 D19 D2 D20 D21 D22 D23 D24 D25 D26 D27 D29 D30 D31 D32 D33 D34 D36 D41 D42 D43 D44 D45 D46 D47 D48 D49 D5 D50 D51 D52 D53 D54 D55 D56 D57 D58 D59 D6 D60 D61 D62 D63 D65 D68 D69 D73 D74 D77 D78 D80 D81 D82 D83 D85 D86 D87 D88 D89 D91 D93 D94 D95 DAA DAD DAY DB DBM DBW DD DEC DG DJ DLT DMA DMK DMO DMQ DMT DN DPC DPR DPT DRA DRI DRL DT DTN DWT DZN DZP E01 E07 E08 E09 E10 E12 E14 E15 E16 E17 E18 E19 E20 E21 E22 E23 E25 E27 E28 E30 E31 E32 E33 E34 E35 E36 E37 E38 E39 E4 E40 E41 E42 E43 E44 E45 E46 E47 E48 E49 E50 E51 E52 E53 E54 E55 E56 E57 E58 E59 E60 E61 E62 E63 E64 E65 E66 E67 E68 E69 E70 E71 E72 E73 E74 E75 E76 E77 E78 E79 E80 E81 E82 E83 E84 E85 E86 E87 E88 E89 E90 E91 E92 E93 E94 E95 E96 E97 E98 E99 EA EB EQ F01 F02 F03 F04 F05 F06 F07 F08 F10 F11 F12 F13 F14 F15 F16 F17 F18 F19 F20 F21 F22 F23 F24 F25 F26 F27 F28 F29 F30 F31 F32 F33 F34 F35 F36 F37 F38 F39 F40 F41 F42 F43 F44 F45 F46 F47 F48 F49 F50 F51 F52 F53 F54 F55 F56 F57 F58 F59 F60 F61 F62 F63 F64 F65 F66 F67 F68 F69 F70 F71 F72 F73 F74 F75 F76 F77 F78 F79 F80 F81 F82 F83 F84 F85 F86 F87 F88 F89 F90 F91 F92 F93 F94 F95 F96 F97 F98 F99 FAH FAR FBM FC FF FH FIT FL FNU FOT FP FR FS FTK FTQ G01 G04 G05 G06 G08 G09 G10 G11 G12 G13 G14 G15 G16 G17 G18 G19 G2 G20 G21 G23 G24 G25 G26 G27 G28 G29 G3 G30 G31 G32 G33 G34 G35 G36 G37 G38 G39 G40 G41 G42 G43 G44 G45 G46 G47 G48 G49 G50 G51 G52 G53 G54 G55 G56 G57 G58 G59 G60 G61 G62 G63 G64 G65 G66 G67 G68 G69 G70 G71 G72 G73 G74 G75 G76 G77 G78 G79 G80 G81 G82 G83 G84 G85 G86 G87 G88 G89 G90 G91 G92 G93 G94 G95 G96 G97 G98 G99 GB GBQ GDW GE GF GFI GGR GIA GIC GII GIP GJ GL GLD GLI GLL GM GO GP GQ GRM GRN GRO GV GWH H03 H04 H05 H06 H07 H08 H09 H10 H11 H12 H13 H14 H15 H16 H18 H19 H20 H21 H22 H23 H24 H25 H26 H27 H28 H29 H30 H31 H32 H33 H34 H35 H36 H37 H38 H39 H40 H41 H42 H43 H44 H45 H46 H47 H48 H49 H50 H51 H52 H53 H54 H55 H56 H57 H58 H59 H60 H61 H62 H63 H64 H65 H66 H67 H68 H69 H70 H71 H72 H73 H74 H75 H76 H77 H79 H80 H81 H82 H83 H84 H85 H87 H88 H89 H90 H91 H92 H93 H94 H95 H96 H98 H99 HA HAD HBA HBX HC HDW HEA HGM HH HIU HKM HLT HM HMO HMQ HMT HPA HTZ HUR HWE IA IE INH INK INQ ISD IU IUG IV J10 J12 J13 J14 J15 J16 J17 J18 J19 J2 J20 J21 J22 J23 J24 J25 J26 J27 J28 J29 J30 J31 J32 J33 J34 J35 J36 J38 J39 J40 J41 J42 J43 J44 J45 J46 J47 J48 J49 J50 J51 J52 J53 J54 J55 J56 J57 J58 J59 J60 J61 J62 J63 J64 J65 J66 J67 J68 J69 J70 J71 J72 J73 J74 J75 J76 J78 J79 J81 J82 J83 J84 J85 J87 J90 J91 J92 J93 J95 J96 J97 J98 J99 JE JK JM JNT JOU JPS JWL K1 K10 K11 K12 K13 K14 K15 K16 K17 K18 K19 K2 K20 K21 K22 K23 K26 K27 K28 K3 K30 K31 K32 K33 K34 K35 K36 K37 K38 K39 K40 K41 K42 K43 K45 K46 K47 K48 K49 K50 K51 K52 K53 K54 K55 K58 K59 K6 K60 K61 K62 K63 K64 K65 K66 K67 K68 K69 K70 K71 K73 K74 K75 K76 K77 K78 K79 K80 K81 K82 K83 K84 K85 K86 K87 K88 K89 K90 K91 K92 K93 K94 K95 K96 K97 K98 K99 KA KAT KB KBA KCC KDW KEL KGM KGS KHY KHZ KI KIC KIP KJ KJO KL KLK KLX KMA KMH KMK KMQ KMT KNI KNM KNS KNT KO KPA KPH KPO KPP KR KSD KSH KT KTN KUR KVA KVR KVT KW KWH KWN KWO KWS KWT KWY KX L10 L11 L12 L13 L14 L15 L16 L17 L18 L19 L2 L20 L21 L23 L24 L25 L26 L27 L28 L29 L30 L31 L32 L33 L34 L35 L36 L37 L38 L39 L40 L41 L42 L43 L44 L45 L46 L47 L48 L49 L50 L51 L52 L53 L54 L55 L56 L57 L58 L59 L60 L63 L64 L65 L66 L67 L68 L69 L70 L71 L72 L73 L74 L75 L76 L77 L78 L79 L80 L81 L82 L83 L84 L85 L86 L87 L88 L89 L90 L91 L92 L93 L94 L95 L96 L98 L99 LA LAC LBR LBT LD LEF LF LH LK LM LN LO LP LPA LR LS LTN LTR LUB LUM LUX LY M1 M10 M11 M12 M13 M14 M15 M16 M17 M18 M19 M20 M21 M22 M23 M24 M25 M26 M27 M29 M30 M31 M32 M33 M34 M35 M36 M37 M38 M39 M4 M40 M41 M42 M43 M44 M45 M46 M47 M48 M49 M5 M50 M51 M52 M53 M55 M56 M57 M58 M59 M60 M61 M62 M63 M64 M65 M66 M67 M68 M69 M7 M70 M71 M72 M73 M74 M75 M76 M77 M78 M79 M80 M81 M82 M83 M84 M85 M86 M87 M88 M89 M9 M90 M91 M92 M93 M94 M95 M96 M97 M98 M99 MAH MAL MAM MAR MAW MBE MBF MBR MC MCU MD MGM MHZ MIK MIL MIN MIO MIU MKD MKM MKW MLD MLT MMK MMQ MMT MND MNJ MON MPA MQD MQH MQM MQS MQW MRD MRM MRW MSK MTK MTQ MTR MTS MTZ MVA MWH N1 N10 N11 N12 N13 N14 N15 N16 N17 N18 N19 N20 N21 N22 N23 N24 N25 N26 N27 N28 N29 N3 N30 N31 N32 N33 N34 N35 N36 N37 N38 N39 N40 N41 N42 N43 N44 N45 N46 N47 N48 N49 N50 N51 N52 N53 N54 N55 N56 N57 N58 N59 N60 N61 N62 N63 N64 N65 N66 N67 N68 N69 N70 N71 N72 N73 N74 N75 N76 N77 N78 N79 N80 N81 N82 N83 N84 N85 N86 N87 N88 N89 N90 N91 N92 N93 N94 N95 N96 N97 N98 N99 NA NAR NCL NEW NF NIL NIU NL NM3 NMI NMP NPT NT NTU NU NX OA ODE ODG ODK ODM OHM ON ONZ OPM OT OZA OZI P1 P10 P11 P12 P13 P14 P15 P16 P17 P18 P19 P2 P20 P21 P22 P23 P24 P25 P26 P27 P28 P29 P30 P31 P32 P33 P34 P35 P36 P37 P38 P39 P40 P41 P42 P43 P44 P45 P46 P47 P48 P49 P5 P50 P51 P52 P53 P54 P55 P56 P57 P58 P59 P60 P61 P62 P63 P64 P65 P66 P67 P68 P69 P70 P71 P72 P73 P74 P75 P76 P77 P78 P79 P80 P81 P82 P83 P84 P85 P86 P87 P88 P89 P90 P91 P92 P93 P94 P95 P96 P97 P98 P99 PAL PD PFL PGL PI PLA PO PQ PR PS PTD PTI PTL PTN Q10 Q11 Q12 Q13 Q14 Q15 Q16 Q17 Q18 Q19 Q20 Q21 Q22 Q23 Q24 Q25 Q26 Q27 Q28 Q29 Q3 Q30 Q31 Q32 Q33 Q34 Q35 Q36 Q37 Q38 Q39 Q40 Q41 Q42 QA QAN QB QR QTD QTI QTL QTR R1 R9 RH RM ROM RP RPM RPS RT S3 S4 SAN SCO SCR SEC SET SG SIE SM3 SMI SQ SQR SR STC STI STK STL STN STW SW SX SYR T0 T3 TAH TAN TI TIC TIP TKM TMS TNE TP TPI TPR TQD TRL TST TTS U1 U2 UB UC VA VLT VP W2 WA WB WCD WE WEB WEE WG WHR WM WSD WTT X1 YDK YDQ YRD Z11 Z9 ZP ZZ X1A X1B X1D X1F X1G X1W X2C X3A X3H X43 X44 X4A X4B X4C X4D X4F X4G X4H X5H X5L X5M X6H X6P X7A X7B X8A X8B X8C XAA XAB XAC XAD XAE XAF XAG XAH XAI XAJ XAL XAM XAP XAT XAV XB4 XBA XBB XBC XBD XBE XBF XBG XBH XBI XBJ XBK XBL XBM XBN XBO XBP XBQ XBR XBS XBT XBU XBV XBW XBX XBY XBZ XCA XCB XCC XCD XCE XCF XCG XCH XCI XCJ XCK XCL XCM XCN XCO XCP XCQ XCR XCS XCT XCU XCV XCW XCX XCY XCZ XDA XDB XDC XDG XDH XDI XDJ XDK XDL XDM XDN XDP XDR XDS XDT XDU XDV XDW XDX XDY XEC XED XEE XEF XEG XEH XEI XEN XFB XFC XFD XFE XFI XFL XFO XFP XFR XFT XFW XFX XGB XGI XGL XGR XGU XGY XGZ XHA XHB XHC XHG XHN XHR XIA XIB XIC XID XIE XIF XIG XIH XIK XIL XIN XIZ XJB XJC XJG XJR XJT XJY XKG XKI XLE XLG XLT XLU XLV XLZ XMA XMB XMC XME XMR XMS XMT XMW XMX XNA XNE XNF XNG XNS XNT XNU XNV XO1 XO2 XO3 XO4 XO5 XO6 XO7 XO8 XO9 XOA XOB XOC XOD XOE XOF XOG XOH XOI XOJ XOK XOL XOM XON XOP XOQ XOR XOS XOT XOU XOV XOW XOX XOY XOZ XP1 XP2 XP3 XP4 XPA XPB XPC XPD XPE XPF XPG XPH XPI XPJ XPK XPL XPN XPO XPP XPR XPT XPU XPV XPX XPY XPZ XQA XQB XQC XQD XQF XQG XQH XQJ XQK XQL XQM XQN XQP XQQ XQR XQS XRD XRG XRJ XRK XRL XRO XRT XRZ XSA XSB XSC XSD XSE XSH XSI XSK XSL XSM XSO XSP XSS XST XSU XSV XSW XSX XSY XSZ XT1 XTB XTC XTD XTE XTG XTI XTK XTL XTN XTO XTR XTS XTT XTU XTV XTW XTY XTZ XUC XUN XVA XVG XVI XVK XVL XVN XVO XVP XVQ XVR XVS XVY XWA XWB XWC XWD XWF XWG XWH XWJ XWK XWL XWM XWN XWP XWQ XWR XWS XWT XWU XWV XWW XWX XWY XWZ XXA XXB XXC XXD XXF XXG XXH XXJ XXK XYA XYB XYC XYD XYF XYG XYH XYJ XYK XYL XYM XYN XYP XYQ XYR XYS XYT XYV XYW XYX XYY XYZ XZA XZB XZC XZD XZF XZG XZH XZJ XZK XZL XZM XZN XZP XZQ XZR XZS XZT XZU XZV XZW XZX XZY XZZ ', concat(' ', normalize-space(@unitCode), ' '))))">
+          <xsl:attribute name="id">BR-CL-23</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-23]-Unit code MUST be coded according to the UN/ECE Recommendation 20 with
+      Rec 21 extension</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EmbeddedDocumentBinaryObject[@mimeCode]" mode="M13" priority="1002">
+    <svrl:fired-rule context="cbc:EmbeddedDocumentBinaryObject[@mimeCode]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((@mimeCode = 'application/pdf' or @mimeCode = 'image/png' or @mimeCode = 'image/jpeg' or @mimeCode = 'text/csv' or @mimeCode = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' or @mimeCode = 'application/vnd.oasis.opendocument.spreadsheet'))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((@mimeCode = 'application/pdf' or @mimeCode = 'image/png' or @mimeCode = 'image/jpeg' or @mimeCode = 'text/csv' or @mimeCode = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' or @mimeCode = 'application/vnd.oasis.opendocument.spreadsheet'))">
+          <xsl:attribute name="id">BR-CL-24</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-24]-For Mime code in attribute use MIMEMediaType.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID]" mode="M13" priority="1001">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' 0002 0007 0009 0037 0060 0088 0096 0097 0106 0130 0135 0142 0147 0151 0154 0158 0170 0177 0183 0184 0188 0190 0191 0192 0193 0194 0195 0196 0198 0199 0200 0201 0202 0203 0204 0205 0208 0209 0210 0211 0212 0213 0215 0216 0217 0218 0219 0220 0221 0225 0230 0235 0240 9910 9913 9914 9915 9918 9919 9920 9922 9923 9924 9925 9926 9927 9928 9929 9930 9931 9932 9933 9934 9935 9936 9937 9938 9939 9940 9941 9942 9943 9944 9945 9946 9947 9948 9949 9950 9951 9952 9953 9957 9959 AN AQ AS AU EM ', concat(' ', normalize-space(@schemeID), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' 0002 0007 0009 0037 0060 0088 0096 0097 0106 0130 0135 0142 0147 0151 0154 0158 0170 0177 0183 0184 0188 0190 0191 0192 0193 0194 0195 0196 0198 0199 0200 0201 0202 0203 0204 0205 0208 0209 0210 0211 0212 0213 0215 0216 0217 0218 0219 0220 0221 0225 0230 0235 0240 9910 9913 9914 9915 9918 9919 9920 9922 9923 9924 9925 9926 9927 9928 9929 9930 9931 9932 9933 9934 9935 9936 9937 9938 9939 9940 9941 9942 9943 9944 9945 9946 9947 9948 9949 9950 9951 9952 9953 9957 9959 AN AQ AS AU EM ', concat(' ', normalize-space(@schemeID), ' '))))">
+          <xsl:attribute name="id">BR-CL-25</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-25]-Endpoint identifier scheme identifier MUST belong to the CEF EAS code list</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:DeliveryLocation/cbc:ID[@schemeID]" mode="M13" priority="1000">
+    <svrl:fired-rule context="cac:DeliveryLocation/cbc:ID[@schemeID]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' 0002 0003 0004 0005 0006 0007 0008 0009 0010 0011 0012 0013 0014 0015 0016 0017 0018 0019 0020 0021 0022 0023 0024 0025 0026 0027 0028 0029 0030 0031 0032 0033 0034 0035 0036 0037 0038 0039 0040 0041 0042 0043 0044 0045 0046 0047 0048 0049 0050 0051 0052 0053 0054 0055 0056 0057 0058 0059 0060 0061 0062 0063 0064 0065 0066 0067 0068 0069 0070 0071 0072 0073 0074 0075 0076 0077 0078 0079 0080 0081 0082 0083 0084 0085 0086 0087 0088 0089 0090 0091 0093 0094 0095 0096 0097 0098 0099 0100 0101 0102 0104 0105 0106 0107 0108 0109 0110 0111 0112 0113 0114 0115 0116 0117 0118 0119 0120 0121 0122 0123 0124 0125 0126 0127 0128 0129 0130 0131 0132 0133 0134 0135 0136 0137 0138 0139 0140 0141 0142 0143 0144 0145 0146 0147 0148 0149 0150 0151 0152 0153 0154 0155 0156 0157 0158 0159 0160 0161 0162 0163 0164 0165 0166 0167 0168 0169 0170 0171 0172 0173 0174 0175 0176 0177 0178 0179 0180 0183 0184 0185 0186 0187 0188 0189 0190 0191 0192 0193 0194 0195 0196 0197 0198 0199 0200 0201 0202 0203 0204 0205 0206 0207 0208 0209 0210 0211 0212 0213 0214 0215 0216 0217 0218 0219 0220 0221 0222 0223 0224 0225 0226 0227 0228 0229 0230 0231 0232 0233 0234 0235 0236 0237 0238 0239 0240 ', concat(' ', normalize-space(@schemeID), ' '))))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(contains(normalize-space(@schemeID), ' ')) and contains(' 0002 0003 0004 0005 0006 0007 0008 0009 0010 0011 0012 0013 0014 0015 0016 0017 0018 0019 0020 0021 0022 0023 0024 0025 0026 0027 0028 0029 0030 0031 0032 0033 0034 0035 0036 0037 0038 0039 0040 0041 0042 0043 0044 0045 0046 0047 0048 0049 0050 0051 0052 0053 0054 0055 0056 0057 0058 0059 0060 0061 0062 0063 0064 0065 0066 0067 0068 0069 0070 0071 0072 0073 0074 0075 0076 0077 0078 0079 0080 0081 0082 0083 0084 0085 0086 0087 0088 0089 0090 0091 0093 0094 0095 0096 0097 0098 0099 0100 0101 0102 0104 0105 0106 0107 0108 0109 0110 0111 0112 0113 0114 0115 0116 0117 0118 0119 0120 0121 0122 0123 0124 0125 0126 0127 0128 0129 0130 0131 0132 0133 0134 0135 0136 0137 0138 0139 0140 0141 0142 0143 0144 0145 0146 0147 0148 0149 0150 0151 0152 0153 0154 0155 0156 0157 0158 0159 0160 0161 0162 0163 0164 0165 0166 0167 0168 0169 0170 0171 0172 0173 0174 0175 0176 0177 0178 0179 0180 0183 0184 0185 0186 0187 0188 0189 0190 0191 0192 0193 0194 0195 0196 0197 0198 0199 0200 0201 0202 0203 0204 0205 0206 0207 0208 0209 0210 0211 0212 0213 0214 0215 0216 0217 0218 0219 0220 0221 0222 0223 0224 0225 0226 0227 0228 0229 0230 0231 0232 0233 0234 0235 0236 0237 0238 0239 0240 ', concat(' ', normalize-space(@schemeID), ' '))))">
+          <xsl:attribute name="id">BR-CL-26</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[BR-CL-26]-Delivery location identifier scheme identifier MUST belong to the ISO 6523 ICD code list</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M13" priority="-1" />
+  <xsl:template match="@*|node()" mode="M13" priority="-2">
+    <xsl:apply-templates mode="M13" select="@*|*" />
+  </xsl:template>
+</xsl:stylesheet>

--- a/data/kosit/bis/resources/peppol/billing-bis/3.0.19/PEPPOL-EN16931-UBL.xslt
+++ b/data/kosit/bis/resources/peppol/billing-bis/3.0.19/PEPPOL-EN16931-UBL.xslt
@@ -1,0 +1,3405 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xsl:stylesheet xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:iso="http://purl.oclc.org/dsdl/schematron" xmlns:saxon="http://saxon.sf.net/" xmlns:schold="http://www.ascc.net/xml/schematron" xmlns:u="utils" xmlns:ubl-creditnote="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:ubl-invoice="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<!--Implementers: please note that overriding process-prolog or process-root is 
+    the preferred method for meta-stylesheets to use where possible. -->
+
+<xsl:param name="archiveDirParameter" />
+  <xsl:param name="archiveNameParameter" />
+  <xsl:param name="fileNameParameter" />
+  <xsl:param name="fileDirParameter" />
+  <xsl:variable name="document-uri">
+    <xsl:value-of select="document-uri(/)" />
+  </xsl:variable>
+
+<!--PHASES-->
+
+
+<!--PROLOG-->
+<xsl:output indent="yes" method="xml" omit-xml-declaration="no" standalone="yes" />
+
+<!--XSD TYPES FOR XSLT2-->
+
+
+<!--KEYS AND FUNCTIONS-->
+<xsl:function as="xs:boolean" name="u:gln">
+    <xsl:param name="val" />
+    <xsl:variable name="length" select="string-length($val) - 1" />
+    <xsl:variable name="digits" select="reverse(for $i in string-to-codepoints(substring($val, 0, $length + 1)) return $i - 48)" />
+    <xsl:variable name="weightedSum" select="sum(for $i in (0 to $length - 1) return $digits[$i + 1] * (1 + ((($i + 1) mod 2) * 2)))" />
+    <xsl:value-of select="(10 - ($weightedSum mod 10)) mod 10 = number(substring($val, $length + 1, 1))" />
+  </xsl:function>
+  <xsl:function as="xs:boolean" name="u:slack">
+    <xsl:param as="xs:decimal" name="exp" />
+    <xsl:param as="xs:decimal" name="val" />
+    <xsl:param as="xs:decimal" name="slack" />
+    <xsl:value-of select="xs:decimal($exp + $slack) >= $val and xs:decimal($exp - $slack) &lt;= $val" />
+  </xsl:function>
+  <xsl:function as="xs:boolean" name="u:mod11">
+    <xsl:param name="val" />
+    <xsl:variable name="length" select="string-length($val) - 1" />
+    <xsl:variable name="digits" select="reverse(for $i in string-to-codepoints(substring($val, 0, $length + 1)) return $i - 48)" />
+    <xsl:variable name="weightedSum" select="sum(for $i in (0 to $length - 1) return $digits[$i + 1] * (($i mod 6) + 2))" />
+    <xsl:value-of select="number($val) > 0 and (11 - ($weightedSum mod 11)) mod 11 = number(substring($val, $length + 1, 1))" />
+  </xsl:function>
+  <xsl:function as="xs:boolean" name="u:mod97-0208">
+    <xsl:param name="val" />
+    <xsl:variable name="checkdigits" select="substring($val,9,2)" />
+    <xsl:variable name="calculated_digits" select="xs:string(97 - (xs:integer(substring($val,1,8)) mod 97))" />
+    <xsl:value-of select="number($checkdigits) = number($calculated_digits)" />
+  </xsl:function>
+  <xsl:function as="xs:boolean" name="u:checkCodiceIPA">
+    <xsl:param as="xs:string?" name="arg" />
+    <xsl:variable name="allowed-characters">ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</xsl:variable>
+    <xsl:sequence select="if ( (string-length(translate($arg, $allowed-characters, '')) = 0) and (string-length($arg) = 6) ) then true() else false()" />
+  </xsl:function>
+  <xsl:function as="xs:boolean" name="u:checkCF">
+    <xsl:param as="xs:string?" name="arg" />
+    <xsl:sequence select="   if ( (string-length($arg) = 16) or (string-length($arg) = 11) )      then    (    if ((string-length($arg) = 16))     then    (     if (u:checkCF16($arg))      then     (      true()     )     else     (      false()     )    )    else    (     if(($arg castable as xs:integer)) then true() else false()       )   )   else   (    false()   )   " />
+  </xsl:function>
+  <xsl:function as="xs:boolean" name="u:checkCF16">
+    <xsl:param as="xs:string?" name="arg" />
+    <xsl:variable name="allowed-characters">ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz</xsl:variable>
+    <xsl:sequence select="     if (  (string-length(translate(substring($arg,1,6), $allowed-characters, '')) = 0) and         (substring($arg,7,2) castable as xs:integer) and        (string-length(translate(substring($arg,9,1), $allowed-characters, '')) = 0) and        (substring($arg,10,2) castable as xs:integer) and         (substring($arg,12,3) castable as xs:string) and        (substring($arg,15,1) castable as xs:integer) and         (string-length(translate(substring($arg,16,1), $allowed-characters, '')) = 0)      )      then true()     else false()     " />
+  </xsl:function>
+  <xsl:function as="xs:boolean" name="u:checkPIVAseIT">
+    <xsl:param as="xs:string" name="arg" />
+    <xsl:variable name="paese" select="substring($arg,1,2)" />
+    <xsl:variable name="codice" select="substring($arg,3)" />
+    <xsl:sequence select="     if ( $paese = 'IT' or $paese = 'it' )    then    (     if ( ( string-length($codice) = 11 ) and ( if (u:checkPIVA($codice)!=0) then false() else true() ))     then     (      true()     )     else     (      false()     )    )    else    (     true()    )      " />
+  </xsl:function>
+  <xsl:function as="xs:integer" name="u:checkPIVA">
+    <xsl:param as="xs:string?" name="arg" />
+    <xsl:sequence select="     if (not($arg castable as xs:integer))       then 1      else ( u:addPIVA($arg,xs:integer(0)) mod 10 )" />
+  </xsl:function>
+  <xsl:function as="xs:integer" name="u:addPIVA">
+    <xsl:param as="xs:string" name="arg" />
+    <xsl:param as="xs:integer" name="pari" />
+    <xsl:variable name="tappo" select="if (not($arg castable as xs:integer)) then 0 else 1" />
+    <xsl:variable name="mapper" select="if ($tappo = 0) then 0 else                    ( if ($pari = 1)                     then ( xs:integer(substring('0246813579', ( xs:integer(substring($arg,1,1)) +1 ) ,1)) )                     else ( xs:integer(substring($arg,1,1) ) )                   )" />
+    <xsl:sequence select="if ($tappo = 0) then $mapper else ( xs:integer($mapper) + u:addPIVA(substring(xs:string($arg),2), (if($pari=0) then 1 else 0) ) )" />
+  </xsl:function>
+  <xsl:function as="xs:boolean" name="u:abn">
+    <xsl:param name="val" />
+    <xsl:value-of select="( ((string-to-codepoints(substring($val,1,1)) - 49) * 10) + ((string-to-codepoints(substring($val,2,1)) - 48) * 1) + ((string-to-codepoints(substring($val,3,1)) - 48) * 3) + ((string-to-codepoints(substring($val,4,1)) - 48) * 5) + ((string-to-codepoints(substring($val,5,1)) - 48) * 7) + ((string-to-codepoints(substring($val,6,1)) - 48) * 9) + ((string-to-codepoints(substring($val,7,1)) - 48) * 11) + ((string-to-codepoints(substring($val,8,1)) - 48) * 13) + ((string-to-codepoints(substring($val,9,1)) - 48) * 15) + ((string-to-codepoints(substring($val,10,1)) - 48) * 17) + ((string-to-codepoints(substring($val,11,1)) - 48) * 19)) mod 89 = 0 " />
+  </xsl:function>
+  <xsl:function as="xs:boolean" name="u:TinVerification">
+    <xsl:param as="xs:string" name="val" />
+    <xsl:variable name="digits" select="    for $ch in string-to-codepoints($val)    return codepoints-to-string($ch)" />
+    <xsl:variable name="checksum" select="    (number($digits[8])*2) +    (number($digits[7])*4) +    (number($digits[6])*8) +    (number($digits[5])*16) +    (number($digits[4])*32) +    (number($digits[3])*64) +    (number($digits[2])*128) +    (number($digits[1])*256) " />
+    <xsl:value-of select="($checksum  mod 11) mod 10 = number($digits[9])" />
+  </xsl:function>
+  <xsl:function as="xs:boolean" name="u:checkSEOrgnr">
+    <xsl:param as="xs:string" name="number" />
+    <xsl:choose>
+      
+      <xsl:when test="not(matches($number, '^\d+$'))">
+        <xsl:sequence select="false()" />
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:variable name="mainPart" select="substring($number, 1, 9)" />
+        <xsl:variable name="checkDigit" select="substring($number, 10, 1)" />
+        <xsl:variable as="xs:integer" name="sum">
+          <xsl:value-of select="sum(       for $pos in 1 to string-length($mainPart) return         if ($pos mod 2 = 1)         then (number(substring($mainPart, string-length($mainPart) - $pos + 1, 1)) * 2) mod 10 +           (number(substring($mainPart, string-length($mainPart) - $pos + 1, 1)) * 2) idiv 10         else number(substring($mainPart, string-length($mainPart) - $pos + 1, 1))      )" />
+        </xsl:variable>
+        <xsl:variable name="calculatedCheckDigit" select="(10 - $sum mod 10) mod 10" />
+        <xsl:sequence select="$calculatedCheckDigit = number($checkDigit)" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+
+<!--DEFAULT RULES-->
+
+
+<!--MODE: SCHEMATRON-SELECT-FULL-PATH-->
+<!--This mode can be used to generate an ugly though full XPath for locators-->
+<xsl:template match="*" mode="schematron-select-full-path">
+    <xsl:apply-templates mode="schematron-get-full-path" select="." />
+  </xsl:template>
+
+<!--MODE: SCHEMATRON-FULL-PATH-->
+<!--This mode can be used to generate an ugly though full XPath for locators-->
+<xsl:template match="*" mode="schematron-get-full-path">
+    <xsl:apply-templates mode="schematron-get-full-path" select="parent::*" />
+    <xsl:text>/</xsl:text>
+    <xsl:choose>
+      <xsl:when test="namespace-uri()=''">
+        <xsl:value-of select="name()" />
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>*:</xsl:text>
+        <xsl:value-of select="local-name()" />
+        <xsl:text>[namespace-uri()='</xsl:text>
+        <xsl:value-of select="namespace-uri()" />
+        <xsl:text>']</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:variable name="preceding" select="count(preceding-sibling::*[local-name()=local-name(current())                                   and namespace-uri() = namespace-uri(current())])" />
+    <xsl:text>[</xsl:text>
+    <xsl:value-of select="1+ $preceding" />
+    <xsl:text>]</xsl:text>
+  </xsl:template>
+  <xsl:template match="@*" mode="schematron-get-full-path">
+    <xsl:apply-templates mode="schematron-get-full-path" select="parent::*" />
+    <xsl:text>/</xsl:text>
+    <xsl:choose>
+      <xsl:when test="namespace-uri()=''">@<xsl:value-of select="name()" />
+</xsl:when>
+      <xsl:otherwise>
+        <xsl:text>@*[local-name()='</xsl:text>
+        <xsl:value-of select="local-name()" />
+        <xsl:text>' and namespace-uri()='</xsl:text>
+        <xsl:value-of select="namespace-uri()" />
+        <xsl:text>']</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+<!--MODE: SCHEMATRON-FULL-PATH-2-->
+<!--This mode can be used to generate prefixed XPath for humans-->
+<xsl:template match="node() | @*" mode="schematron-get-full-path-2">
+    <xsl:for-each select="ancestor-or-self::*">
+      <xsl:text>/</xsl:text>
+      <xsl:value-of select="name(.)" />
+      <xsl:if test="preceding-sibling::*[name(.)=name(current())]">
+        <xsl:text>[</xsl:text>
+        <xsl:value-of select="count(preceding-sibling::*[name(.)=name(current())])+1" />
+        <xsl:text>]</xsl:text>
+      </xsl:if>
+    </xsl:for-each>
+    <xsl:if test="not(self::*)">
+      <xsl:text />/@<xsl:value-of select="name(.)" />
+    </xsl:if>
+  </xsl:template>
+<!--MODE: SCHEMATRON-FULL-PATH-3-->
+<!--This mode can be used to generate prefixed XPath for humans 
+	(Top-level element has index)-->
+
+<xsl:template match="node() | @*" mode="schematron-get-full-path-3">
+    <xsl:for-each select="ancestor-or-self::*">
+      <xsl:text>/</xsl:text>
+      <xsl:value-of select="name(.)" />
+      <xsl:if test="parent::*">
+        <xsl:text>[</xsl:text>
+        <xsl:value-of select="count(preceding-sibling::*[name(.)=name(current())])+1" />
+        <xsl:text>]</xsl:text>
+      </xsl:if>
+    </xsl:for-each>
+    <xsl:if test="not(self::*)">
+      <xsl:text />/@<xsl:value-of select="name(.)" />
+    </xsl:if>
+  </xsl:template>
+
+<!--MODE: GENERATE-ID-FROM-PATH -->
+<xsl:template match="/" mode="generate-id-from-path" />
+  <xsl:template match="text()" mode="generate-id-from-path">
+    <xsl:apply-templates mode="generate-id-from-path" select="parent::*" />
+    <xsl:value-of select="concat('.text-', 1+count(preceding-sibling::text()), '-')" />
+  </xsl:template>
+  <xsl:template match="comment()" mode="generate-id-from-path">
+    <xsl:apply-templates mode="generate-id-from-path" select="parent::*" />
+    <xsl:value-of select="concat('.comment-', 1+count(preceding-sibling::comment()), '-')" />
+  </xsl:template>
+  <xsl:template match="processing-instruction()" mode="generate-id-from-path">
+    <xsl:apply-templates mode="generate-id-from-path" select="parent::*" />
+    <xsl:value-of select="concat('.processing-instruction-', 1+count(preceding-sibling::processing-instruction()), '-')" />
+  </xsl:template>
+  <xsl:template match="@*" mode="generate-id-from-path">
+    <xsl:apply-templates mode="generate-id-from-path" select="parent::*" />
+    <xsl:value-of select="concat('.@', name())" />
+  </xsl:template>
+  <xsl:template match="*" mode="generate-id-from-path" priority="-0.5">
+    <xsl:apply-templates mode="generate-id-from-path" select="parent::*" />
+    <xsl:text>.</xsl:text>
+    <xsl:value-of select="concat('.',name(),'-',1+count(preceding-sibling::*[name()=name(current())]),'-')" />
+  </xsl:template>
+
+<!--MODE: GENERATE-ID-2 -->
+<xsl:template match="/" mode="generate-id-2">U</xsl:template>
+  <xsl:template match="*" mode="generate-id-2" priority="2">
+    <xsl:text>U</xsl:text>
+    <xsl:number count="*" level="multiple" />
+  </xsl:template>
+  <xsl:template match="node()" mode="generate-id-2">
+    <xsl:text>U.</xsl:text>
+    <xsl:number count="*" level="multiple" />
+    <xsl:text>n</xsl:text>
+    <xsl:number count="node()" />
+  </xsl:template>
+  <xsl:template match="@*" mode="generate-id-2">
+    <xsl:text>U.</xsl:text>
+    <xsl:number count="*" level="multiple" />
+    <xsl:text>_</xsl:text>
+    <xsl:value-of select="string-length(local-name(.))" />
+    <xsl:text>_</xsl:text>
+    <xsl:value-of select="translate(name(),':','.')" />
+  </xsl:template>
+<!--Strip characters-->  <xsl:template match="text()" priority="-1" />
+
+<!--SCHEMA SETUP-->
+<xsl:template match="/">
+    <svrl:schematron-output schemaVersion="iso" title="Rules for Peppol BIS 3.0 Billing">
+      <xsl:comment>
+        <xsl:value-of select="$archiveDirParameter" />   
+		 <xsl:value-of select="$archiveNameParameter" />  
+		 <xsl:value-of select="$fileNameParameter" />  
+		 <xsl:value-of select="$fileDirParameter" />
+      </xsl:comment>
+      <svrl:ns-prefix-in-attribute-values prefix="cbc" uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="cac" uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="ubl-creditnote" uri="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="ubl-invoice" uri="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" />
+      <svrl:ns-prefix-in-attribute-values prefix="xs" uri="http://www.w3.org/2001/XMLSchema" />
+      <svrl:ns-prefix-in-attribute-values prefix="u" uri="utils" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M26" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M27" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M28" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M29" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M30" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M31" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M32" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M37" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M38" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M39" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M40" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="id">german-rules</xsl:attribute>
+        <xsl:attribute name="name">german-rules</xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M41" select="/" />
+      <svrl:active-pattern>
+        <xsl:attribute name="document">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:attribute name="documents">
+          <xsl:value-of select="document-uri(/)" />
+        </xsl:attribute>
+        <xsl:apply-templates />
+      </svrl:active-pattern>
+      <xsl:apply-templates mode="M42" select="/" />
+    </svrl:schematron-output>
+  </xsl:template>
+
+<!--SCHEMATRON PATTERNS-->
+<svrl:text>Rules for Peppol BIS 3.0 Billing</svrl:text>
+  <xsl:param name="profile" select="       if (/*/cbc:ProfileID and matches(normalize-space(/*/cbc:ProfileID), 'urn:fdc:peppol.eu:2017:poacc:billing:([0-9]{2}):1.0')) then         tokenize(normalize-space(/*/cbc:ProfileID), ':')[7]       else         'Unknown'" />
+  <xsl:param name="supplierCountry" select="       if (/*/cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2)) then         upper-case(normalize-space(/*/cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2)))       else         if (/*/cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2)) then           upper-case(normalize-space(/*/cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2)))         else           if (/*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode) then             upper-case(normalize-space(/*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode))           else             'XX'" />
+  <xsl:param name="customerCountry" select="   if (/*/cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2)) then   upper-case(normalize-space(/*/cac:AccountingCustomerParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2)))   else   if (/*/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode) then   upper-case(normalize-space(/*/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode))   else   'XX'" />
+  <xsl:param name="supplierCountryIsDE" select="(upper-case(normalize-space(/*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode)) = 'DE')" />
+  <xsl:param name="customerCountryIsDE" select="(upper-case(normalize-space(/*/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode)) = 'DE')" />
+  <xsl:param name="documentCurrencyCode" select="/*/cbc:DocumentCurrencyCode" />
+
+<!--PATTERN -->
+
+
+	<!--RULE -->
+<xsl:template match="//*[not(*) and not(normalize-space())]" mode="M26" priority="1000">
+    <svrl:fired-rule context="//*[not(*) and not(normalize-space())]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="false()" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="false()">
+          <xsl:attribute name="id">PEPPOL-EN16931-R008</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Document MUST not contain empty elements.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M26" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M26" priority="-1" />
+  <xsl:template match="@*|node()" mode="M26" priority="-2">
+    <xsl:apply-templates mode="M26" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN -->
+
+
+	<!--RULE -->
+<xsl:template match="ubl-creditnote:CreditNote" mode="M27" priority="1000">
+    <svrl:fired-rule context="ubl-creditnote:CreditNote" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AdditionalDocumentReference[cbc:DocumentTypeCode='50']) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AdditionalDocumentReference[cbc:DocumentTypeCode='50']) &lt;= 1)">
+          <xsl:attribute name="id">PEPPOL-EN16931-R080</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Only one project reference is allowed on document level</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M27" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M27" priority="-1" />
+  <xsl:template match="@*|node()" mode="M27" priority="-2">
+    <xsl:apply-templates mode="M27" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN -->
+
+
+	<!--RULE -->
+<xsl:template match="ubl-creditnote:CreditNote | ubl-invoice:Invoice" mode="M28" priority="1023">
+    <svrl:fired-rule context="ubl-creditnote:CreditNote | ubl-invoice:Invoice" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:ProfileID" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:ProfileID">
+          <xsl:attribute name="id">PEPPOL-EN16931-R001</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Business process MUST be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="$profile != 'Unknown'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="$profile != 'Unknown'">
+          <xsl:attribute name="id">PEPPOL-EN16931-R007</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Business process MUST be in the format 'urn:fdc:peppol.eu:2017:poacc:billing:NN:1.0' where NN indicates the process number.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cbc:Note) &lt;= 1 or ($supplierCountryIsDE and $customerCountryIsDE)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cbc:Note) &lt;= 1 or ($supplierCountryIsDE and $customerCountryIsDE)">
+          <xsl:attribute name="id">PEPPOL-EN16931-R002</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>No more than one note is allowed on document level, unless both the buyer and seller are German organizations.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:BuyerReference or cac:OrderReference/cbc:ID" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:BuyerReference or cac:OrderReference/cbc:ID">
+          <xsl:attribute name="id">PEPPOL-EN16931-R003</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>A buyer reference or purchase order reference MUST be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="starts-with(normalize-space(cbc:CustomizationID/text()), 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0')" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="starts-with(normalize-space(cbc:CustomizationID/text()), 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0')">
+          <xsl:attribute name="id">PEPPOL-EN16931-R004</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Specification identifier MUST have the value 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0'.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:TaxTotal[cac:TaxSubtotal]) = 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:TaxTotal[cac:TaxSubtotal]) = 1">
+          <xsl:attribute name="id">PEPPOL-EN16931-R053</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Only one tax total with tax subtotals MUST be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:TaxTotal[not(cac:TaxSubtotal)]) = (if (cbc:TaxCurrencyCode) then 1 else 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:TaxTotal[not(cac:TaxSubtotal)]) = (if (cbc:TaxCurrencyCode) then 1 else 0)">
+          <xsl:attribute name="id">PEPPOL-EN16931-R054</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Only one tax total without tax subtotals MUST be provided when tax currency code is provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:TaxCurrencyCode) or (cac:TaxTotal/cbc:TaxAmount[@currencyID=normalize-space(../../cbc:TaxCurrencyCode)] &lt;= 0 and cac:TaxTotal/cbc:TaxAmount[@currencyID=normalize-space(../../cbc:DocumentCurrencyCode)] &lt;= 0) or (cac:TaxTotal/cbc:TaxAmount[@currencyID=normalize-space(../../cbc:TaxCurrencyCode)] >= 0 and cac:TaxTotal/cbc:TaxAmount[@currencyID=normalize-space(../../cbc:DocumentCurrencyCode)] >= 0) " />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:TaxCurrencyCode) or (cac:TaxTotal/cbc:TaxAmount[@currencyID=normalize-space(../../cbc:TaxCurrencyCode)] &lt;= 0 and cac:TaxTotal/cbc:TaxAmount[@currencyID=normalize-space(../../cbc:DocumentCurrencyCode)] &lt;= 0) or (cac:TaxTotal/cbc:TaxAmount[@currencyID=normalize-space(../../cbc:TaxCurrencyCode)] >= 0 and cac:TaxTotal/cbc:TaxAmount[@currencyID=normalize-space(../../cbc:DocumentCurrencyCode)] >= 0)">
+          <xsl:attribute name="id">PEPPOL-EN16931-R055</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Invoice total VAT amount and Invoice total VAT amount in accounting currency MUST have the same operational sign</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:TaxCurrencyCode" mode="M28" priority="1022">
+    <svrl:fired-rule context="cbc:TaxCurrencyCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(normalize-space(text()) = normalize-space(../cbc:DocumentCurrencyCode/text()))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(normalize-space(text()) = normalize-space(../cbc:DocumentCurrencyCode/text()))">
+          <xsl:attribute name="id">PEPPOL-EN16931-R005</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>VAT accounting currency code MUST be different from invoice currency code when provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingCustomerParty/cac:Party" mode="M28" priority="1021">
+    <svrl:fired-rule context="cac:AccountingCustomerParty/cac:Party" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:EndpointID" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:EndpointID">
+          <xsl:attribute name="id">PEPPOL-EN16931-R010</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Buyer electronic address MUST be provided</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty/cac:Party" mode="M28" priority="1020">
+    <svrl:fired-rule context="cac:AccountingSupplierParty/cac:Party" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:EndpointID" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:EndpointID">
+          <xsl:attribute name="id">PEPPOL-EN16931-R020</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Seller electronic address MUST be provided</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="ubl-invoice:Invoice/cac:AllowanceCharge[cbc:MultiplierFactorNumeric and not(cbc:BaseAmount)] | ubl-invoice:Invoice/cac:InvoiceLine/cac:AllowanceCharge[cbc:MultiplierFactorNumeric and not(cbc:BaseAmount)] | ubl-creditnote:CreditNote/cac:AllowanceCharge[cbc:MultiplierFactorNumeric and not(cbc:BaseAmount)] | ubl-creditnote:CreditNote/cac:CreditNoteLine/cac:AllowanceCharge[cbc:MultiplierFactorNumeric and not(cbc:BaseAmount)]" mode="M28" priority="1019">
+    <svrl:fired-rule context="ubl-invoice:Invoice/cac:AllowanceCharge[cbc:MultiplierFactorNumeric and not(cbc:BaseAmount)] | ubl-invoice:Invoice/cac:InvoiceLine/cac:AllowanceCharge[cbc:MultiplierFactorNumeric and not(cbc:BaseAmount)] | ubl-creditnote:CreditNote/cac:AllowanceCharge[cbc:MultiplierFactorNumeric and not(cbc:BaseAmount)] | ubl-creditnote:CreditNote/cac:CreditNoteLine/cac:AllowanceCharge[cbc:MultiplierFactorNumeric and not(cbc:BaseAmount)]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="false()" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="false()">
+          <xsl:attribute name="id">PEPPOL-EN16931-R041</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Allowance/charge base amount MUST be provided when allowance/charge percentage is provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="ubl-invoice:Invoice/cac:AllowanceCharge[not(cbc:MultiplierFactorNumeric) and cbc:BaseAmount] | ubl-invoice:Invoice/cac:InvoiceLine/cac:AllowanceCharge[not(cbc:MultiplierFactorNumeric) and cbc:BaseAmount] | ubl-creditnote:CreditNote/cac:AllowanceCharge[not(cbc:MultiplierFactorNumeric) and cbc:BaseAmount] | ubl-creditnote:CreditNote/cac:CreditNoteLine/cac:AllowanceCharge[not(cbc:MultiplierFactorNumeric) and cbc:BaseAmount]" mode="M28" priority="1018">
+    <svrl:fired-rule context="ubl-invoice:Invoice/cac:AllowanceCharge[not(cbc:MultiplierFactorNumeric) and cbc:BaseAmount] | ubl-invoice:Invoice/cac:InvoiceLine/cac:AllowanceCharge[not(cbc:MultiplierFactorNumeric) and cbc:BaseAmount] | ubl-creditnote:CreditNote/cac:AllowanceCharge[not(cbc:MultiplierFactorNumeric) and cbc:BaseAmount] | ubl-creditnote:CreditNote/cac:CreditNoteLine/cac:AllowanceCharge[not(cbc:MultiplierFactorNumeric) and cbc:BaseAmount]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="false()" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="false()">
+          <xsl:attribute name="id">PEPPOL-EN16931-R042</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Allowance/charge percentage MUST be provided when allowance/charge base amount is provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="ubl-invoice:Invoice/cac:AllowanceCharge | ubl-invoice:Invoice/cac:InvoiceLine/cac:AllowanceCharge | ubl-creditnote:CreditNote/cac:AllowanceCharge | ubl-creditnote:CreditNote/cac:CreditNoteLine/cac:AllowanceCharge" mode="M28" priority="1017">
+    <svrl:fired-rule context="ubl-invoice:Invoice/cac:AllowanceCharge | ubl-invoice:Invoice/cac:InvoiceLine/cac:AllowanceCharge | ubl-creditnote:CreditNote/cac:AllowanceCharge | ubl-creditnote:CreditNote/cac:CreditNoteLine/cac:AllowanceCharge" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="           not(cbc:MultiplierFactorNumeric and cbc:BaseAmount) or u:slack(if (cbc:Amount) then             cbc:Amount           else             0, (xs:decimal(cbc:BaseAmount) * xs:decimal(cbc:MultiplierFactorNumeric)) div 100, 0.02)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:MultiplierFactorNumeric and cbc:BaseAmount) or u:slack(if (cbc:Amount) then cbc:Amount else 0, (xs:decimal(cbc:BaseAmount) * xs:decimal(cbc:MultiplierFactorNumeric)) div 100, 0.02)">
+          <xsl:attribute name="id">PEPPOL-EN16931-R040</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Allowance/charge amount must equal base amount * percentage/100 if base amount and percentage exists</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ChargeIndicator/text()) = 'true' or normalize-space(cbc:ChargeIndicator/text()) = 'false'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ChargeIndicator/text()) = 'true' or normalize-space(cbc:ChargeIndicator/text()) = 'false'">
+          <xsl:attribute name="id">PEPPOL-EN16931-R043</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Allowance/charge ChargeIndicator value MUST equal 'true' or 'false'</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="         cac:PaymentMeans[some $code in tokenize('49 59', '\s')           satisfies normalize-space(cbc:PaymentMeansCode) = $code]" mode="M28" priority="1016">
+    <svrl:fired-rule context="         cac:PaymentMeans[some $code in tokenize('49 59', '\s')           satisfies normalize-space(cbc:PaymentMeansCode) = $code]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:PaymentMandate/cbc:ID" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:PaymentMandate/cbc:ID">
+          <xsl:attribute name="id">PEPPOL-EN16931-R061</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Mandate reference MUST be provided for direct debit.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:Amount | cbc:BaseAmount | cbc:PriceAmount | cac:TaxTotal[cac:TaxSubtotal]/cbc:TaxAmount | cac:TaxSubtotal/cbc:TaxAmount | cbc:TaxableAmount | cbc:LineExtensionAmount | cbc:TaxExclusiveAmount | cbc:TaxInclusiveAmount | cbc:AllowanceTotalAmount | cbc:ChargeTotalAmount | cbc:PrepaidAmount | cbc:PayableRoundingAmount | cbc:PayableAmount" mode="M28" priority="1015">
+    <svrl:fired-rule context="cbc:Amount | cbc:BaseAmount | cbc:PriceAmount | cac:TaxTotal[cac:TaxSubtotal]/cbc:TaxAmount | cac:TaxSubtotal/cbc:TaxAmount | cbc:TaxableAmount | cbc:LineExtensionAmount | cbc:TaxExclusiveAmount | cbc:TaxInclusiveAmount | cbc:AllowanceTotalAmount | cbc:ChargeTotalAmount | cbc:PrepaidAmount | cbc:PayableRoundingAmount | cbc:PayableAmount" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="@currencyID = $documentCurrencyCode" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="@currencyID = $documentCurrencyCode">
+          <xsl:attribute name="id">PEPPOL-EN16931-R051</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>All currencyID attributes must have the same value as the invoice currency code (BT-5), except for the invoice total VAT amount in accounting currency (BT-111).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="ubl-invoice:Invoice[cac:InvoicePeriod/cbc:StartDate]/cac:InvoiceLine/cac:InvoicePeriod/cbc:StartDate | ubl-creditnote:CreditNote[cac:InvoicePeriod/cbc:StartDate]/cac:CreditNoteLine/cac:InvoicePeriod/cbc:StartDate" mode="M28" priority="1014">
+    <svrl:fired-rule context="ubl-invoice:Invoice[cac:InvoicePeriod/cbc:StartDate]/cac:InvoiceLine/cac:InvoicePeriod/cbc:StartDate | ubl-creditnote:CreditNote[cac:InvoicePeriod/cbc:StartDate]/cac:CreditNoteLine/cac:InvoicePeriod/cbc:StartDate" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="xs:date(text()) >= xs:date(../../../cac:InvoicePeriod/cbc:StartDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="xs:date(text()) >= xs:date(../../../cac:InvoicePeriod/cbc:StartDate)">
+          <xsl:attribute name="id">PEPPOL-EN16931-R110</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Start date of line period MUST be within invoice period.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="ubl-invoice:Invoice[cac:InvoicePeriod/cbc:EndDate]/cac:InvoiceLine/cac:InvoicePeriod/cbc:EndDate | ubl-creditnote:CreditNote[cac:InvoicePeriod/cbc:EndDate]/cac:CreditNoteLine/cac:InvoicePeriod/cbc:EndDate" mode="M28" priority="1013">
+    <svrl:fired-rule context="ubl-invoice:Invoice[cac:InvoicePeriod/cbc:EndDate]/cac:InvoiceLine/cac:InvoicePeriod/cbc:EndDate | ubl-creditnote:CreditNote[cac:InvoicePeriod/cbc:EndDate]/cac:CreditNoteLine/cac:InvoicePeriod/cbc:EndDate" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="xs:date(text()) &lt;= xs:date(../../../cac:InvoicePeriod/cbc:EndDate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="xs:date(text()) &lt;= xs:date(../../../cac:InvoicePeriod/cbc:EndDate)">
+          <xsl:attribute name="id">PEPPOL-EN16931-R111</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>End date of line period MUST be within invoice period.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoiceLine | cac:CreditNoteLine" mode="M28" priority="1012">
+    <svrl:fired-rule context="cac:InvoiceLine | cac:CreditNoteLine" />
+    <xsl:variable name="lineExtensionAmount" select="           if (cbc:LineExtensionAmount) then             xs:decimal(cbc:LineExtensionAmount)           else             0" />
+    <xsl:variable name="quantity" select="           if (/ubl-invoice:Invoice) then             (if (cbc:InvoicedQuantity) then               xs:decimal(cbc:InvoicedQuantity)             else               1)           else             (if (cbc:CreditedQuantity) then               xs:decimal(cbc:CreditedQuantity)             else               1)" />
+    <xsl:variable name="priceAmount" select="           if (cac:Price/cbc:PriceAmount) then             xs:decimal(cac:Price/cbc:PriceAmount)           else             0" />
+    <xsl:variable name="baseQuantity" select="           if (cac:Price/cbc:BaseQuantity and xs:decimal(cac:Price/cbc:BaseQuantity) != 0) then             xs:decimal(cac:Price/cbc:BaseQuantity)           else             1" />
+    <xsl:variable name="allowancesTotal" select="           if (cac:AllowanceCharge[normalize-space(cbc:ChargeIndicator) = 'false']) then             round(sum(cac:AllowanceCharge[normalize-space(cbc:ChargeIndicator) = 'false']/cbc:Amount/xs:decimal(.)) * 10 * 10) div 100           else             0" />
+    <xsl:variable name="chargesTotal" select="           if (cac:AllowanceCharge[normalize-space(cbc:ChargeIndicator) = 'true']) then             round(sum(cac:AllowanceCharge[normalize-space(cbc:ChargeIndicator) = 'true']/cbc:Amount/xs:decimal(.)) * 10 * 10) div 100           else             0" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="u:slack($lineExtensionAmount, ($quantity * ($priceAmount div $baseQuantity)) + $chargesTotal - $allowancesTotal, 0.02)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="u:slack($lineExtensionAmount, ($quantity * ($priceAmount div $baseQuantity)) + $chargesTotal - $allowancesTotal, 0.02)">
+          <xsl:attribute name="id">PEPPOL-EN16931-R120</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Invoice line net amount MUST equal (Invoiced quantity * (Item net price/item price base quantity) + Sum of invoice line charge amount - sum of invoice line allowance amount</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:Price/cbc:BaseQuantity) or xs:decimal(cac:Price/cbc:BaseQuantity) > 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:Price/cbc:BaseQuantity) or xs:decimal(cac:Price/cbc:BaseQuantity) > 0">
+          <xsl:attribute name="id">PEPPOL-EN16931-R121</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Base quantity MUST be a positive number above zero.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:DocumentReference) &lt;= 1)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:DocumentReference) &lt;= 1)">
+          <xsl:attribute name="id">PEPPOL-EN16931-R100</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Only one invoiced object is allowed pr line</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(not(cac:DocumentReference) or (cac:DocumentReference/cbc:DocumentTypeCode='130'))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(not(cac:DocumentReference) or (cac:DocumentReference/cbc:DocumentTypeCode='130'))">
+          <xsl:attribute name="id">PEPPOL-EN16931-R101</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Element Document reference can only be used for Invoice line object</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:Price/cac:AllowanceCharge" mode="M28" priority="1011">
+    <svrl:fired-rule context="cac:Price/cac:AllowanceCharge" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ChargeIndicator) = 'false'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ChargeIndicator) = 'false'">
+          <xsl:attribute name="id">PEPPOL-EN16931-R044</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Charge on price level is NOT allowed. Only value 'false' allowed.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:BaseAmount) or xs:decimal(../cbc:PriceAmount) = xs:decimal(cbc:BaseAmount) - xs:decimal(cbc:Amount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:BaseAmount) or xs:decimal(../cbc:PriceAmount) = xs:decimal(cbc:BaseAmount) - xs:decimal(cbc:Amount)">
+          <xsl:attribute name="id">PEPPOL-EN16931-R046</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Item net price MUST equal (Gross price - Allowance amount) when gross price is provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:Price/cbc:BaseQuantity[@unitCode]" mode="M28" priority="1010">
+    <svrl:fired-rule context="cac:Price/cbc:BaseQuantity[@unitCode]" />
+    <xsl:variable name="hasQuantity" select="../../cbc:InvoicedQuantity or ../../cbc:CreditedQuantity" />
+    <xsl:variable name="quantity" select="           if (/ubl-invoice:Invoice) then             ../../cbc:InvoicedQuantity           else             ../../cbc:CreditedQuantity" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not($hasQuantity) or @unitCode = $quantity/@unitCode" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not($hasQuantity) or @unitCode = $quantity/@unitCode">
+          <xsl:attribute name="id">PEPPOL-EN16931-R130</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Unit code of price base quantity MUST be same as invoiced quantity.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID = '0088'] | cac:PartyIdentification/cbc:ID[@schemeID = '0088'] | cbc:CompanyID[@schemeID = '0088']" mode="M28" priority="1009">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID = '0088'] | cac:PartyIdentification/cbc:ID[@schemeID = '0088'] | cbc:CompanyID[@schemeID = '0088']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="matches(normalize-space(), '^[0-9]+$') and u:gln(normalize-space())" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="matches(normalize-space(), '^[0-9]+$') and u:gln(normalize-space())">
+          <xsl:attribute name="id">PEPPOL-COMMON-R040</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>GLN must have a valid format according to GS1 rules.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID = '0192'] | cac:PartyIdentification/cbc:ID[@schemeID = '0192'] | cbc:CompanyID[@schemeID = '0192']" mode="M28" priority="1008">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID = '0192'] | cac:PartyIdentification/cbc:ID[@schemeID = '0192'] | cbc:CompanyID[@schemeID = '0192']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="matches(normalize-space(), '^[0-9]{9}$') and u:mod11(normalize-space())" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="matches(normalize-space(), '^[0-9]{9}$') and u:mod11(normalize-space())">
+          <xsl:attribute name="id">PEPPOL-COMMON-R041</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Norwegian organization number MUST be stated in the correct format.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID = '0184'] | cac:PartyIdentification/cbc:ID[@schemeID = '0184'] | cbc:CompanyID[@schemeID = '0184']" mode="M28" priority="1007">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID = '0184'] | cac:PartyIdentification/cbc:ID[@schemeID = '0184'] | cbc:CompanyID[@schemeID = '0184']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(string-length(string()) = 10 and substring(string(), 1, 2) = 'DK' and string-length(translate(substring(string(), 3, 8), '1234567890', '')) = 0)                or               (string-length(string()) = 8) and (string-length(translate(substring(string(), 1, 8),'1234567890', '')) = 0)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(string-length(string()) = 10 and substring(string(), 1, 2) = 'DK' and string-length(translate(substring(string(), 3, 8), '1234567890', '')) = 0) or (string-length(string()) = 8) and (string-length(translate(substring(string(), 1, 8),'1234567890', '')) = 0)">
+          <xsl:attribute name="id">PEPPOL-COMMON-R042</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Danish organization number (CVR) MUST be stated in the correct format.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID = '0208'] | cac:PartyIdentification/cbc:ID[@schemeID = '0208'] | cbc:CompanyID[@schemeID = '0208']" mode="M28" priority="1006">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID = '0208'] | cac:PartyIdentification/cbc:ID[@schemeID = '0208'] | cbc:CompanyID[@schemeID = '0208']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="matches(normalize-space(), '^[0-9]{10}$') and u:mod97-0208(normalize-space())" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="matches(normalize-space(), '^[0-9]{10}$') and u:mod97-0208(normalize-space())">
+          <xsl:attribute name="id">PEPPOL-COMMON-R043</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Belgian enterprise number MUST be stated in the correct format.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID = '0201'] | cac:PartyIdentification/cbc:ID[@schemeID = '0201'] | cbc:CompanyID[@schemeID = '0201']" mode="M28" priority="1005">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID = '0201'] | cac:PartyIdentification/cbc:ID[@schemeID = '0201'] | cbc:CompanyID[@schemeID = '0201']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="u:checkCodiceIPA(normalize-space())" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="u:checkCodiceIPA(normalize-space())">
+          <xsl:attribute name="id">PEPPOL-COMMON-R044</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>IPA Code (Codice Univoco Unità Organizzativa) must be stated in the correct format</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID = '0210'] | cac:PartyIdentification/cbc:ID[@schemeID = '0210'] | cbc:CompanyID[@schemeID = '0210']" mode="M28" priority="1004">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID = '0210'] | cac:PartyIdentification/cbc:ID[@schemeID = '0210'] | cbc:CompanyID[@schemeID = '0210']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="u:checkCF(normalize-space())" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="u:checkCF(normalize-space())">
+          <xsl:attribute name="id">PEPPOL-COMMON-R045</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Tax Code (Codice Fiscale) must be stated in the correct format</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID = '9907']" mode="M28" priority="1003">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID = '9907']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="u:checkCF(normalize-space())" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="u:checkCF(normalize-space())">
+          <xsl:attribute name="id">PEPPOL-COMMON-R046</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Tax Code (Codice Fiscale) must be stated in the correct format</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID = '0211'] | cac:PartyIdentification/cbc:ID[@schemeID = '0211'] | cbc:CompanyID[@schemeID = '0211']" mode="M28" priority="1002">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID = '0211'] | cac:PartyIdentification/cbc:ID[@schemeID = '0211'] | cbc:CompanyID[@schemeID = '0211']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="u:checkPIVAseIT(normalize-space())" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="u:checkPIVAseIT(normalize-space())">
+          <xsl:attribute name="id">PEPPOL-COMMON-R047</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Italian VAT Code (Partita Iva) must be stated in the correct format</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID = '0007'] | cac:PartyIdentification/cbc:ID[@schemeID = '0007'] | cbc:CompanyID[@schemeID = '0007']" mode="M28" priority="1001">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID = '0007'] | cac:PartyIdentification/cbc:ID[@schemeID = '0007'] | cbc:CompanyID[@schemeID = '0007']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space()) = 10 and string(number(normalize-space())) != 'NaN' and u:checkSEOrgnr(normalize-space())" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space()) = 10 and string(number(normalize-space())) != 'NaN' and u:checkSEOrgnr(normalize-space())">
+          <xsl:attribute name="id">PEPPOL-COMMON-R049</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Swedish organization number MUST be stated in the correct format.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID = '0151'] | cac:PartyIdentification/cbc:ID[@schemeID = '0151'] | cbc:CompanyID[@schemeID = '0151']" mode="M28" priority="1000">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID = '0151'] | cac:PartyIdentification/cbc:ID[@schemeID = '0151'] | cbc:CompanyID[@schemeID = '0151']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="matches(normalize-space(), '^[0-9]{11}$') and u:abn(normalize-space())" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="matches(normalize-space(), '^[0-9]{11}$') and u:abn(normalize-space())">
+          <xsl:attribute name="id">PEPPOL-COMMON-R050</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Australian Business Number (ABN) MUST be stated in the correct format.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M28" priority="-1" />
+  <xsl:template match="@*|node()" mode="M28" priority="-2">
+    <xsl:apply-templates mode="M28" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN -->
+
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty/cac:Party[$supplierCountry = 'NO']" mode="M29" priority="1000">
+    <svrl:fired-rule context="cac:AccountingSupplierParty/cac:Party[$supplierCountry = 'NO']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'TAX']/cbc:CompanyID) = 'Foretaksregisteret'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'TAX']/cbc:CompanyID) = 'Foretaksregisteret'">
+          <xsl:attribute name="id">NO-R-002</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Norwegian suppliers, most invoice issuers are required to append "Foretaksregisteret" to their invoice. "Dersom selger er aksjeselskap, allmennaksjeselskap eller filial av utenlandsk selskap skal også ordet «Foretaksregisteret» fremgå av salgsdokumentet, jf. foretaksregisterloven § 10-2."</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/substring(cbc:CompanyID, 1, 2)='NO' and matches(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/substring(cbc:CompanyID,3), '^[0-9]{9}MVA$')           and u:mod11(substring(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID, 3, 9)) or not(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/substring(cbc:CompanyID, 1, 2)='NO')" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/substring(cbc:CompanyID, 1, 2)='NO' and matches(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/substring(cbc:CompanyID,3), '^[0-9]{9}MVA$') and u:mod11(substring(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID, 3, 9)) or not(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/substring(cbc:CompanyID, 1, 2)='NO')">
+          <xsl:attribute name="id">NO-R-001</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Norwegian suppliers, a VAT number MUST be the country code prefix NO followed by a valid Norwegian organization number (nine numbers) followed by the letters MVA.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M29" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M29" priority="-1" />
+  <xsl:template match="@*|node()" mode="M29" priority="-2">
+    <xsl:apply-templates mode="M29" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN -->
+<xsl:variable name="DKSupplierCountry" select="concat(ubl-creditnote:CreditNote/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode, ubl-invoice:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode)" />
+  <xsl:variable name="DKCustomerCountry" select="concat(ubl-creditnote:CreditNote/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode, ubl-invoice:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode)" />
+
+	<!--RULE -->
+<xsl:template match="ubl-creditnote:CreditNote[$DKSupplierCountry = 'DK'] | ubl-invoice:Invoice[$DKSupplierCountry = 'DK']" mode="M30" priority="1004">
+    <svrl:fired-rule context="ubl-creditnote:CreditNote[$DKSupplierCountry = 'DK'] | ubl-invoice:Invoice[$DKSupplierCountry = 'DK']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(normalize-space(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID/text()) != '')" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(normalize-space(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID/text()) != '')">
+          <xsl:attribute name="id">DK-R-002</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Danish suppliers MUST provide legal entity (CVR-number)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(((boolean(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID))           and (normalize-space(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID/@schemeID) != '0184'))       )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(((boolean(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID)) and (normalize-space(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID/@schemeID) != '0184')) )">
+          <xsl:attribute name="id">DK-R-014</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Danish Suppliers it is mandatory to specify schemeID as "0184" (DK CVR-number) when PartyLegalEntity/CompanyID is used for AccountingSupplierParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((boolean(/ubl-creditnote:CreditNote) and ($DKCustomerCountry = 'DK'))       and (number(cac:LegalMonetaryTotal/cbc:PayableAmount/text()) &lt; 0)       )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((boolean(/ubl-creditnote:CreditNote) and ($DKCustomerCountry = 'DK')) and (number(cac:LegalMonetaryTotal/cbc:PayableAmount/text()) &lt; 0) )">
+          <xsl:attribute name="id">DK-R-016</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Danish Suppliers, a Credit note cannot have a negative total (PayableAmount)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M30" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="ubl-creditnote:CreditNote[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification | ubl-creditnote:CreditNote[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification | ubl-invoice:Invoice[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification | ubl-invoice:Invoice[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification" mode="M30" priority="1003">
+    <svrl:fired-rule context="ubl-creditnote:CreditNote[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification | ubl-creditnote:CreditNote[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification | ubl-invoice:Invoice[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification | ubl-invoice:Invoice[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((boolean(cbc:ID))        and (normalize-space(cbc:ID/@schemeID) = '')       )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((boolean(cbc:ID)) and (normalize-space(cbc:ID/@schemeID) = '') )">
+          <xsl:attribute name="id">DK-R-013</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Danish Suppliers it is mandatory to use schemeID when PartyIdentification/ID is used for AccountingCustomerParty or AccountingSupplierParty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M30" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="ubl-invoice:Invoice[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:PaymentMeans" mode="M30" priority="1002">
+    <svrl:fired-rule context="ubl-invoice:Invoice[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:PaymentMeans" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="contains(' 1 10 31 42 48 49 50 58 59 93 97 ', concat(' ', cbc:PaymentMeansCode, ' '))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="contains(' 1 10 31 42 48 49 50 58 59 93 97 ', concat(' ', cbc:PaymentMeansCode, ' '))">
+          <xsl:attribute name="id">DK-R-005</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Danish suppliers the following Payment means codes are allowed: 1, 10, 31, 42, 48, 49, 50, 58, 59, 93 and 97</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(((cbc:PaymentMeansCode = '31') or (cbc:PaymentMeansCode = '42'))       and not((normalize-space(cac:PayeeFinancialAccount/cbc:ID/text()) != '') and (normalize-space(cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cbc:ID/text()) != ''))       )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(((cbc:PaymentMeansCode = '31') or (cbc:PaymentMeansCode = '42')) and not((normalize-space(cac:PayeeFinancialAccount/cbc:ID/text()) != '') and (normalize-space(cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cbc:ID/text()) != '')) )">
+          <xsl:attribute name="id">DK-R-006</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Danish suppliers bank account and registration account is mandatory if payment means is 31 or 42</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cbc:PaymentMeansCode = '49')       and not((normalize-space(cac:PaymentMandate/cbc:ID/text()) != '')           and (normalize-space(cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID/text()) != ''))       )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cbc:PaymentMeansCode = '49') and not((normalize-space(cac:PaymentMandate/cbc:ID/text()) != '') and (normalize-space(cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID/text()) != '')) )">
+          <xsl:attribute name="id">DK-R-007</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Danish suppliers PaymentMandate/ID and PayerFinancialAccount/ID are mandatory when payment means is 49</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cbc:PaymentMeansCode = '50')       and not(((substring(cbc:PaymentID, 1, 3) = '01#')           or (substring(cbc:PaymentID, 1, 3) = '04#')           or (substring(cbc:PaymentID, 1, 3) = '15#'))         and matches(cac:PayeeFinancialAccount/cbc:ID, '^[0-9]{7,8}$')         )       )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cbc:PaymentMeansCode = '50') and not(((substring(cbc:PaymentID, 1, 3) = '01#') or (substring(cbc:PaymentID, 1, 3) = '04#') or (substring(cbc:PaymentID, 1, 3) = '15#')) and matches(cac:PayeeFinancialAccount/cbc:ID, '^[0-9]{7,8}$') ) )">
+          <xsl:attribute name="id">DK-R-008</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Danish Suppliers PaymentID is mandatory and MUST start with 01#, 04# or 15# (kortartkode), and PayeeFinancialAccount/ID (Giro kontonummer) is mandatory and must be 7 or 8 numerical characters long, when payment means equals 50 (Giro)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cbc:PaymentMeansCode = '50')       and ((substring(cbc:PaymentID, 1, 3) = '04#')          or (substring(cbc:PaymentID, 1, 3)  = '15#'))       and not(string-length(cbc:PaymentID) = 19)       )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cbc:PaymentMeansCode = '50') and ((substring(cbc:PaymentID, 1, 3) = '04#') or (substring(cbc:PaymentID, 1, 3) = '15#')) and not(string-length(cbc:PaymentID) = 19) )">
+          <xsl:attribute name="id">DK-R-009</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Danish Suppliers if the PaymentID is prefixed with 04# or 15# the 16 digits instruction Id must be added to the PaymentID eg. "04#1234567890123456" when Payment means equals 50 (Giro)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cbc:PaymentMeansCode = '93')       and not(((substring(cbc:PaymentID, 1, 3) = '71#')           or (substring(cbc:PaymentID, 1, 3) = '73#')           or (substring(cbc:PaymentID, 1, 3) = '75#'))         and (string-length(cac:PayeeFinancialAccount/cbc:ID/text()) = 8)         )       )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cbc:PaymentMeansCode = '93') and not(((substring(cbc:PaymentID, 1, 3) = '71#') or (substring(cbc:PaymentID, 1, 3) = '73#') or (substring(cbc:PaymentID, 1, 3) = '75#')) and (string-length(cac:PayeeFinancialAccount/cbc:ID/text()) = 8) ) )">
+          <xsl:attribute name="id">DK-R-010</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Danish Suppliers the PaymentID is mandatory and MUST start with 71#, 73# or 75# (kortartkode) and CreditAccount/AccountID (Kreditornummer) is mandatory and MUST be exactly 8 characters long, when Payment means equals 93 (FIK)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cbc:PaymentMeansCode = '93')       and ((substring(cbc:PaymentID, 1, 3) = '71#')          or (substring(cbc:PaymentID, 1, 3)  = '75#'))       and not((string-length(cbc:PaymentID) = 18)          or (string-length(cbc:PaymentID) = 19))       )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cbc:PaymentMeansCode = '93') and ((substring(cbc:PaymentID, 1, 3) = '71#') or (substring(cbc:PaymentID, 1, 3) = '75#')) and not((string-length(cbc:PaymentID) = 18) or (string-length(cbc:PaymentID) = 19)) )">
+          <xsl:attribute name="id">DK-R-011</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Danish Suppliers if the PaymentID is prefixed with 71# or 75# the 15-16 digits instruction Id must be added to the PaymentID eg. "71#1234567890123456" when payment Method equals 93 (FIK)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M30" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="ubl-creditnote:CreditNote[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:CreditNoteLine | ubl-invoice:Invoice[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:InvoiceLine" mode="M30" priority="1001">
+    <svrl:fired-rule context="ubl-creditnote:CreditNote[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:CreditNoteLine | ubl-invoice:Invoice[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']/cac:InvoiceLine" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode/@listID = 'TST')       and not((cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode/@listVersionID = '19.05.01')           or (cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode/@listVersionID = '19.0501')                                or (cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode/@listVersionID = '26.08.01')                                or (cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode/@listVersionID = '26.0801')           )       )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode/@listID = 'TST') and not((cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode/@listVersionID = '19.05.01') or (cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode/@listVersionID = '19.0501') or (cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode/@listVersionID = '26.08.01') or (cac:Item/cac:CommodityClassification/cbc:ItemClassificationCode/@listVersionID = '26.0801') ) )">
+          <xsl:attribute name="id">DK-R-003</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If ItemClassification is provided from Danish suppliers, UNSPSC version 19.05.01 or 26.08.01 should be used.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M30" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']" mode="M30" priority="1000">
+    <svrl:fired-rule context="cac:AllowanceCharge[$DKSupplierCountry = 'DK' and $DKCustomerCountry = 'DK']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not((cbc:AllowanceChargeReasonCode = 'ZZZ')       and not(((string-length(normalize-space(cbc:AllowanceChargeReason/text())) = 4)         and (number(cbc:AllowanceChargeReason) >= 0)         and (number(cbc:AllowanceChargeReason) &lt;= 9999)) or         (((cbc:AllowanceChargeReason and contains(cbc:AllowanceChargeReason, '#')                                   and not(starts-with(cbc:AllowanceChargeReason, '#'))                                   and not(ends-with(cbc:AllowanceChargeReason, '#')))) )                                )      )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not((cbc:AllowanceChargeReasonCode = 'ZZZ') and not(((string-length(normalize-space(cbc:AllowanceChargeReason/text())) = 4) and (number(cbc:AllowanceChargeReason) >= 0) and (number(cbc:AllowanceChargeReason) &lt;= 9999)) or (((cbc:AllowanceChargeReason and contains(cbc:AllowanceChargeReason, '#') and not(starts-with(cbc:AllowanceChargeReason, '#')) and not(ends-with(cbc:AllowanceChargeReason, '#')))) ) ) )">
+          <xsl:attribute name="id">DK-R-004</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When specifying non-VAT Taxes for Danish customers, Danish suppliers MUST use the AllowanceChargeReasonCode="ZZZ" and MUST be specified in AllowanceChargeReason; Either as the 4-digit Tax category or must include a #, but the # is not allowed as first and last character</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M30" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M30" priority="-1" />
+  <xsl:template match="@*|node()" mode="M30" priority="-2">
+    <xsl:apply-templates mode="M30" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN -->
+
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty/cac:Party[$supplierCountry = 'IT']/cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) != 'VAT']" mode="M31" priority="1001">
+    <svrl:fired-rule context="cac:AccountingSupplierParty/cac:Party[$supplierCountry = 'IT']/cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) != 'VAT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="matches(normalize-space(cbc:CompanyID),'^[A-Z0-9]{11,16}$')" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="matches(normalize-space(cbc:CompanyID),'^[A-Z0-9]{11,16}$')">
+          <xsl:attribute name="id">IT-R-001</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IT-R-001] BT-32 (Seller tax registration identifier) - For Italian suppliers BT-32 minimum length 11 and maximum length shall be 16. Per i fornitori italiani il BT-32 deve avere una lunghezza tra 11 e 16 caratteri</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M31" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty/cac:Party[$supplierCountry = 'IT']" mode="M31" priority="1000">
+    <svrl:fired-rule context="cac:AccountingSupplierParty/cac:Party[$supplierCountry = 'IT']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:PostalAddress/cbc:StreetName" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:PostalAddress/cbc:StreetName">
+          <xsl:attribute name="id">IT-R-002</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IT-R-002] BT-35 (Seller address line 1) - Italian suppliers MUST provide the postal address line 1 - I fornitori italiani devono indicare l'indirizzo postale.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:PostalAddress/cbc:CityName" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:PostalAddress/cbc:CityName">
+          <xsl:attribute name="id">IT-R-003</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IT-R-003] BT-37 (Seller city) - Italian suppliers MUST provide the postal address city - I fornitori italiani devono indicare la città di residenza.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:PostalAddress/cbc:PostalZone" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:PostalAddress/cbc:PostalZone">
+          <xsl:attribute name="id">IT-R-004</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>"&gt;[IT-R-004] BT-38 (Seller post code) - Italian suppliers MUST provide the postal address post code - I fornitori italiani devono indicare il CAP di residenza.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M31" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M31" priority="-1" />
+  <xsl:template match="@*|node()" mode="M31" priority="-2">
+    <xsl:apply-templates mode="M31" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN -->
+
+
+	<!--RULE -->
+<xsl:template match="//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE' and cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2) = 'SE']" mode="M32" priority="1007">
+    <svrl:fired-rule context="//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE' and cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2) = 'SE']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space(cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/cbc:CompanyID)) = 14" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space(cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/cbc:CompanyID)) = 14">
+          <xsl:attribute name="id">SE-R-001</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Swedish suppliers, Swedish VAT-numbers must consist of 14 characters.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string(number(substring(cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/cbc:CompanyID, 3, 12))) != 'NaN'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string(number(substring(cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/cbc:CompanyID, 3, 12))) != 'NaN'">
+          <xsl:attribute name="id">SE-R-002</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Swedish suppliers, the Swedish VAT-numbers must have the trailing 12 characters in numeric form</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M32" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity[../cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE' and cbc:CompanyID]" mode="M32" priority="1006">
+    <svrl:fired-rule context="//cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity[../cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE' and cbc:CompanyID]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string(number(cbc:CompanyID)) != 'NaN'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string(number(cbc:CompanyID)) != 'NaN'">
+          <xsl:attribute name="id">SE-R-003</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Swedish organisation numbers should be numeric.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space(cbc:CompanyID)) = 10" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space(cbc:CompanyID)) = 10">
+          <xsl:attribute name="id">SE-R-004</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Swedish organisation numbers consist of 10 characters.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="u:checkSEOrgnr(normalize-space(cbc:CompanyID))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="u:checkSEOrgnr(normalize-space(cbc:CompanyID))">
+          <xsl:attribute name="id">SE-R-013</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The last digit of a Swedish organization number must be valid according to the Luhn algorithm.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M32" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE' and exists(cac:PartyLegalEntity/cbc:CompanyID)]/cac:PartyTaxScheme[normalize-space(upper-case(cac:TaxScheme/cbc:ID)) != 'VAT']/cbc:CompanyID" mode="M32" priority="1005">
+    <svrl:fired-rule context="//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE' and exists(cac:PartyLegalEntity/cbc:CompanyID)]/cac:PartyTaxScheme[normalize-space(upper-case(cac:TaxScheme/cbc:ID)) != 'VAT']/cbc:CompanyID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(upper-case(.)) = 'GODKÄND FÖR F-SKATT'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(upper-case(.)) = 'GODKÄND FÖR F-SKATT'">
+          <xsl:attribute name="id">SE-R-005</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Swedish suppliers, when using Seller tax registration identifier, 'Godkänd för F-skatt' must be stated</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M32" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:TaxCategory[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE' and cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2) = 'SE'] and cbc:ID = 'S'] | //cac:ClassifiedTaxCategory[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE' and cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2) = 'SE'] and cbc:ID = 'S']" mode="M32" priority="1004">
+    <svrl:fired-rule context="//cac:TaxCategory[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE' and cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2) = 'SE'] and cbc:ID = 'S'] | //cac:ClassifiedTaxCategory[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE' and cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2) = 'SE'] and cbc:ID = 'S']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="number(cbc:Percent) = 25 or number(cbc:Percent) = 12 or number(cbc:Percent) = 6" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="number(cbc:Percent) = 25 or number(cbc:Percent) = 12 or number(cbc:Percent) = 6">
+          <xsl:attribute name="id">SE-R-006</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Swedish suppliers, only standard VAT rate of 6, 12 or 25 are used</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M32" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:PaymentMeans[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE'] and normalize-space(cbc:PaymentMeansCode) = '30' and normalize-space(cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cbc:ID) = 'SE:PLUSGIRO']/cac:PayeeFinancialAccount/cbc:ID" mode="M32" priority="1003">
+    <svrl:fired-rule context="//cac:PaymentMeans[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE'] and normalize-space(cbc:PaymentMeansCode) = '30' and normalize-space(cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cbc:ID) = 'SE:PLUSGIRO']/cac:PayeeFinancialAccount/cbc:ID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string(number(normalize-space(.))) != 'NaN'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string(number(normalize-space(.))) != 'NaN'">
+          <xsl:attribute name="id">SE-R-007</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Swedish suppliers using Plusgiro, the Account ID must be numeric </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space(.)) >= 2 and string-length(normalize-space(.)) &lt;= 8" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space(.)) >= 2 and string-length(normalize-space(.)) &lt;= 8">
+          <xsl:attribute name="id">SE-R-010</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Swedish suppliers using Plusgiro, the Account ID must have 2-8 characters</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M32" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:PaymentMeans[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE'] and normalize-space(cbc:PaymentMeansCode) = '30' and normalize-space(cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cbc:ID) = 'SE:BANKGIRO']/cac:PayeeFinancialAccount/cbc:ID" mode="M32" priority="1002">
+    <svrl:fired-rule context="//cac:PaymentMeans[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE'] and normalize-space(cbc:PaymentMeansCode) = '30' and normalize-space(cac:PayeeFinancialAccount/cac:FinancialInstitutionBranch/cbc:ID) = 'SE:BANKGIRO']/cac:PayeeFinancialAccount/cbc:ID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string(number(normalize-space(.))) != 'NaN'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string(number(normalize-space(.))) != 'NaN'">
+          <xsl:attribute name="id">SE-R-008</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Swedish suppliers using Bankgiro, the Account ID must be numeric </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space(.)) = 7 or string-length(normalize-space(.)) = 8" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space(.)) = 7 or string-length(normalize-space(.)) = 8">
+          <xsl:attribute name="id">SE-R-009</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Swedish suppliers using Bankgiro, the Account ID must have 7-8 characters</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M32" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:PaymentMeans[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE'] and (cbc:PaymentMeansCode = normalize-space('50') or cbc:PaymentMeansCode = normalize-space('56'))]" mode="M32" priority="1001">
+    <svrl:fired-rule context="//cac:PaymentMeans[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE'] and (cbc:PaymentMeansCode = normalize-space('50') or cbc:PaymentMeansCode = normalize-space('56'))]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="false()" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="false()">
+          <xsl:attribute name="id">SE-R-011</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For Swedish suppliers using Swedish Bankgiro or Plusgiro, the proper way to indicate this is to use Code 30 for PaymentMeans and FinancialInstitutionBranch ID with code SE:BANKGIRO or SE:PLUSGIRO</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M32" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="//cac:PaymentMeans[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE']  and //cac:AccountingCustomerParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE'] and (cbc:PaymentMeansCode = normalize-space('31'))]" mode="M32" priority="1000">
+    <svrl:fired-rule context="//cac:PaymentMeans[//cac:AccountingSupplierParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE']  and //cac:AccountingCustomerParty/cac:Party[cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'SE'] and (cbc:PaymentMeansCode = normalize-space('31'))]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="false()" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="false()">
+          <xsl:attribute name="id">SE-R-012</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For domestic transactions between Swedish trading partners, credit transfer should be indicated by PaymentMeansCode="30"</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M32" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M32" priority="-1" />
+  <xsl:template match="@*|node()" mode="M32" priority="-2">
+    <xsl:apply-templates mode="M32" select="@*|*" />
+  </xsl:template>
+  <xsl:param name="isGreekSender" select="($supplierCountry ='GR') or ($supplierCountry ='EL')" />
+  <xsl:param name="isGreekReceiver" select="($customerCountry ='GR') or ($customerCountry ='EL')" />
+  <xsl:param name="isGreekSenderandReceiver" select="$isGreekSender and $isGreekReceiver" />
+  <xsl:param name="accountingSupplierCountry" select="     if (/*/cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2)) then     upper-case(normalize-space(/*/cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 1, 2)))     else     if (/*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode) then     upper-case(normalize-space(/*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode))     else     'XX'" />
+
+<!--PATTERN -->
+<xsl:variable name="dateRegExp" select="'^(0?[1-9]|[12][0-9]|3[01])[-\\/ ]?(0?[1-9]|1[0-2])[-\\/ ]?(19|20)[0-9]{2}'" />
+  <xsl:variable name="greekDocumentType" select="tokenize('1.1 1.6 2.1 2.4 5.1 5.2 ','\s')" />
+  <xsl:variable name="tokenizedUblIssueDate" select="tokenize(/*/cbc:IssueDate,'-')" />
+
+	<!--RULE -->
+<xsl:template match="/ubl-invoice:Invoice/cbc:ID[$isGreekSender] | /ubl-creditnote:CreditNote/cbc:ID[$isGreekSender]" mode="M37" priority="1007">
+    <svrl:fired-rule context="/ubl-invoice:Invoice/cbc:ID[$isGreekSender] | /ubl-creditnote:CreditNote/cbc:ID[$isGreekSender]" />
+    <xsl:variable name="IdSegments" select="tokenize(.,'\|')" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count($IdSegments) = 6" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count($IdSegments) = 6">
+          <xsl:attribute name="id">GR-R-001-1</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text> When the Supplier is Greek, the Invoice Id should consist of 6 segments</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space($IdSegments[1])) = 9                                   and u:TinVerification($IdSegments[1])                                  and ($IdSegments[1] = /*/cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 3, 9)                                  or $IdSegments[1] = /*/cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 3, 9) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space($IdSegments[1])) = 9 and u:TinVerification($IdSegments[1]) and ($IdSegments[1] = /*/cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 3, 9) or $IdSegments[1] = /*/cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 3, 9) )">
+          <xsl:attribute name="id">GR-R-001-2</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When the Supplier is Greek, the Invoice Id first segment must be a valid TIN Number and match either the Supplier's or the Tax Representative's Tin Number</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:variable name="tokenizedIdDate" select="tokenize($IdSegments[2],'/')" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space($IdSegments[2]))>0                                   and matches($IdSegments[2],$dateRegExp)                                  and ($tokenizedIdDate[1] = $tokenizedUblIssueDate[3]                                     and $tokenizedIdDate[2] = $tokenizedUblIssueDate[2]                                    and $tokenizedIdDate[3] = $tokenizedUblIssueDate[1])" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space($IdSegments[2]))>0 and matches($IdSegments[2],$dateRegExp) and ($tokenizedIdDate[1] = $tokenizedUblIssueDate[3] and $tokenizedIdDate[2] = $tokenizedUblIssueDate[2] and $tokenizedIdDate[3] = $tokenizedUblIssueDate[1])">
+          <xsl:attribute name="id">GR-R-001-3</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When the Supplier is Greek, the Invoice Id second segment must be a valid Date that matches the invoice Issue Date</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space($IdSegments[3]))>0 and string(number($IdSegments[3])) != 'NaN' and xs:integer($IdSegments[3]) >= 0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space($IdSegments[3]))>0 and string(number($IdSegments[3])) != 'NaN' and xs:integer($IdSegments[3]) >= 0">
+          <xsl:attribute name="id">GR-R-001-4</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When Supplier is Greek, the Invoice Id third segment must be a positive integer</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space($IdSegments[4]))>0 and (some $c in $greekDocumentType satisfies $IdSegments[4] = $c)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space($IdSegments[4]))>0 and (some $c in $greekDocumentType satisfies $IdSegments[4] = $c)">
+          <xsl:attribute name="id">GR-R-001-5</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When Supplier is Greek, the Invoice Id in the fourth segment must be a valid greek document type</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length($IdSegments[5]) > 0 " />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length($IdSegments[5]) > 0">
+          <xsl:attribute name="id">GR-R-001-6</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When Supplier is Greek, the Invoice Id fifth segment must not be empty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length($IdSegments[6]) > 0 " />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length($IdSegments[6]) > 0">
+          <xsl:attribute name="id">GR-R-001-7</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When Supplier is Greek, the Invoice Id sixth segment must not be empty</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M37" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty[$isGreekSender]/cac:Party" mode="M37" priority="1006">
+    <svrl:fired-rule context="cac:AccountingSupplierParty[$isGreekSender]/cac:Party" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(./cac:PartyName/cbc:Name)>0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(./cac:PartyName/cbc:Name)>0">
+          <xsl:attribute name="id">GR-R-002</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Greek Suppliers must provide their full name as they are registered in the Greek Business Registry (G.E.MH.) as a legal entity or in the Tax Registry as a natural person </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID)=1 and                             substring(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID,1,2) = 'EL' and                             u:TinVerification(substring(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID,3))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID)=1 and substring(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID,1,2) = 'EL' and u:TinVerification(substring(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID,3))">
+          <xsl:attribute name="id">GR-S-011</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Greek suppliers must provide their Seller Tax Registration Number, prefixed by the country code</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M37" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty[$isGreekSender]/cac:Party/cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID" mode="M37" priority="1005">
+    <svrl:fired-rule context="cac:AccountingSupplierParty[$isGreekSender]/cac:Party/cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="substring(.,1,2) = 'EL' and u:TinVerification(substring(.,3))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="substring(.,1,2) = 'EL' and u:TinVerification(substring(.,3))">
+          <xsl:attribute name="id">GR-R-003</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>For the Greek Suppliers, the VAT must start with 'EL' and must be a valid TIN number</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M37" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="/ubl-invoice:Invoice[$isGreekSender and ( /*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'GR')] | /ubl-creditnote:CreditNote[$isGreekSender and ( /*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'GR')]" mode="M37" priority="1004">
+    <svrl:fired-rule context="/ubl-invoice:Invoice[$isGreekSender and ( /*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'GR')] | /ubl-creditnote:CreditNote[$isGreekSender and ( /*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'GR')]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:AdditionalDocumentReference[cbc:DocumentDescription = '##M.AR.K##'])=1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:AdditionalDocumentReference[cbc:DocumentDescription = '##M.AR.K##'])=1">
+          <xsl:attribute name="id">GR-R-004-1</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text> When Supplier is Greek, there must be one MARK Number</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:AdditionalDocumentReference[cbc:DocumentDescription = '##INVOICE|URL##'])=1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:AdditionalDocumentReference[cbc:DocumentDescription = '##INVOICE|URL##'])=1">
+          <xsl:attribute name="id">GR-S-008-1</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When Supplier is Greek, there should be one invoice url</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(count(cac:AdditionalDocumentReference[cbc:DocumentDescription = '##INVOICE|URL##']) = 0 ) or (count(cac:AdditionalDocumentReference[cbc:DocumentDescription = '##INVOICE|URL##']) = 1 )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(count(cac:AdditionalDocumentReference[cbc:DocumentDescription = '##INVOICE|URL##']) = 0 ) or (count(cac:AdditionalDocumentReference[cbc:DocumentDescription = '##INVOICE|URL##']) = 1 )">
+          <xsl:attribute name="id">GR-R-008-2</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When Supplier is Greek, there should be no more than one invoice url</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M37" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AdditionalDocumentReference[$isGreekSender and ( /*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'GR') and cbc:DocumentDescription = '##M.AR.K##']/cbc:ID" mode="M37" priority="1003">
+    <svrl:fired-rule context="cac:AdditionalDocumentReference[$isGreekSender and ( /*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'GR') and cbc:DocumentDescription = '##M.AR.K##']/cbc:ID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="matches(.,'^[1-9]([0-9]*)')" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="matches(.,'^[1-9]([0-9]*)')">
+          <xsl:attribute name="id">GR-R-004-2</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When Supplier is Greek, the MARK Number must be a positive integer</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M37" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AdditionalDocumentReference[$isGreekSender and cbc:DocumentDescription = '##INVOICE|URL##']" mode="M37" priority="1002">
+    <svrl:fired-rule context="cac:AdditionalDocumentReference[$isGreekSender and cbc:DocumentDescription = '##INVOICE|URL##']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(normalize-space(cac:Attachment/cac:ExternalReference/cbc:URI))>0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(normalize-space(cac:Attachment/cac:ExternalReference/cbc:URI))>0">
+          <xsl:attribute name="id">GR-R-008-3</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>When Supplier is Greek and the INVOICE URL Document reference exists, the External Reference URI should be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M37" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingCustomerParty[$isGreekSender]/cac:Party" mode="M37" priority="1001">
+    <svrl:fired-rule context="cac:AccountingCustomerParty[$isGreekSender]/cac:Party" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(./cac:PartyName/cbc:Name)>0" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(./cac:PartyName/cbc:Name)>0">
+          <xsl:attribute name="id">GR-R-005</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Greek Suppliers must provide the full name of the buyer</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M37" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty/cac:Party[$accountingSupplierCountry='GR' or $accountingSupplierCountry='EL']/cbc:EndpointID" mode="M37" priority="1000">
+    <svrl:fired-rule context="cac:AccountingSupplierParty/cac:Party[$accountingSupplierCountry='GR' or $accountingSupplierCountry='EL']/cbc:EndpointID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="./@schemeID='9933' and u:TinVerification(.)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="./@schemeID='9933' and u:TinVerification(.)">
+          <xsl:attribute name="id">GR-R-009</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Greek suppliers that send an invoice through the PEPPOL network must use a correct TIN number as an electronic address according to PEPPOL Electronic Address Identifier scheme (schemeID 9933).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M37" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M37" priority="-1" />
+  <xsl:template match="@*|node()" mode="M37" priority="-2">
+    <xsl:apply-templates mode="M37" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN -->
+
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingCustomerParty[$isGreekSenderandReceiver]/cac:Party" mode="M38" priority="1001">
+    <svrl:fired-rule context="cac:AccountingCustomerParty[$isGreekSenderandReceiver]/cac:Party" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID)=1 and                             substring(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID,1,2) = 'EL' and                             u:TinVerification(substring(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID,3))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID)=1 and substring(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID,1,2) = 'EL' and u:TinVerification(substring(cac:PartyTaxScheme[normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']/cbc:CompanyID,3))">
+          <xsl:attribute name="id">GR-R-006</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Greek Suppliers must provide the VAT number of the buyer, if the buyer is Greek </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M38" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingCustomerParty[$isGreekSenderandReceiver]/cac:Party/cbc:EndpointID" mode="M38" priority="1000">
+    <svrl:fired-rule context="cac:AccountingCustomerParty[$isGreekSenderandReceiver]/cac:Party/cbc:EndpointID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="./@schemeID='9933' and u:TinVerification(.)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="./@schemeID='9933' and u:TinVerification(.)">
+          <xsl:attribute name="id">GR-R-010</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Greek Suppliers that send an invoice through the PEPPOL network to a greek buyer must use a correct TIN number as an electronic address according to PEPPOL Electronic Address Identifier scheme (SchemeID 9933)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M38" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M38" priority="-1" />
+  <xsl:template match="@*|node()" mode="M38" priority="-2">
+    <xsl:apply-templates mode="M38" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN -->
+<xsl:variable name="SupplierCountry" select="concat(ubl-creditnote:CreditNote/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode, ubl-invoice:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode)" />
+  <xsl:variable name="CustomerCountry" select="concat(ubl-creditnote:CreditNote/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode, ubl-invoice:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode)" />
+
+	<!--RULE -->
+<xsl:template match="ubl-creditnote:CreditNote[$SupplierCountry = 'IS'] | ubl-invoice:Invoice[$SupplierCountry = 'IS']" mode="M39" priority="1001">
+    <svrl:fired-rule context="ubl-creditnote:CreditNote[$SupplierCountry = 'IS'] | ubl-invoice:Invoice[$SupplierCountry = 'IS']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="( ( not(contains(normalize-space(cbc:InvoiceTypeCode),' ')) and contains( ' 380 381 ',concat(' ',normalize-space(cbc:InvoiceTypeCode),' ') ) ) ) or ( ( not(contains(normalize-space(cbc:CreditNoteTypeCode),' ')) and contains( ' 380 381 ',concat(' ',normalize-space(cbc:CreditNoteTypeCode),' ') ) ) )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="( ( not(contains(normalize-space(cbc:InvoiceTypeCode),' ')) and contains( ' 380 381 ',concat(' ',normalize-space(cbc:InvoiceTypeCode),' ') ) ) ) or ( ( not(contains(normalize-space(cbc:CreditNoteTypeCode),' ')) and contains( ' 380 381 ',concat(' ',normalize-space(cbc:CreditNoteTypeCode),' ') ) ) )">
+          <xsl:attribute name="id">IS-R-001</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IS-R-001]-If seller is icelandic then invoice type should be 380 or 381 — Ef seljandi er íslenskur þá ætti gerð reiknings (BT-3) að vera sölureikningur (380) eða kreditreikningur (381).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID) and cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID/@schemeID = '0196'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID) and cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID/@schemeID = '0196'">
+          <xsl:attribute name="id">IS-R-002</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IS-R-002]-If seller is icelandic then it shall contain sellers legal id — Ef seljandi er íslenskur þá skal reikningur innihalda íslenska kennitölu seljanda (BT-30).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:StreetName) and exists(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:PostalZone)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:StreetName) and exists(cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:PostalZone)">
+          <xsl:attribute name="id">IS-R-003</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IS-R-003]-If seller is icelandic then it shall contain his address with street name and zip code — Ef seljandi er íslenskur þá skal heimilisfang seljanda innihalda götuheiti og póstnúmer (BT-35 og BT-38).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:PaymentMeans[cbc:PaymentMeansCode = '9']/cac:PayeeFinancialAccount/cbc:ID)         and string-length(normalize-space(cac:PaymentMeans[cbc:PaymentMeansCode = '9']/cac:PayeeFinancialAccount/cbc:ID)) = 12        or not(exists(cac:PaymentMeans[cbc:PaymentMeansCode = '9']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:PaymentMeans[cbc:PaymentMeansCode = '9']/cac:PayeeFinancialAccount/cbc:ID) and string-length(normalize-space(cac:PaymentMeans[cbc:PaymentMeansCode = '9']/cac:PayeeFinancialAccount/cbc:ID)) = 12 or not(exists(cac:PaymentMeans[cbc:PaymentMeansCode = '9']))">
+          <xsl:attribute name="id">IS-R-006</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IS-R-006]-If seller is icelandic and payment means code is 9 then a 12 digit account id must exist — Ef seljandi er íslenskur og greiðslumáti (BT-81) er krafa (kóti 9) þá skal koma fram 12 stafa númer (bankanúmer, höfuðbók 66 og reikningsnúmer) (BT-84)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:PaymentMeans[cbc:PaymentMeansCode = '42']/cac:PayeeFinancialAccount/cbc:ID)         and string-length(normalize-space(cac:PaymentMeans[cbc:PaymentMeansCode = '42']/cac:PayeeFinancialAccount/cbc:ID)) = 12        or not(exists(cac:PaymentMeans[cbc:PaymentMeansCode = '42']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:PaymentMeans[cbc:PaymentMeansCode = '42']/cac:PayeeFinancialAccount/cbc:ID) and string-length(normalize-space(cac:PaymentMeans[cbc:PaymentMeansCode = '42']/cac:PayeeFinancialAccount/cbc:ID)) = 12 or not(exists(cac:PaymentMeans[cbc:PaymentMeansCode = '42']))">
+          <xsl:attribute name="id">IS-R-007</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IS-R-007]-If seller is icelandic and payment means code is 42 then a 12 digit account id must exist — Ef seljandi er íslenskur og greiðslumáti (BT-81) er millifærsla (kóti 42) þá skal koma fram 12 stafa reikningnúmer (BT-84)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']) and string-length(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']/cbc:ID) = 10 and (string(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']/cbc:ID) castable as xs:date)) or not(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']) and string-length(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']/cbc:ID) = 10 and (string(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']/cbc:ID) castable as xs:date)) or not(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']))">
+          <xsl:attribute name="id">IS-R-008</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IS-R-008]-If seller is icelandic and invoice contains supporting description EINDAGI then the id form must be YYYY-MM-DD — Ef seljandi er íslenskur þá skal eindagi (BT-122, DocumentDescription = EINDAGI) vera á forminu YYYY-MM-DD.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']) and exists(cbc:DueDate)) or not(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']) and exists(cbc:DueDate)) or not(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']))">
+          <xsl:attribute name="id">IS-R-009</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IS-R-009]-If seller is icelandic and invoice contains supporting description EINDAGI invoice must have due date — Ef seljandi er íslenskur þá skal reikningur sem inniheldur eindaga (BT-122, DocumentDescription = EINDAGI) einnig hafa gjalddaga (BT-9).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']) and (cbc:DueDate) &lt;= (cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']/cbc:ID)) or not(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']) and (cbc:DueDate) &lt;= (cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']/cbc:ID)) or not(exists(cac:AdditionalDocumentReference[cbc:DocumentDescription = 'EINDAGI']))">
+          <xsl:attribute name="id">IS-R-010</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IS-R-010]-If seller is icelandic and invoice contains supporting description EINDAGI the id date must be same or later than due date — Ef seljandi er íslenskur þá skal eindagi (BT-122, DocumentDescription = EINDAGI) skal vera sami eða síðar en gjalddagi (BT-9) ef eindagi er til staðar.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M39" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="ubl-creditnote:CreditNote[$SupplierCountry = 'IS' and $CustomerCountry = 'IS']/cac:AccountingCustomerParty | ubl-invoice:Invoice[$SupplierCountry = 'IS' and $CustomerCountry = 'IS']/cac:AccountingCustomerParty" mode="M39" priority="1000">
+    <svrl:fired-rule context="ubl-creditnote:CreditNote[$SupplierCountry = 'IS' and $CustomerCountry = 'IS']/cac:AccountingCustomerParty | ubl-invoice:Invoice[$SupplierCountry = 'IS' and $CustomerCountry = 'IS']/cac:AccountingCustomerParty" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:Party/cac:PartyLegalEntity/cbc:CompanyID) and cac:Party/cac:PartyLegalEntity/cbc:CompanyID/@schemeID = '0196'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:Party/cac:PartyLegalEntity/cbc:CompanyID) and cac:Party/cac:PartyLegalEntity/cbc:CompanyID/@schemeID = '0196'">
+          <xsl:attribute name="id">IS-R-004</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IS-R-004]-If seller and buyer are icelandic then the invoice shall contain the buyers icelandic legal identifier — Ef seljandi og kaupandi eru íslenskir þá skal reikningurinn innihalda íslenska kennitölu kaupanda (BT-47).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(cac:Party/cac:PostalAddress/cbc:StreetName) and exists(cac:Party/cac:PostalAddress/cbc:PostalZone)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(cac:Party/cac:PostalAddress/cbc:StreetName) and exists(cac:Party/cac:PostalAddress/cbc:PostalZone)">
+          <xsl:attribute name="id">IS-R-005</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[IS-R-005]-If seller and buyer are icelandic then the invoice shall contain the buyers address with street name and zip code — Ef seljandi og kaupandi eru íslenskir þá skal heimilisfang kaupanda innihalda götuheiti og póstnúmer (BT-50 og BT-53)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M39" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M39" priority="-1" />
+  <xsl:template match="@*|node()" mode="M39" priority="-2">
+    <xsl:apply-templates mode="M39" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN -->
+<xsl:variable name="supplierCountryIsNL" select="(upper-case(normalize-space(/*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode)) = 'NL')" />
+  <xsl:variable name="customerCountryIsNL" select="(upper-case(normalize-space(/*/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode)) = 'NL')" />
+  <xsl:variable name="taxRepresentativeCountryIsNL" select="(upper-case(normalize-space(/*/cac:TaxRepresentativeParty/cac:PostalAddress/cac:Country/cbc:IdentificationCode)) = 'NL')" />
+
+	<!--RULE -->
+<xsl:template match="cbc:CreditNoteTypeCode[$supplierCountryIsNL]" mode="M40" priority="1008">
+    <svrl:fired-rule context="cbc:CreditNoteTypeCode[$supplierCountryIsNL]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="/*/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="/*/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID">
+          <xsl:attribute name="id">NL-R-001</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[NL-R-001] For suppliers in the Netherlands, if the document is a creditnote, the document MUST contain an invoice reference (cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M40" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty/cac:Party/cac:PostalAddress[$supplierCountryIsNL]" mode="M40" priority="1007">
+    <svrl:fired-rule context="cac:AccountingSupplierParty/cac:Party/cac:PostalAddress[$supplierCountryIsNL]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:StreetName and cbc:CityName and cbc:PostalZone" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:StreetName and cbc:CityName and cbc:PostalZone">
+          <xsl:attribute name="id">NL-R-002</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[NL-R-002] For suppliers in the Netherlands the supplier's address (cac:AccountingSupplierParty/cac:Party/cac:PostalAddress) MUST contain street name (cbc:StreetName), city (cbc:CityName) and post code (cbc:PostalZone)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M40" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID[$supplierCountryIsNL]" mode="M40" priority="1006">
+    <svrl:fired-rule context="cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID[$supplierCountryIsNL]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0106 ') or contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0190 ')) and (normalize-space(.) != '')" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0106 ') or contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0190 ')) and (normalize-space(.) != '')">
+          <xsl:attribute name="id">NL-R-003</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[NL-R-003] For suppliers in the Netherlands, the legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M40" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingCustomerParty/cac:Party/cac:PostalAddress[$supplierCountryIsNL and $customerCountryIsNL]" mode="M40" priority="1005">
+    <svrl:fired-rule context="cac:AccountingCustomerParty/cac:Party/cac:PostalAddress[$supplierCountryIsNL and $customerCountryIsNL]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:StreetName and cbc:CityName and cbc:PostalZone" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:StreetName and cbc:CityName and cbc:PostalZone">
+          <xsl:attribute name="id">NL-R-004</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[NL-R-004] For suppliers in the Netherlands, if the customer is in the Netherlands, the customer address (cac:AccountingCustomerParty/cac:Party/cac:PostalAddress) MUST contain the street name (cbc:StreetName), the city (cbc:CityName) and post code (cbc:PostalZone)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M40" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID[$supplierCountryIsNL and $customerCountryIsNL]" mode="M40" priority="1004">
+    <svrl:fired-rule context="cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID[$supplierCountryIsNL and $customerCountryIsNL]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0106 ') or contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0190 ')) and (normalize-space(.) != '')" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0106 ') or contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0190 ')) and (normalize-space(.) != '')">
+          <xsl:attribute name="id">NL-R-005</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[NL-R-005] For suppliers in the Netherlands, if the customer is in the Netherlands, the customer's legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M40" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxRepresentativeParty/cac:PostalAddress[$supplierCountryIsNL and $taxRepresentativeCountryIsNL]" mode="M40" priority="1003">
+    <svrl:fired-rule context="cac:TaxRepresentativeParty/cac:PostalAddress[$supplierCountryIsNL and $taxRepresentativeCountryIsNL]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:StreetName and cbc:CityName and cbc:PostalZone" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:StreetName and cbc:CityName and cbc:PostalZone">
+          <xsl:attribute name="id">NL-R-006</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[NL-R-006] For suppliers in the Netherlands, if the fiscal representative is in the Netherlands, the representative's address (cac:TaxRepresentativeParty/cac:PostalAddress) MUST contain street name (cbc:StreetName), city (cbc:CityName) and post code (cbc:PostalZone)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M40" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:LegalMonetaryTotal[$supplierCountryIsNL]" mode="M40" priority="1002">
+    <svrl:fired-rule context="cac:LegalMonetaryTotal[$supplierCountryIsNL]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="(/ubl-invoice:Invoice and xs:decimal(cbc:PayableAmount) &lt;= 0.0) or (/ubl-creditnote:CreditNote and xs:decimal(cbc:PayableAmount) >= 0.0) or (//cac:PaymentMeans)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(/ubl-invoice:Invoice and xs:decimal(cbc:PayableAmount) &lt;= 0.0) or (/ubl-creditnote:CreditNote and xs:decimal(cbc:PayableAmount) >= 0.0) or (//cac:PaymentMeans)">
+          <xsl:attribute name="id">NL-R-007</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (cac:PaymentMeans) if the payment is from customer to supplier</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M40" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:PaymentMeans[$supplierCountryIsNL and $customerCountryIsNL]" mode="M40" priority="1001">
+    <svrl:fired-rule context="cac:PaymentMeans[$supplierCountryIsNL and $customerCountryIsNL]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:PaymentMeansCode) = '30' or         normalize-space(cbc:PaymentMeansCode) = '48' or         normalize-space(cbc:PaymentMeansCode) = '49' or         normalize-space(cbc:PaymentMeansCode) = '57' or         normalize-space(cbc:PaymentMeansCode) = '58' or         normalize-space(cbc:PaymentMeansCode) = '59'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:PaymentMeansCode) = '30' or normalize-space(cbc:PaymentMeansCode) = '48' or normalize-space(cbc:PaymentMeansCode) = '49' or normalize-space(cbc:PaymentMeansCode) = '57' or normalize-space(cbc:PaymentMeansCode) = '58' or normalize-space(cbc:PaymentMeansCode) = '59'">
+          <xsl:attribute name="id">NL-R-008</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[NL-R-008] For suppliers in the Netherlands, if the customer is in the Netherlands, the payment means code (cac:PaymentMeans/cbc:PaymentMeansCode) MUST be one of 30, 48, 49, 57, 58 or 59</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M40" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:OrderLineReference/cbc:LineID[$supplierCountryIsNL]" mode="M40" priority="1000">
+    <svrl:fired-rule context="cac:OrderLineReference/cbc:LineID[$supplierCountryIsNL]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="exists(/*/cac:OrderReference/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="exists(/*/cac:OrderReference/cbc:ID)">
+          <xsl:attribute name="id">NL-R-009</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[NL-R-009] For suppliers in the Netherlands, if an order line reference (cac:OrderLineReference/cbc:LineID) is used, there must be an order reference on the document level (cac:OrderReference/cbc:ID)</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M40" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M40" priority="-1" />
+  <xsl:template match="@*|node()" mode="M40" priority="-2">
+    <xsl:apply-templates mode="M40" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN german-rules-->
+<xsl:variable name="XR-SKONTO-REGEX" select="'#(SKONTO)#TAGE=([0-9]+#PROZENT=[0-9]+\.[0-9]{2})(#BASISBETRAG=-?[0-9]+\.[0-9]{2})?#$'" />
+  <xsl:variable name="XR-EMAIL-REGEX" select="'^[a-zA-Z0-9!#\$%&amp;&quot;*+/=?^_`{|}~-]+(\.[a-zA-Z0-9!#\$%&amp;&quot;*+/=?^_`{|}~-]+)*@([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$'" />
+  <xsl:variable name="XR-TELEPHONE-REGEX" select="'.*([0-9].*){3,}.*'" />
+
+	<!--RULE -->
+<xsl:template match="(/ubl-invoice:Invoice | /ubl-creditnote:CreditNote)[$supplierCountryIsDE and $customerCountryIsDE]" mode="M41" priority="1009">
+    <svrl:fired-rule context="(/ubl-invoice:Invoice | /ubl-creditnote:CreditNote)[$supplierCountryIsDE and $customerCountryIsDE]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:PaymentMeans" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:PaymentMeans">
+          <xsl:attribute name="id">DE-R-001</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>An invoice shall contain information on "PAYMENT INSTRUCTIONS" (BG-16).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:BuyerReference[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:BuyerReference[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-015</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Buyer reference" (BT-10) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:variable name="supportedVATCodes" select="('S', 'Z', 'E', 'AE', 'K', 'G', 'L', 'M')" />
+    <xsl:variable name="BT-31orBT-32Path" select="cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID[boolean(normalize-space(.))]" />
+    <xsl:variable name="BT-95-UBL-Inv" select="cac:AllowanceCharge/cac:TaxCategory/cbc:ID[ancestor::cac:AllowanceCharge/cbc:ChargeIndicator = 'false' and         following-sibling::cac:TaxScheme/cbc:ID = 'VAT']" />
+    <xsl:variable name="BT-95-UBL-CN" select="cac:AllowanceCharge/cac:TaxCategory/cbc:ID[ancestor::cac:AllowanceCharge/cbc:ChargeIndicator = 'false']" />
+    <xsl:variable name="BT-102" select="cac:AllowanceCharge/cac:TaxCategory/cbc:ID[ancestor::cac:AllowanceCharge/cbc:ChargeIndicator = 'true']" />
+    <xsl:variable name="BT-151" select="(cac:InvoiceLine | cac:CreditNoteLine)/cac:Item/cac:ClassifiedTaxCategory/cbc:ID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="         (not(           ($BT-95-UBL-Inv = $supportedVATCodes or $BT-95-UBL-CN = $supportedVATCodes) or           ($BT-102 = $supportedVATCodes) or           ($BT-151 = $supportedVATCodes)         ) or         (cac:TaxRepresentativeParty, $BT-31orBT-32Path))         " />
+      <xsl:otherwise>
+        <svrl:failed-assert test="(not( ($BT-95-UBL-Inv = $supportedVATCodes or $BT-95-UBL-CN = $supportedVATCodes) or ($BT-102 = $supportedVATCodes) or ($BT-151 = $supportedVATCodes) ) or (cac:TaxRepresentativeParty, $BT-31orBT-32Path))">
+          <xsl:attribute name="id">DE-R-016</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If one of the VAT codes S, Z, E, AE, K, G, L, or M is used, an invoice shall contain at least one of the following elements: "Seller VAT identifier" (BT-31) or "Seller tax registration identifier" (BT-32) or "SELLER TAX REPRESENTATIVE PARTY" (BG-11).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:variable name="supportedInvAndCNTypeCodes" select="('326', '380', '384', '389', '381', '875', '876', '877')" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:InvoiceTypeCode = $supportedInvAndCNTypeCodes         or cbc:CreditNoteTypeCode = $supportedInvAndCNTypeCodes" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:InvoiceTypeCode = $supportedInvAndCNTypeCodes or cbc:CreditNoteTypeCode = $supportedInvAndCNTypeCodes">
+          <xsl:attribute name="id">DE-R-017</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Invoice type code" (BT-3) should only contain the following values from code list UNTDID 1001: 326 (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 389 (Self-billed invoice), 381 (Credit note), 875 (Partial construction invoice), 876 (Partial final construction invoice), 877 (Final construction invoice).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="every $line in             cac:PaymentTerms/cbc:Note[1]/tokenize(. , '(\r?\n)')[starts-with( normalize-space(.) , '#')]              satisfies matches ( normalize-space ($line), $XR-SKONTO-REGEX)                                  and                                 matches( cac:PaymentTerms/cbc:Note[1]/tokenize(. ,  '#.+#')[last()], '^\s*\n' )" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="every $line in cac:PaymentTerms/cbc:Note[1]/tokenize(. , '(\r?\n)')[starts-with( normalize-space(.) , '#')] satisfies matches ( normalize-space ($line), $XR-SKONTO-REGEX) and matches( cac:PaymentTerms/cbc:Note[1]/tokenize(. , '#.+#')[last()], '^\s*\n' )">
+          <xsl:attribute name="id">DE-R-018</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Information on cash discounts for prompt payment (Skonto) shall be provided within the element "Payment terms" BT-20 in the following way: First segment "SKONTO", second segment amount of days ("TAGE=N"), third segment percentage ("PROZENT=N"). Percentage must be separated by dot with two decimal places. In case the base value of the invoiced amount is not provided in BT-115 but as a partial amount, the base value shall be provided as fourth segment "BASISBETRAG=N" as semantic data type amount. Each entry shall start with a #, the segments must be separated by # and a row shall end with a #. A complete statement on cash discount for prompt payment shall end with a XML-conformant line break. All statements on cash discount for prompt payment shall be given in capital letters. Additional whitespaces (blanks, tabulators or line breaks) are not allowed. Other characters or texts than defined above are not allowed.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="count(cac:AdditionalDocumentReference) =                      count(cac:AdditionalDocumentReference[not(./cac:Attachment/cbc:EmbeddedDocumentBinaryObject/@filename = preceding-sibling::cac:AdditionalDocumentReference/cac:Attachment/cbc:EmbeddedDocumentBinaryObject/@filename)])" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="count(cac:AdditionalDocumentReference) = count(cac:AdditionalDocumentReference[not(./cac:Attachment/cbc:EmbeddedDocumentBinaryObject/@filename = preceding-sibling::cac:AdditionalDocumentReference/cac:Attachment/cbc:EmbeddedDocumentBinaryObject/@filename)])">
+          <xsl:attribute name="id">DE-R-022</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Attached documents provided with an invoice in "ADDITIONAL SUPPORTING DOCUMENTS" (BG-24) shall have a unique filename (non case-sensitive) within the element ″Attached document″ (BT-125).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="((not(cbc:InvoiceTypeCode = 384 or cbc:CreditNoteTypeCode = 384) or                     (cac:BillingReference/cac:InvoiceDocumentReference)))" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="((not(cbc:InvoiceTypeCode = 384 or cbc:CreditNoteTypeCode = 384) or (cac:BillingReference/cac:InvoiceDocumentReference)))">
+          <xsl:attribute name="id">DE-R-026</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If "Invoice type code" (BT-3) contains the code 384 (Corrected invoice), "PRECEDING INVOICE REFERENCE" (BG-3) should be provided at least once.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate)                        or (cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID[@schemeID='SEPA']                          | cac:PayeeParty/cac:PartyIdentification/cbc:ID[@schemeID='SEPA'])" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate) or (cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID[@schemeID='SEPA'] | cac:PayeeParty/cac:PartyIdentification/cbc:ID[@schemeID='SEPA'])">
+          <xsl:attribute name="id">DE-R-030</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If the group "DIRECT DEBIT" (BG-19) is delivered, the element "Bank assigned creditor identifier" (BT-90) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PaymentMeans/cac:PaymentMandate) or (cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PaymentMeans/cac:PaymentMandate) or (cac:PaymentMeans/cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID)">
+          <xsl:attribute name="id">DE-R-031</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If the group "DIRECT DEBIT" (BG-19) is delivered, the element "Debited account identifier" (BT-91) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="(/ubl-invoice:Invoice/cac:AccountingSupplierParty | /ubl-creditnote:CreditNote/cac:AccountingSupplierParty)[$supplierCountryIsDE and $customerCountryIsDE]" mode="M41" priority="1008">
+    <svrl:fired-rule context="(/ubl-invoice:Invoice/cac:AccountingSupplierParty | /ubl-creditnote:CreditNote/cac:AccountingSupplierParty)[$supplierCountryIsDE and $customerCountryIsDE]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:Party/cac:Contact" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:Party/cac:Contact">
+          <xsl:attribute name="id">DE-R-002</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The group "SELLER CONTACT" (BG-6) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="(/ubl-invoice:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress | /ubl-creditnote:CreditNote/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress)[$supplierCountryIsDE and $customerCountryIsDE]" mode="M41" priority="1007">
+    <svrl:fired-rule context="(/ubl-invoice:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress | /ubl-creditnote:CreditNote/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress)[$supplierCountryIsDE and $customerCountryIsDE]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:CityName[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:CityName[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-003</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Seller city" (BT-37) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:PostalZone[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:PostalZone[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-004</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Seller post code" (BT-38) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="(/ubl-invoice:Invoice/cac:AccountingSupplierParty/cac:Party/cac:Contact | /ubl-creditnote:CreditNote/cac:AccountingSupplierParty/cac:Party/cac:Contact)[$supplierCountryIsDE and $customerCountryIsDE]" mode="M41" priority="1006">
+    <svrl:fired-rule context="(/ubl-invoice:Invoice/cac:AccountingSupplierParty/cac:Party/cac:Contact | /ubl-creditnote:CreditNote/cac:AccountingSupplierParty/cac:Party/cac:Contact)[$supplierCountryIsDE and $customerCountryIsDE]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:Name[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:Name[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-005</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Seller contact point" (BT-41) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:Telephone[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:Telephone[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-006</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Seller contact telephone number" (BT-42) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:ElectronicMail[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:ElectronicMail[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-007</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Seller contact email address" (BT-43) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="matches(normalize-space(cbc:Telephone), $XR-TELEPHONE-REGEX)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="matches(normalize-space(cbc:Telephone), $XR-TELEPHONE-REGEX)">
+          <xsl:attribute name="id">DE-R-027</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>"Seller contact telephone number" (BT-42) should contain a valid telephone number. A valid telephone should consist of 3 digits minimum.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="matches(normalize-space(cbc:ElectronicMail), $XR-EMAIL-REGEX)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="matches(normalize-space(cbc:ElectronicMail), $XR-EMAIL-REGEX)">
+          <xsl:attribute name="id">DE-R-028</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>"Seller contact email address" (BT-43) should contain exactly one @-sign, which should not be framed by a whitespace or a dot but by at least two characters on each side. A dot should not be the first or last character.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="(/ubl-invoice:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress | /ubl-creditnote:CreditNote/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress)[$supplierCountryIsDE and $customerCountryIsDE]" mode="M41" priority="1005">
+    <svrl:fired-rule context="(/ubl-invoice:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress | /ubl-creditnote:CreditNote/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress)[$supplierCountryIsDE and $customerCountryIsDE]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:CityName[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:CityName[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-008</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Buyer city" (BT-52) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:PostalZone[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:PostalZone[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-009</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Buyer post code" (BT-53) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="(/ubl-invoice:Invoice/cac:Delivery/cac:DeliveryLocation/cac:Address | /ubl-creditnote:CreditNote/cac:Delivery/cac:DeliveryLocation/cac:Address)[$supplierCountryIsDE and $customerCountryIsDE]" mode="M41" priority="1004">
+    <svrl:fired-rule context="(/ubl-invoice:Invoice/cac:Delivery/cac:DeliveryLocation/cac:Address | /ubl-creditnote:CreditNote/cac:Delivery/cac:DeliveryLocation/cac:Address)[$supplierCountryIsDE and $customerCountryIsDE]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:CityName[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:CityName[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-010</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Deliver to city" (BT-77) shall be provided if the group "DELIVER TO ADDRESS" (BG-15) is delivered.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cbc:PostalZone[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cbc:PostalZone[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-011</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Deliver to post code" (BT-78) shall be provided if the group "DELIVER TO ADDRESS" (BG-15) is delivered.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="(/ubl-invoice:Invoice/cac:PaymentMeans[cbc:PaymentMeansCode = (30,58)] | /ubl-creditnote:CreditNote/cac:PaymentMeans[cbc:PaymentMeansCode = (30,58)])[$supplierCountryIsDE and $customerCountryIsDE]" mode="M41" priority="1003">
+    <svrl:fired-rule context="(/ubl-invoice:Invoice/cac:PaymentMeans[cbc:PaymentMeansCode = (30,58)] | /ubl-creditnote:CreditNote/cac:PaymentMeans[cbc:PaymentMeansCode = (30,58)])[$supplierCountryIsDE and $customerCountryIsDE]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:PaymentMeansCode = '58') or                     matches(normalize-space(replace(cac:PayeeFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')), '^[A-Z]{2}[0-9]{2}[a-zA-Z0-9]{0,30}$') and                     xs:integer(string-join(for $cp in string-to-codepoints(concat(substring(normalize-space(replace(cac:PayeeFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),5),upper-case(substring(normalize-space(replace(cac:PayeeFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),1,2)),substring(normalize-space(replace(cac:PayeeFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),3,2))) return  (if($cp > 64) then string($cp - 55) else  string($cp - 48)),'')) mod 97 = 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:PaymentMeansCode = '58') or matches(normalize-space(replace(cac:PayeeFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')), '^[A-Z]{2}[0-9]{2}[a-zA-Z0-9]{0,30}$') and xs:integer(string-join(for $cp in string-to-codepoints(concat(substring(normalize-space(replace(cac:PayeeFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),5),upper-case(substring(normalize-space(replace(cac:PayeeFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),1,2)),substring(normalize-space(replace(cac:PayeeFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),3,2))) return (if($cp > 64) then string($cp - 55) else string($cp - 48)),'')) mod 97 = 1">
+          <xsl:attribute name="id">DE-R-019</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Payment account identifier" (BT-84) should contain a valid IBAN if code 58 SEPA is provided in "Payment means type code" (BT-81).</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:PayeeFinancialAccount" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:PayeeFinancialAccount">
+          <xsl:attribute name="id">DE-R-023-1</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If "Payment means type code" (BT-81) contains a code for credit transfer (30, 58), "CREDIT TRANSFER" (BG-17) shall
+        be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:CardAccount) and                     not(cac:PaymentMandate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:CardAccount) and not(cac:PaymentMandate)">
+          <xsl:attribute name="id">DE-R-023-2</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If "Payment means type code" (BT-81) contains a code for credit transfer (30, 58), BG-18 and BG-19 shall not be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="(/ubl-invoice:Invoice/cac:PaymentMeans[cbc:PaymentMeansCode = (48,54,55)] |/ubl-creditnote:CreditNote/cac:PaymentMeans[cbc:PaymentMeansCode = (48,54,55)])[$supplierCountryIsDE and $customerCountryIsDE]" mode="M41" priority="1002">
+    <svrl:fired-rule context="(/ubl-invoice:Invoice/cac:PaymentMeans[cbc:PaymentMeansCode = (48,54,55)] |/ubl-creditnote:CreditNote/cac:PaymentMeans[cbc:PaymentMeansCode = (48,54,55)])[$supplierCountryIsDE and $customerCountryIsDE]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:CardAccount" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:CardAccount">
+          <xsl:attribute name="id">DE-R-024-1</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If "Payment means type code" (BT-81) contains a code for payment card (48, 54, 55), "PAYMENT CARD INFORMATION" (BG-18) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeFinancialAccount) and                     not(cac:PaymentMandate)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeFinancialAccount) and not(cac:PaymentMandate)">
+          <xsl:attribute name="id">DE-R-024-2</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If "Payment means type code" (BT-81) contains a code for payment card (48, 54, 55), BG-17 and BG-19 shall not be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="(/ubl-invoice:Invoice/cac:PaymentMeans[cbc:PaymentMeansCode = 59] | /ubl-creditnote:CreditNote/cac:PaymentMeans[cbc:PaymentMeansCode = 59])[$supplierCountryIsDE and $customerCountryIsDE]" mode="M41" priority="1001">
+    <svrl:fired-rule context="(/ubl-invoice:Invoice/cac:PaymentMeans[cbc:PaymentMeansCode = 59] | /ubl-creditnote:CreditNote/cac:PaymentMeans[cbc:PaymentMeansCode = 59])[$supplierCountryIsDE and $customerCountryIsDE]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cbc:PaymentMeansCode = '59') or                     matches(normalize-space(replace(cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')), '^[A-Z]{2}[0-9]{2}[a-zA-Z0-9]{0,30}$') and                     xs:decimal(string-join(for $cp in string-to-codepoints(concat(substring(normalize-space(replace(cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),5),upper-case(substring(normalize-space(replace(cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),1,2)),substring(normalize-space(replace(cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),3,2))) return  (if($cp > 64) then string($cp - 55) else  string($cp - 48)),'')) mod 97 = 1" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cbc:PaymentMeansCode = '59') or matches(normalize-space(replace(cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')), '^[A-Z]{2}[0-9]{2}[a-zA-Z0-9]{0,30}$') and xs:decimal(string-join(for $cp in string-to-codepoints(concat(substring(normalize-space(replace(cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),5),upper-case(substring(normalize-space(replace(cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),1,2)),substring(normalize-space(replace(cac:PaymentMandate/cac:PayerFinancialAccount/cbc:ID, '([ \n\r\t\s])', '')),3,2))) return (if($cp > 64) then string($cp - 55) else string($cp - 48)),'')) mod 97 = 1">
+          <xsl:attribute name="id">DE-R-020</xsl:attribute>
+          <xsl:attribute name="flag">warning</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "Debited account identifier" (BT-91) should contain a valid IBAN if code 59 SEPA is provided in "Payment means type code" (BT-81). </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:PaymentMandate" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:PaymentMandate">
+          <xsl:attribute name="id">DE-R-025-1</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If "Payment means type code" (BT-81) contains a code for direct debit (59), "DIRECT DEBIT" (BG-19) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(cac:PayeeFinancialAccount) and                     not(cac:CardAccount)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(cac:PayeeFinancialAccount) and not(cac:CardAccount)">
+          <xsl:attribute name="id">DE-R-025-2</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>If "Payment means type code" (BT-81) contains a code for direct debit (59), BG-17 and BG-18 shall not be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="(/ubl-invoice:Invoice/cac:TaxTotal/cac:TaxSubtotal | /ubl-creditnote:CreditNote/cac:TaxTotal/cac:TaxSubtotal)[$supplierCountryIsDE and $customerCountryIsDE]" mode="M41" priority="1000">
+    <svrl:fired-rule context="(/ubl-invoice:Invoice/cac:TaxTotal/cac:TaxSubtotal | /ubl-creditnote:CreditNote/cac:TaxTotal/cac:TaxSubtotal)[$supplierCountryIsDE and $customerCountryIsDE]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="cac:TaxCategory/cbc:Percent[boolean(normalize-space(.))]" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="cac:TaxCategory/cbc:Percent[boolean(normalize-space(.))]">
+          <xsl:attribute name="id">DE-R-014</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>The element "VAT category rate" (BT-119) shall be provided.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M41" priority="-1" />
+  <xsl:template match="@*|node()" mode="M41" priority="-2">
+    <xsl:apply-templates mode="M41" select="@*|*" />
+  </xsl:template>
+
+<!--PATTERN -->
+<xsl:variable name="ISO3166" select="tokenize('AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW 1A XI', '\s')" />
+  <xsl:variable name="ISO4217" select="tokenize('AED AFN ALL AMD ANG AOA ARS AUD AWG AZN BAM BBD BDT BGN BHD BIF BMD BND BOB BOV BRL BSD BTN BWP BYN BZD CAD CDF CHE CHF CHW CLF CLP CNY COP COU CRC CUP CVE CZK DJF DKK DOP DZD EGP ERN ETB EUR FJD FKP GBP GEL GHS GIP GMD GNF GTQ GYD HKD HNL HTG HUF IDR ILS INR IQD IRR ISK JMD JOD JPY KES KGS KHR KMF KPW KRW KWD KYD KZT LAK LBP LKR LRD LSL LYD MAD MDL MGA MKD MMK MNT MOP MRU MUR MVR MWK MXN MXV MYR MZN NAD NGN NIO NOK NPR NZD OMR PAB PEN PGK PHP PKR PLN PYG QAR RON RSD RUB RWF SAR SBD SCR SDG SEK SGD SHP SLE SOS SRD SSP STN SVC SYP SZL THB TJS TMT TND TOP TRY TTD TWD TZS UAH UGX USD USN UYI UYU UYW UZS VED VES VND VUV WST XAF XAG XAU XBA XBB XBC XBD XCD XDR XOF XPD XPF XPT XSU XTS XUA YER ZAR ZMW ZWG XXX', '\s')" />
+  <xsl:variable name="MIMECODE" select="tokenize('application/pdf image/png image/jpeg text/csv application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.oasis.opendocument.spreadsheet', '\s')" />
+  <xsl:variable name="UNCL2005" select="tokenize('3 35 432', '\s')" />
+  <xsl:variable name="UNCL5189" select="tokenize('41 42 60 62 63 64 65 66 67 68 70 71 88 95 100 102 103 104 105', '\s')" />
+  <xsl:variable name="UNCL7161" select="tokenize('AA AAA AAC AAD AAE AAF AAH AAI AAS AAT AAV AAY AAZ ABA ABB ABC ABD ABF ABK ABL ABN ABR ABS ABT ABU ACF ACG ACH ACI ACJ ACK ACL ACM ACS ADC ADE ADJ ADK ADL ADM ADN ADO ADP ADQ ADR ADT ADW ADY ADZ AEA AEB AEC AED AEF AEH AEI AEJ AEK AEL AEM AEN AEO AEP AES AET AEU AEV AEW AEX AEY AEZ AJ AU CA CAB CAD CAE CAF CAI CAJ CAK CAL CAM CAN CAO CAP CAQ CAR CAS CAT CAU CAV CAW CAX CAY CAZ CD CG CS CT DAB DAC DAD DAF DAG DAH DAI DAJ DAK DAL DAM DAN DAO DAP DAQ DL EG EP ER FAA FAB FAC FC FH FI GAA HAA HD HH IAA IAB ID IF IR IS KO L1 LA LAA LAB LF MAE MI ML NAA OA PA PAA PC PL PRV RAB RAC RAD RAF RE RF RH RV SA SAA SAD SAE SAI SG SH SM SU TAB TAC TT TV V1 V2 WH XAA YY ZZZ', '\s')" />
+  <xsl:variable name="UNCL5305" select="tokenize('AE E S Z G O K L M B', '\s')" />
+  <xsl:variable name="eaid" select="tokenize('0002 0007 0009 0037 0060 0088 0096 0097 0106 0130 0135 0142 0151 0177 0183 0184 0188 0190 0191 0192 0193 0195 0196 0198 0199 0200 0201 0202 0204 0208 0209 0210 0211 0212 0213 0215 0216 0218 0221 0230 0235 9910 9913 9914 9915 9918 9919 9920 9922 9923 9924 9925 9926 9927 9928 9929 9930 9931 9932 9933 9934 9935 9936 9937 9938 9939 9940 9941 9942 9943 9944 9945 9946 9947 9948 9949 9950 9951 9952 9953 9957 9959 0147 0154 0158 0170 0194 0203 0205 0217 0225 0240', '\s')" />
+
+	<!--RULE -->
+<xsl:template match="cbc:EmbeddedDocumentBinaryObject[@mimeCode]" mode="M42" priority="1016">
+    <svrl:fired-rule context="cbc:EmbeddedDocumentBinaryObject[@mimeCode]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="           some $code in $MIMECODE             satisfies @mimeCode = $code" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="some $code in $MIMECODE satisfies @mimeCode = $code">
+          <xsl:attribute name="id">PEPPOL-EN16931-CL001</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Mime code must be according to subset of IANA code list.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator = 'false']/cbc:AllowanceChargeReasonCode" mode="M42" priority="1015">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator = 'false']/cbc:AllowanceChargeReasonCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="           some $code in $UNCL5189             satisfies normalize-space(text()) = $code" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="some $code in $UNCL5189 satisfies normalize-space(text()) = $code">
+          <xsl:attribute name="id">PEPPOL-EN16931-CL002</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Reason code MUST be according to subset of UNCL 5189 D.16B.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:AllowanceCharge[cbc:ChargeIndicator = 'true']/cbc:AllowanceChargeReasonCode" mode="M42" priority="1014">
+    <svrl:fired-rule context="cac:AllowanceCharge[cbc:ChargeIndicator = 'true']/cbc:AllowanceChargeReasonCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="           some $code in $UNCL7161             satisfies normalize-space(text()) = $code" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="some $code in $UNCL7161 satisfies normalize-space(text()) = $code">
+          <xsl:attribute name="id">PEPPOL-EN16931-CL003</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Reason code MUST be according to UNCL 7161 D.16B.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:InvoicePeriod/cbc:DescriptionCode" mode="M42" priority="1013">
+    <svrl:fired-rule context="cac:InvoicePeriod/cbc:DescriptionCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="           some $code in $UNCL2005             satisfies normalize-space(text()) = $code" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="some $code in $UNCL2005 satisfies normalize-space(text()) = $code">
+          <xsl:attribute name="id">PEPPOL-EN16931-CL006</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Invoice period description code must be according to UNCL 2005 D.16B.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:Amount | cbc:BaseAmount | cbc:PriceAmount | cbc:TaxAmount | cbc:TaxableAmount | cbc:LineExtensionAmount | cbc:TaxExclusiveAmount | cbc:TaxInclusiveAmount | cbc:AllowanceTotalAmount | cbc:ChargeTotalAmount | cbc:PrepaidAmount | cbc:PayableRoundingAmount | cbc:PayableAmount" mode="M42" priority="1012">
+    <svrl:fired-rule context="cbc:Amount | cbc:BaseAmount | cbc:PriceAmount | cbc:TaxAmount | cbc:TaxableAmount | cbc:LineExtensionAmount | cbc:TaxExclusiveAmount | cbc:TaxInclusiveAmount | cbc:AllowanceTotalAmount | cbc:ChargeTotalAmount | cbc:PrepaidAmount | cbc:PayableRoundingAmount | cbc:PayableAmount" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="           some $code in $ISO4217             satisfies @currencyID = $code" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="some $code in $ISO4217 satisfies @currencyID = $code">
+          <xsl:attribute name="id">PEPPOL-EN16931-CL007</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Currency code must be according to ISO 4217:2005</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:InvoiceTypeCode" mode="M42" priority="1011">
+    <svrl:fired-rule context="cbc:InvoiceTypeCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="           $profile != '01' or (some $code in tokenize('71 80 82 84 102 218 219 326 331 380 382 383 384 386 388 393 395 553 575 623 780 817 870 875 876 877', '\s')             satisfies normalize-space(text()) = $code)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="$profile != '01' or (some $code in tokenize('71 80 82 84 102 218 219 326 331 380 382 383 384 386 388 393 395 553 575 623 780 817 870 875 876 877', '\s') satisfies normalize-space(text()) = $code)">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0100</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Invoice type code MUST be set according to the profile.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(normalize-space(.) = '326' or normalize-space(.) = '384') or ($supplierCountryIsDE and $customerCountryIsDE)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(normalize-space(.) = '326' or normalize-space(.) = '384') or ($supplierCountryIsDE and $customerCountryIsDE)">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0112</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Invoice type code 326 or 384 are only allowed when both buyer and seller are German organizations </svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:CreditNoteTypeCode" mode="M42" priority="1010">
+    <svrl:fired-rule context="cbc:CreditNoteTypeCode" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="           $profile != '01' or (some $code in tokenize('381 396 81 83 532', '\s')             satisfies normalize-space(text()) = $code)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="$profile != '01' or (some $code in tokenize('381 396 81 83 532', '\s') satisfies normalize-space(text()) = $code)">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0101</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Credit note type code MUST be set according to the profile.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:IssueDate | cbc:DueDate | cbc:TaxPointDate | cbc:StartDate | cbc:EndDate | cbc:ActualDeliveryDate" mode="M42" priority="1009">
+    <svrl:fired-rule context="cbc:IssueDate | cbc:DueDate | cbc:TaxPointDate | cbc:StartDate | cbc:EndDate | cbc:ActualDeliveryDate" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="string-length(text()) = 10 and (string(.) castable as xs:date)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="string-length(text()) = 10 and (string(.) castable as xs:date)">
+          <xsl:attribute name="id">PEPPOL-EN16931-F001</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>A date MUST be formatted YYYY-MM-DD.</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cbc:EndpointID[@schemeID]" mode="M42" priority="1008">
+    <svrl:fired-rule context="cbc:EndpointID[@schemeID]" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="         some $code in $eaid         satisfies @schemeID = $code" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="some $code in $eaid satisfies @schemeID = $code">
+          <xsl:attribute name="id">PEPPOL-EN16931-CL008</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Electronic address identifier scheme must be from the codelist "Electronic Address Identifier Scheme"</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-G']" mode="M42" priority="1007">
+    <svrl:fired-rule context="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-G']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID)='G'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID)='G'">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0104</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Tax Category G MUST be used when exemption reason code is VATEX-EU-G</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-O']" mode="M42" priority="1006">
+    <svrl:fired-rule context="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-O']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID)='O'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID)='O'">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0105</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Tax Category O MUST be used when exemption reason code is VATEX-EU-O</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-IC']" mode="M42" priority="1005">
+    <svrl:fired-rule context="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-IC']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID)='K'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID)='K'">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0106</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Tax Category K MUST be used when exemption reason code is VATEX-EU-IC</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-AE']" mode="M42" priority="1004">
+    <svrl:fired-rule context="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-AE']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID)='AE'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID)='AE'">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0107</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Tax Category AE MUST be used when exemption reason code is VATEX-EU-AE</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-D']" mode="M42" priority="1003">
+    <svrl:fired-rule context="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-D']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID)='E'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID)='E'">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0108</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Tax Category E MUST be used when exemption reason code is VATEX-EU-D</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-F']" mode="M42" priority="1002">
+    <svrl:fired-rule context="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-F']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID)='E'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID)='E'">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0109</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Tax Category E MUST be used when exemption reason code is VATEX-EU-F</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-I']" mode="M42" priority="1001">
+    <svrl:fired-rule context="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-I']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID)='E'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID)='E'">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0110</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Tax Category E MUST be used when exemption reason code is VATEX-EU-I</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+
+	<!--RULE -->
+<xsl:template match="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-J']" mode="M42" priority="1000">
+    <svrl:fired-rule context="cac:TaxCategory[upper-case(cbc:TaxExemptionReasonCode)='VATEX-EU-J']" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="normalize-space(cbc:ID)='E'" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="normalize-space(cbc:ID)='E'">
+          <xsl:attribute name="id">PEPPOL-EN16931-P0111</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>Tax Category E MUST be used when exemption reason code is VATEX-EU-J</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+  <xsl:template match="text()" mode="M42" priority="-1" />
+  <xsl:template match="@*|node()" mode="M42" priority="-2">
+    <xsl:apply-templates mode="M42" select="@*|*" />
+  </xsl:template>
+</xsl:stylesheet>

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/CCTS_CCT_SchemaModule-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/CCTS_CCT_SchemaModule-2.1.xsd
@@ -1,0 +1,731 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ====================================================================== -->
+<!-- ===== CCTS Core Component Type Schema Module ===== -->
+<!-- ====================================================================== -->
+<!--
+   Module of Core Component Type
+   Agency: UN/CEFACT
+   VersionID: 1.1
+   Last change: 14 January 2005
+   
+   
+   
+   Copyright (C) UN/CEFACT (2006). All Rights Reserved.
+   This document and translations of it may be copied and furnished to others,
+   and derivative works that comment on or otherwise explain it or assist
+   in its implementation may be prepared, copied, published and distributed,
+   in whole or in part, without restriction of any kind, provided that the
+   above copyright notice and this paragraph are included on all such copies
+   and derivative works. However, this document itself may not be modified in
+   any way, such as by removing the copyright notice or references to
+   UN/CEFACT, except as needed for the purpose of developing UN/CEFACT
+   specifications, in which case the procedures for copyrights defined in the
+   UN/CEFACT Intellectual Property Rights document must be followed, or as
+   
+   
+   required to translate it into languages other than English.
+   The limited permissions granted above are perpetual and will not be revoked
+   
+   
+   
+   by UN/CEFACT or its successors or assigns.
+   This document and the information contained herein is provided on an "AS IS"
+   basis and UN/CEFACT DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL
+   NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR
+   FITNESS FOR A PARTICULAR PURPOSE.
+-->
+<xsd:schema targetNamespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
+xmlns:ccts="urn:un:unece:uncefact:documentation:2"
+xmlns:cct="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
+xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+   <!-- ===== Type Definitions ===== -->
+   <!-- =================================================================== -->
+   <!-- ===== CCT: AmountType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="AmountType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000001</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Amount. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A number of monetary units specified in a currency where the unit of the currency is explicit or implied.</ccts:Definition>
+            <ccts:RepresentationTermName>Amount</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="currencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000001-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Amount Currency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The currency of the amount.</ccts:Definition>
+                     <ccts:ObjectClass>Amount Currency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Reference UNECE Rec 9, using 3-letter alphabetic codes.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="currencyCodeListVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000001-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Amount Currency. Code List Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The VersionID of the UN/ECE Rec9 code list.</ccts:Definition>
+                     <ccts:ObjectClass>Amount Currency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: BinaryObjectType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="BinaryObjectType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000002</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Binary Object. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A set of finite-length sequences of binary octets.</ccts:Definition>
+            <ccts:RepresentationTermName>Binary Object</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:base64Binary">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The format of the binary content.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Mime. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The mime type of the binary object.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="encodingCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Encoding. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>Specifies the decoding algorithm of the binary object.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Encoding</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="characterSetCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Character Set. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The character set of the binary object if the mime type is text.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Character Set</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="uri" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC6</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the binary object is located.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="filename" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC7</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Filename.Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The filename of the binary object.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Filename</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: CodeType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="CodeType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000007</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Code. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A character string (letters, figures, or symbols) that for brevity and/or languange independence may be used to represent or replace a definitive value or text of an attribute together with relevant supplementary information.</ccts:Definition>
+            <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+            <ccts:UsageRule>Should not be used if the character string identifies an instance of an object class or an object in the real world, in which case the Identifier. Type should be used.</ccts:UsageRule>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:normalizedString">
+            <xsd:attribute name="listID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of a list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listAgencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Agency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>An agency that maintains one or more lists of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Agency</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Defaults to the UN/EDIFACT data element 3055 code list.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listAgencyName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Agency Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the agency that maintains the list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Agency Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of a list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC6</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The version of the list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="name" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC7</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The textual equivalent of the code content component.</ccts:Definition>
+                     <ccts:ObjectClass>Code</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="languageID" type="xsd:language" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC8</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Language. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identifier of the language used in the code name.</ccts:Definition>
+                     <ccts:ObjectClass>Language</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC9</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the code list is located.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listSchemeURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC10</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List Scheme. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the code list scheme is located.</ccts:Definition>
+                     <ccts:ObjectClass>Code List Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: DateTimeType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="DateTimeType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000008</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Date Time. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A particular point in the progression of time together with the relevant supplementary information.</ccts:Definition>
+            <ccts:RepresentationTermName>Date Time</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+            <ccts:UsageRule>Can be used for a date and/or time.</ccts:UsageRule>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000008-SC1</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Date Time. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The format of the date time content</ccts:Definition>
+                     <ccts:ObjectClass>Date Time</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: IdentifierType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="IdentifierType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000011</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Identifier. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A character string to identify and distinguish uniquely, one instance of an object in an identification scheme from all other objects in the same scheme together with relevant supplementary information.</ccts:Definition>
+            <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:normalizedString">
+            <xsd:attribute name="schemeID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeAgencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme Agency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the agency that maintains the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme Agency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Defaults to the UN/EDIFACT data element 3055 code list.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeAgencyName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme Agency. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the agency that maintains the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme Agency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Agency Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC6</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The version of the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeDataURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC7</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme Data. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the identification scheme data is located.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme Data</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC8</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the identification scheme is located.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: IndicatorType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="IndicatorType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000012</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Indicator. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A list of two mutually exclusive Boolean values that express the only possible states of a Property.</ccts:Definition>
+            <ccts:RepresentationTermName>Indicator</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000012-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Indicator. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>Whether the indicator is numeric, textual or binary.</ccts:Definition>
+                     <ccts:ObjectClass>Indicator</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: MeasureType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="MeasureType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000013</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Measure. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A numeric value determined by measuring an object along with the specified unit of measure.</ccts:Definition>
+            <ccts:RepresentationTermName>Measure</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="unitCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000013-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Measure Unit. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The type of unit of measure.</ccts:Definition>
+                     <ccts:ObjectClass>Measure Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Reference UNECE Rec. 20 and X12 355</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000013-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Measure Unit. Code List Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The version of the measure unit code list.</ccts:Definition>
+                     <ccts:ObjectClass>Measure Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: NumericType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="NumericType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000014</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Numeric. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+            <ccts:RepresentationTermName>Numeric</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000014-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Numeric. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>Whether the number is an integer, decimal, real number or percentage.</ccts:Definition>
+                     <ccts:ObjectClass>Numeric</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: QuantityType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="QuantityType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000018</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Quantity. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A counted number of non-monetary units possibly including fractions.</ccts:Definition>
+            <ccts:RepresentationTermName>Quantity</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="unitCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity. Unit. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The unit of the quantity</ccts:Definition>
+                     <ccts:ObjectClass>Quantity</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Unit Code</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity Unit. Code List. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The quantity unit code list.</ccts:Definition>
+                     <ccts:ObjectClass>Quantity Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListAgencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity Unit. Code List Agency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the agency that maintains the quantity unit code list</ccts:Definition>
+                     <ccts:ObjectClass>Quantity Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Agency</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Defaults to the UN/EDIFACT data element 3055 code list.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListAgencyName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity Unit. Code List Agency Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the agency which maintains the quantity unit code list.</ccts:Definition>
+                     <ccts:ObjectClass>Quantity Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Agency Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: TextType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="TextType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000019</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Text. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A character string (i.e. a finite set of characters) generally in the form of words of a language.</ccts:Definition>
+            <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="languageID" type="xsd:language" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000019-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Language. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identifier of the language used in the content component.</ccts:Definition>
+                     <ccts:ObjectClass>Language</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="languageLocaleID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000019-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName> Language. Locale. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the locale of the language.</ccts:Definition>
+                     <ccts:ObjectClass>Language</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Locale</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-CommonAggregateComponents-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-CommonAggregateComponents-2.1.xsd
@@ -1,0 +1,4156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            xsdrt/common/UBL-CommonAggregateComponents-2.1.xsd
+  Generated on:      2013-10-31 17:17z
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.1">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="UBL-CommonBasicComponents-2.1.xsd"/>
+   <xsd:element name="AcceptanceTransportEvent" type="TransportEventType"/>
+   <xsd:element name="AccessoryRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="AccountingContact" type="ContactType"/>
+   <xsd:element name="AccountingCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="AccountingSupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="ActivityDataLine" type="ActivityDataLineType"/>
+   <xsd:element name="ActivityFinalLocation" type="LocationType"/>
+   <xsd:element name="ActivityOriginLocation" type="LocationType"/>
+   <xsd:element name="ActivityPeriod" type="PeriodType"/>
+   <xsd:element name="ActivityProperty" type="ActivityPropertyType"/>
+   <xsd:element name="ActualArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualPackage" type="PackageType"/>
+   <xsd:element name="ActualPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualWaypointTransportEvent" type="TransportEventType"/>
+   <xsd:element name="AdditionalCommodityClassification"
+                type="CommodityClassificationType"/>
+   <xsd:element name="AdditionalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="AdditionalDocumentResponse" type="DocumentResponseType"/>
+   <xsd:element name="AdditionalInformationParty" type="PartyType"/>
+   <xsd:element name="AdditionalItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="AdditionalItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="AdditionalQualifyingParty" type="QualifyingPartyType"/>
+   <xsd:element name="AdditionalTemperature" type="TemperatureType"/>
+   <xsd:element name="AdditionalTransportationService" type="TransportationServiceType"/>
+   <xsd:element name="Address" type="AddressType"/>
+   <xsd:element name="AddressLine" type="AddressLineType"/>
+   <xsd:element name="AgentParty" type="PartyType"/>
+   <xsd:element name="AirTransport" type="AirTransportType"/>
+   <xsd:element name="AllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="AllowedSubcontractTerms" type="SubcontractTermsType"/>
+   <xsd:element name="AlternativeConditionPrice" type="PriceType"/>
+   <xsd:element name="AlternativeDeliveryLocation" type="LocationType"/>
+   <xsd:element name="AlternativeLineItem" type="LineItemType"/>
+   <xsd:element name="AnticipatedMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="AppealInformationParty" type="PartyType"/>
+   <xsd:element name="AppealReceiverParty" type="PartyType"/>
+   <xsd:element name="AppealTerms" type="AppealTermsType"/>
+   <xsd:element name="ApplicableAddress" type="AddressType"/>
+   <xsd:element name="ApplicablePeriod" type="PeriodType"/>
+   <xsd:element name="ApplicableRegulation" type="RegulationType"/>
+   <xsd:element name="ApplicableTaxCategory" type="TaxCategoryType"/>
+   <xsd:element name="ApplicableTerritoryAddress" type="AddressType"/>
+   <xsd:element name="ApplicableTransportMeans" type="TransportMeansType"/>
+   <xsd:element name="AtLocation" type="LocationType"/>
+   <xsd:element name="AttachedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="Attachment" type="AttachmentType"/>
+   <xsd:element name="AuctionTerms" type="AuctionTermsType"/>
+   <xsd:element name="AvailabilityTransportEvent" type="TransportEventType"/>
+   <xsd:element name="AwardedTenderedProject" type="TenderedProjectType"/>
+   <xsd:element name="AwardingCriterion" type="AwardingCriterionType"/>
+   <xsd:element name="AwardingCriterionResponse" type="AwardingCriterionResponseType"/>
+   <xsd:element name="AwardingTerms" type="AwardingTermsType"/>
+   <xsd:element name="BeneficiaryParty" type="PartyType"/>
+   <xsd:element name="BillOfLadingHolderParty" type="PartyType"/>
+   <xsd:element name="BillToParty" type="PartyType"/>
+   <xsd:element name="BillingReference" type="BillingReferenceType"/>
+   <xsd:element name="BillingReferenceLine" type="BillingReferenceLineType"/>
+   <xsd:element name="BonusPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="Branch" type="BranchType"/>
+   <xsd:element name="BudgetAccount" type="BudgetAccountType"/>
+   <xsd:element name="BudgetAccountLine" type="BudgetAccountLineType"/>
+   <xsd:element name="BusinessClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="BuyerContact" type="ContactType"/>
+   <xsd:element name="BuyerCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="BuyerProposedSubstituteLineItem" type="LineItemType"/>
+   <xsd:element name="BuyersItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="CallDuty" type="DutyType"/>
+   <xsd:element name="CallForTendersDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CallForTendersLineReference" type="LineReferenceType"/>
+   <xsd:element name="Capability" type="CapabilityType"/>
+   <xsd:element name="CardAccount" type="CardAccountType"/>
+   <xsd:element name="CarrierParty" type="PartyType"/>
+   <xsd:element name="CatalogueDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CatalogueItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="CatalogueItemSpecificationUpdateLine"
+                type="CatalogueItemSpecificationUpdateLineType"/>
+   <xsd:element name="CatalogueLine" type="CatalogueLineType"/>
+   <xsd:element name="CatalogueLineReference" type="LineReferenceType"/>
+   <xsd:element name="CataloguePricingUpdateLine" type="CataloguePricingUpdateLineType"/>
+   <xsd:element name="CatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="CatalogueRequestLine" type="CatalogueRequestLineType"/>
+   <xsd:element name="CategorizesClassificationCategory"
+                type="ClassificationCategoryType"/>
+   <xsd:element name="Certificate" type="CertificateType"/>
+   <xsd:element name="CertificateOfOriginApplication"
+                type="CertificateOfOriginApplicationType"/>
+   <xsd:element name="ChildConsignment" type="ConsignmentType"/>
+   <xsd:element name="ClassificationCategory" type="ClassificationCategoryType"/>
+   <xsd:element name="ClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="ClassifiedTaxCategory" type="TaxCategoryType"/>
+   <xsd:element name="Clause" type="ClauseType"/>
+   <xsd:element name="CollectPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="CollectedPayment" type="PaymentType"/>
+   <xsd:element name="CommissionPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="CommodityClassification" type="CommodityClassificationType"/>
+   <xsd:element name="Communication" type="CommunicationType"/>
+   <xsd:element name="ComplementaryRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="CompletedTask" type="CompletedTaskType"/>
+   <xsd:element name="ComponentRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="Condition" type="ConditionType"/>
+   <xsd:element name="ConsigneeParty" type="PartyType"/>
+   <xsd:element name="Consignment" type="ConsignmentType"/>
+   <xsd:element name="ConsignorParty" type="PartyType"/>
+   <xsd:element name="ConsolidatedShipment" type="ShipmentType"/>
+   <xsd:element name="ConstitutionPeriod" type="PeriodType"/>
+   <xsd:element name="Consumption" type="ConsumptionType"/>
+   <xsd:element name="ConsumptionAverage" type="ConsumptionAverageType"/>
+   <xsd:element name="ConsumptionCorrection" type="ConsumptionCorrectionType"/>
+   <xsd:element name="ConsumptionHistory" type="ConsumptionHistoryType"/>
+   <xsd:element name="ConsumptionLine" type="ConsumptionLineType"/>
+   <xsd:element name="ConsumptionPoint" type="ConsumptionPointType"/>
+   <xsd:element name="ConsumptionReport" type="ConsumptionReportType"/>
+   <xsd:element name="ConsumptionReportReference" type="ConsumptionReportReferenceType"/>
+   <xsd:element name="Contact" type="ContactType"/>
+   <xsd:element name="ContactParty" type="PartyType"/>
+   <xsd:element name="ContainedGoodsItem" type="GoodsItemType"/>
+   <xsd:element name="ContainedInTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="ContainedPackage" type="PackageType"/>
+   <xsd:element name="ContainingPackage" type="PackageType"/>
+   <xsd:element name="ContainingTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="Contract" type="ContractType"/>
+   <xsd:element name="ContractAcceptancePeriod" type="PeriodType"/>
+   <xsd:element name="ContractDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ContractExecutionRequirement"
+                type="ContractExecutionRequirementType"/>
+   <xsd:element name="ContractExtension" type="ContractExtensionType"/>
+   <xsd:element name="ContractFormalizationPeriod" type="PeriodType"/>
+   <xsd:element name="ContractResponsibleParty" type="PartyType"/>
+   <xsd:element name="ContractingActivity" type="ContractingActivityType"/>
+   <xsd:element name="ContractingParty" type="ContractingPartyType"/>
+   <xsd:element name="ContractingPartyType" type="ContractingPartyTypeType"/>
+   <xsd:element name="ContractorCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="ContractualDelivery" type="DeliveryType"/>
+   <xsd:element name="ContractualDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CorporateRegistrationScheme"
+                type="CorporateRegistrationSchemeType"/>
+   <xsd:element name="Country" type="CountryType"/>
+   <xsd:element name="CreditAccount" type="CreditAccountType"/>
+   <xsd:element name="CreditNoteDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CreditNoteLine" type="CreditNoteLineType"/>
+   <xsd:element name="CrewMemberPerson" type="PersonType"/>
+   <xsd:element name="CurrentStatus" type="StatusType"/>
+   <xsd:element name="CustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="CustomsAgentParty" type="PartyType"/>
+   <xsd:element name="CustomsDeclaration" type="CustomsDeclarationType"/>
+   <xsd:element name="DebitNoteDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="DebitNoteLine" type="DebitNoteLineType"/>
+   <xsd:element name="Declaration" type="DeclarationType"/>
+   <xsd:element name="DefaultLanguage" type="LanguageType"/>
+   <xsd:element name="DeletedCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="Delivery" type="DeliveryType"/>
+   <xsd:element name="DeliveryAddress" type="AddressType"/>
+   <xsd:element name="DeliveryContact" type="ContactType"/>
+   <xsd:element name="DeliveryCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="DeliveryLocation" type="LocationType"/>
+   <xsd:element name="DeliveryParty" type="PartyType"/>
+   <xsd:element name="DeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="DeliveryTerms" type="DeliveryTermsType"/>
+   <xsd:element name="DeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DeliveryUnit" type="DeliveryUnitType"/>
+   <xsd:element name="DependentLineReference" type="LineReferenceType"/>
+   <xsd:element name="DependentPriceReference" type="DependentPriceReferenceType"/>
+   <xsd:element name="Despatch" type="DespatchType"/>
+   <xsd:element name="DespatchAddress" type="AddressType"/>
+   <xsd:element name="DespatchContact" type="ContactType"/>
+   <xsd:element name="DespatchDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="DespatchLine" type="DespatchLineType"/>
+   <xsd:element name="DespatchLineReference" type="LineReferenceType"/>
+   <xsd:element name="DespatchLocation" type="LocationType"/>
+   <xsd:element name="DespatchParty" type="PartyType"/>
+   <xsd:element name="DespatchSupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="DestinationCountry" type="CountryType"/>
+   <xsd:element name="DetentionTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DigitalSignatureAttachment" type="AttachmentType"/>
+   <xsd:element name="Dimension" type="DimensionType"/>
+   <xsd:element name="DisbursementPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="DischargeTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DiscrepancyResponse" type="ResponseType"/>
+   <xsd:element name="DocumentAvailabilityPeriod" type="PeriodType"/>
+   <xsd:element name="DocumentDistribution" type="DocumentDistributionType"/>
+   <xsd:element name="DocumentProviderParty" type="PartyType"/>
+   <xsd:element name="DocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="DocumentResponse" type="DocumentResponseType"/>
+   <xsd:element name="DocumentTenderRequirement" type="TenderRequirementType"/>
+   <xsd:element name="DriverPerson" type="PersonType"/>
+   <xsd:element name="DropoffTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DurationPeriod" type="PeriodType"/>
+   <xsd:element name="Duty" type="DutyType"/>
+   <xsd:element name="EconomicOperatorRole" type="EconomicOperatorRoleType"/>
+   <xsd:element name="EconomicOperatorShortList" type="EconomicOperatorShortListType"/>
+   <xsd:element name="EffectivePeriod" type="PeriodType"/>
+   <xsd:element name="EmbassyEndorsement" type="EndorsementType"/>
+   <xsd:element name="EmergencyTemperature" type="TemperatureType"/>
+   <xsd:element name="EmissionCalculationMethod" type="EmissionCalculationMethodType"/>
+   <xsd:element name="EmploymentLegislationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="Endorsement" type="EndorsementType"/>
+   <xsd:element name="EndorserParty" type="EndorserPartyType"/>
+   <xsd:element name="EnergyTaxReport" type="EnergyTaxReportType"/>
+   <xsd:element name="EnergyWaterConsumptionCorrection"
+                type="ConsumptionCorrectionType"/>
+   <xsd:element name="EnergyWaterSupply" type="EnergyWaterSupplyType"/>
+   <xsd:element name="EnvironmentalEmission" type="EnvironmentalEmissionType"/>
+   <xsd:element name="EnvironmentalLegislationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="EstimatedArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="EstimatedDeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="EstimatedDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="EstimatedDespatchPeriod" type="PeriodType"/>
+   <xsd:element name="EstimatedDurationPeriod" type="PeriodType"/>
+   <xsd:element name="EstimatedTransitPeriod" type="PeriodType"/>
+   <xsd:element name="EvaluationCriterion" type="EvaluationCriterionType"/>
+   <xsd:element name="Event" type="EventType"/>
+   <xsd:element name="EventComment" type="EventCommentType"/>
+   <xsd:element name="EventLineItem" type="EventLineItemType"/>
+   <xsd:element name="EventTactic" type="EventTacticType"/>
+   <xsd:element name="EventTacticEnumeration" type="EventTacticEnumerationType"/>
+   <xsd:element name="Evidence" type="EvidenceType"/>
+   <xsd:element name="EvidenceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="EvidenceIssuingParty" type="PartyType"/>
+   <xsd:element name="EvidenceSupplied" type="EvidenceSuppliedType"/>
+   <xsd:element name="ExaminationTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ExceptionCriteriaLine" type="ExceptionCriteriaLineType"/>
+   <xsd:element name="ExceptionNotificationLine" type="ExceptionNotificationLineType"/>
+   <xsd:element name="ExceptionObservationPeriod" type="PeriodType"/>
+   <xsd:element name="ExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="ExportCountry" type="CountryType"/>
+   <xsd:element name="ExportationTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ExporterParty" type="PartyType"/>
+   <xsd:element name="ExternalReference" type="ExternalReferenceType"/>
+   <xsd:element name="ExtraAllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="FinalDeliveryParty" type="PartyType"/>
+   <xsd:element name="FinalDeliveryTransportationService"
+                type="TransportationServiceType"/>
+   <xsd:element name="FinalDestinationCountry" type="CountryType"/>
+   <xsd:element name="FinalFinancialGuarantee" type="FinancialGuaranteeType"/>
+   <xsd:element name="FinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="FinancialCapability" type="CapabilityType"/>
+   <xsd:element name="FinancialEvaluationCriterion" type="EvaluationCriterionType"/>
+   <xsd:element name="FinancialGuarantee" type="FinancialGuaranteeType"/>
+   <xsd:element name="FinancialInstitution" type="FinancialInstitutionType"/>
+   <xsd:element name="FinancialInstitutionBranch" type="BranchType"/>
+   <xsd:element name="FinancingFinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="FinancingParty" type="PartyType"/>
+   <xsd:element name="FirstArrivalPortLocation" type="LocationType"/>
+   <xsd:element name="FiscalLegislationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="FlashpointTemperature" type="TemperatureType"/>
+   <xsd:element name="FloorSpaceMeasurementDimension" type="DimensionType"/>
+   <xsd:element name="ForecastException" type="ForecastExceptionType"/>
+   <xsd:element name="ForecastExceptionCriterionLine"
+                type="ForecastExceptionCriterionLineType"/>
+   <xsd:element name="ForecastLine" type="ForecastLineType"/>
+   <xsd:element name="ForecastPeriod" type="PeriodType"/>
+   <xsd:element name="ForecastRevisionLine" type="ForecastRevisionLineType"/>
+   <xsd:element name="ForeignExchangeContract" type="ContractType"/>
+   <xsd:element name="FrameworkAgreement" type="FrameworkAgreementType"/>
+   <xsd:element name="FreightAllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="FreightChargeLocation" type="LocationType"/>
+   <xsd:element name="FreightForwarderParty" type="PartyType"/>
+   <xsd:element name="FrequencyPeriod" type="PeriodType"/>
+   <xsd:element name="FromLocation" type="LocationType"/>
+   <xsd:element name="GoodsItem" type="GoodsItemType"/>
+   <xsd:element name="GoodsItemContainer" type="GoodsItemContainerType"/>
+   <xsd:element name="GuaranteeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="GuarantorParty" type="PartyType"/>
+   <xsd:element name="GuidanceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="HandlingTransportEvent" type="TransportEventType"/>
+   <xsd:element name="HandlingUnitDespatchLine" type="DespatchLineType"/>
+   <xsd:element name="HaulageTradingTerms" type="TradingTermsType"/>
+   <xsd:element name="HazardousGoodsTransit" type="HazardousGoodsTransitType"/>
+   <xsd:element name="HazardousItem" type="HazardousItemType"/>
+   <xsd:element name="HazardousItemNotificationParty" type="PartyType"/>
+   <xsd:element name="HeadOfficeParty" type="PartyType"/>
+   <xsd:element name="IdentityDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ImmobilizedSecurity" type="ImmobilizedSecurityType"/>
+   <xsd:element name="ImporterParty" type="PartyType"/>
+   <xsd:element name="InformationContentProviderParty" type="PartyType"/>
+   <xsd:element name="InstructionForReturnsLine" type="InstructionForReturnsLineType"/>
+   <xsd:element name="InsuranceEndorsement" type="EndorsementType"/>
+   <xsd:element name="InsuranceParty" type="PartyType"/>
+   <xsd:element name="InterestedParty" type="PartyType"/>
+   <xsd:element name="InterestedProcurementProjectLot" type="ProcurementProjectLotType"/>
+   <xsd:element name="InventoryLocation" type="LocationType"/>
+   <xsd:element name="InventoryPeriod" type="PeriodType"/>
+   <xsd:element name="InventoryReportLine" type="InventoryReportLineType"/>
+   <xsd:element name="InventoryReportingParty" type="PartyType"/>
+   <xsd:element name="InvitationSubmissionPeriod" type="PeriodType"/>
+   <xsd:element name="InvoiceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="InvoiceLine" type="InvoiceLineType"/>
+   <xsd:element name="InvoicePeriod" type="PeriodType"/>
+   <xsd:element name="IssuerEndorsement" type="EndorsementType"/>
+   <xsd:element name="IssuerParty" type="PartyType"/>
+   <xsd:element name="IssuingCountry" type="CountryType"/>
+   <xsd:element name="Item" type="ItemType"/>
+   <xsd:element name="ItemComparison" type="ItemComparisonType"/>
+   <xsd:element name="ItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="ItemInformationRequestLine" type="ItemInformationRequestLineType"/>
+   <xsd:element name="ItemInstance" type="ItemInstanceType"/>
+   <xsd:element name="ItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="ItemManagementProfile" type="ItemManagementProfileType"/>
+   <xsd:element name="ItemPriceExtension" type="PriceExtensionType"/>
+   <xsd:element name="ItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="ItemPropertyGroup" type="ItemPropertyGroupType"/>
+   <xsd:element name="ItemPropertyRange" type="ItemPropertyRangeType"/>
+   <xsd:element name="ItemSpecificationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="JurisdictionRegionAddress" type="AddressType"/>
+   <xsd:element name="KeywordItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="Language" type="LanguageType"/>
+   <xsd:element name="LastExitPortLocation" type="LocationType"/>
+   <xsd:element name="LegalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="LegalMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="LineItem" type="LineItemType"/>
+   <xsd:element name="LineReference" type="LineReferenceType"/>
+   <xsd:element name="LineResponse" type="LineResponseType"/>
+   <xsd:element name="LineValidityPeriod" type="PeriodType"/>
+   <xsd:element name="LoadingLocation" type="LocationType"/>
+   <xsd:element name="LoadingPortLocation" type="LocationType"/>
+   <xsd:element name="LoadingProofParty" type="PartyType"/>
+   <xsd:element name="LoadingTransportEvent" type="TransportEventType"/>
+   <xsd:element name="Location" type="LocationType"/>
+   <xsd:element name="LocationAddress" type="AddressType"/>
+   <xsd:element name="LocationCoordinate" type="LocationCoordinateType"/>
+   <xsd:element name="LogisticsOperatorParty" type="PartyType"/>
+   <xsd:element name="LotIdentification" type="LotIdentificationType"/>
+   <xsd:element name="MainCarriageShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="MainCommodityClassification" type="CommodityClassificationType"/>
+   <xsd:element name="MainOnAccountPayment" type="OnAccountPaymentType"/>
+   <xsd:element name="MainPeriod" type="PeriodType"/>
+   <xsd:element name="MainQualifyingParty" type="QualifyingPartyType"/>
+   <xsd:element name="MainTransportationService" type="TransportationServiceType"/>
+   <xsd:element name="MandateDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ManufacturerParty" type="PartyType"/>
+   <xsd:element name="ManufacturersItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="MaritimeTransport" type="MaritimeTransportType"/>
+   <xsd:element name="MasterPerson" type="PersonType"/>
+   <xsd:element name="MaximumDeliveryUnit" type="DeliveryUnitType"/>
+   <xsd:element name="MaximumTemperature" type="TemperatureType"/>
+   <xsd:element name="MeasurementDimension" type="DimensionType"/>
+   <xsd:element name="MeasurementFromLocation" type="LocationType"/>
+   <xsd:element name="MeasurementToLocation" type="LocationType"/>
+   <xsd:element name="MediationParty" type="PartyType"/>
+   <xsd:element name="Meter" type="MeterType"/>
+   <xsd:element name="MeterProperty" type="MeterPropertyType"/>
+   <xsd:element name="MeterReading" type="MeterReadingType"/>
+   <xsd:element name="MinimumDeliveryUnit" type="DeliveryUnitType"/>
+   <xsd:element name="MinimumTemperature" type="TemperatureType"/>
+   <xsd:element name="MinutesDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="MiscellaneousEvent" type="MiscellaneousEventType"/>
+   <xsd:element name="MonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="MortgageHolderParty" type="PartyType"/>
+   <xsd:element name="NominationPeriod" type="PeriodType"/>
+   <xsd:element name="NotaryParty" type="PartyType"/>
+   <xsd:element name="NoticeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="NotificationLocation" type="LocationType"/>
+   <xsd:element name="NotificationPeriod" type="PeriodType"/>
+   <xsd:element name="NotificationRequirement" type="NotificationRequirementType"/>
+   <xsd:element name="NotifyParty" type="PartyType"/>
+   <xsd:element name="OccurenceLocation" type="LocationType"/>
+   <xsd:element name="OfferedItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="OnAccountPayment" type="OnAccountPaymentType"/>
+   <xsd:element name="OnCarriageShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="OpenTenderEvent" type="EventType"/>
+   <xsd:element name="OperatingParty" type="PartyType"/>
+   <xsd:element name="OptionValidityPeriod" type="PeriodType"/>
+   <xsd:element name="OptionalTakeoverTransportEvent" type="TransportEventType"/>
+   <xsd:element name="OrderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OrderLine" type="OrderLineType"/>
+   <xsd:element name="OrderLineReference" type="OrderLineReferenceType"/>
+   <xsd:element name="OrderReference" type="OrderReferenceType"/>
+   <xsd:element name="OrderedShipment" type="OrderedShipmentType"/>
+   <xsd:element name="OriginAddress" type="AddressType"/>
+   <xsd:element name="OriginCountry" type="CountryType"/>
+   <xsd:element name="OriginalDepartureCountry" type="CountryType"/>
+   <xsd:element name="OriginalDespatchParty" type="PartyType"/>
+   <xsd:element name="OriginalDespatchTransportationService"
+                type="TransportationServiceType"/>
+   <xsd:element name="OriginalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OriginalItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="OriginatorCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="OriginatorDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OriginatorParty" type="PartyType"/>
+   <xsd:element name="OtherCommunication" type="CommunicationType"/>
+   <xsd:element name="OwnerParty" type="PartyType"/>
+   <xsd:element name="Package" type="PackageType"/>
+   <xsd:element name="PackagedTransportHandlingUnit" type="TransportHandlingUnitType"/>
+   <xsd:element name="PalletSpaceMeasurementDimension" type="DimensionType"/>
+   <xsd:element name="ParentDocumentLineReference" type="LineReferenceType"/>
+   <xsd:element name="ParentDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ParticipatingLocationsLocation" type="LocationType"/>
+   <xsd:element name="ParticipationRequestReceptionPeriod" type="PeriodType"/>
+   <xsd:element name="Party" type="PartyType"/>
+   <xsd:element name="PartyIdentification" type="PartyIdentificationType"/>
+   <xsd:element name="PartyLegalEntity" type="PartyLegalEntityType"/>
+   <xsd:element name="PartyName" type="PartyNameType"/>
+   <xsd:element name="PartyTaxScheme" type="PartyTaxSchemeType"/>
+   <xsd:element name="PassengerPerson" type="PersonType"/>
+   <xsd:element name="PayeeFinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="PayeeParty" type="PartyType"/>
+   <xsd:element name="PayerFinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="PayerParty" type="PartyType"/>
+   <xsd:element name="Payment" type="PaymentType"/>
+   <xsd:element name="PaymentAlternativeExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="PaymentExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="PaymentMandate" type="PaymentMandateType"/>
+   <xsd:element name="PaymentMeans" type="PaymentMeansType"/>
+   <xsd:element name="PaymentReversalPeriod" type="PeriodType"/>
+   <xsd:element name="PaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="PenaltyClause" type="ClauseType"/>
+   <xsd:element name="PenaltyPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="PenaltyPeriod" type="PeriodType"/>
+   <xsd:element name="PerformanceDataLine" type="PerformanceDataLineType"/>
+   <xsd:element name="PerformingCarrierParty" type="PartyType"/>
+   <xsd:element name="Period" type="PeriodType"/>
+   <xsd:element name="Person" type="PersonType"/>
+   <xsd:element name="PhysicalAttribute" type="PhysicalAttributeType"/>
+   <xsd:element name="PhysicalLocation" type="LocationType"/>
+   <xsd:element name="Pickup" type="PickupType"/>
+   <xsd:element name="PickupLocation" type="LocationType"/>
+   <xsd:element name="PickupParty" type="PartyType"/>
+   <xsd:element name="PickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedPeriod" type="PeriodType"/>
+   <xsd:element name="PlannedPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedWaypointTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PositioningTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PostalAddress" type="AddressType"/>
+   <xsd:element name="PowerOfAttorney" type="PowerOfAttorneyType"/>
+   <xsd:element name="PreCarriageShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="PreSelectedParty" type="PartyType"/>
+   <xsd:element name="PrepaidPayment" type="PaymentType"/>
+   <xsd:element name="PrepaidPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="PreparationParty" type="PartyType"/>
+   <xsd:element name="PresentationPeriod" type="PeriodType"/>
+   <xsd:element name="PreviousDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="PreviousPriceList" type="PriceListType"/>
+   <xsd:element name="Price" type="PriceType"/>
+   <xsd:element name="PriceExtension" type="PriceExtensionType"/>
+   <xsd:element name="PriceList" type="PriceListType"/>
+   <xsd:element name="PricingExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="PricingReference" type="PricingReferenceType"/>
+   <xsd:element name="ProcessJustification" type="ProcessJustificationType"/>
+   <xsd:element name="ProcurementLegislationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="ProcurementProject" type="ProcurementProjectType"/>
+   <xsd:element name="ProcurementProjectLot" type="ProcurementProjectLotType"/>
+   <xsd:element name="ProjectReference" type="ProjectReferenceType"/>
+   <xsd:element name="PromisedDeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="PromotionalEvent" type="PromotionalEventType"/>
+   <xsd:element name="PromotionalEventLineItem" type="PromotionalEventLineItemType"/>
+   <xsd:element name="PromotionalSpecification" type="PromotionalSpecificationType"/>
+   <xsd:element name="ProviderParty" type="PartyType"/>
+   <xsd:element name="QualificationResolution" type="QualificationResolutionType"/>
+   <xsd:element name="QualifyingParty" type="QualifyingPartyType"/>
+   <xsd:element name="QuarantineTransportEvent" type="TransportEventType"/>
+   <xsd:element name="QuotationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="QuotationLine" type="QuotationLineType"/>
+   <xsd:element name="QuotationLineReference" type="LineReferenceType"/>
+   <xsd:element name="QuotedMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="RailTransport" type="RailTransportType"/>
+   <xsd:element name="RangeDimension" type="DimensionType"/>
+   <xsd:element name="RealizedLocation" type="LocationType"/>
+   <xsd:element name="ReceiptDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReceiptLine" type="ReceiptLineType"/>
+   <xsd:element name="ReceiptLineReference" type="LineReferenceType"/>
+   <xsd:element name="ReceiptTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ReceivedHandlingUnitReceiptLine" type="ReceiptLineType"/>
+   <xsd:element name="ReceiverParty" type="PartyType"/>
+   <xsd:element name="RecipientCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="RecipientParty" type="PartyType"/>
+   <xsd:element name="ReferencedConsignment" type="ConsignmentType"/>
+   <xsd:element name="ReferencedContract" type="ContractType"/>
+   <xsd:element name="ReferencedGoodsItem" type="GoodsItemType"/>
+   <xsd:element name="ReferencedPackage" type="PackageType"/>
+   <xsd:element name="ReferencedShipment" type="ShipmentType"/>
+   <xsd:element name="ReferencedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="RegistrationAddress" type="AddressType"/>
+   <xsd:element name="RegistryCertificateDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="RegistryPortLocation" type="LocationType"/>
+   <xsd:element name="Regulation" type="RegulationType"/>
+   <xsd:element name="RelatedCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="RelatedItem" type="RelatedItemType"/>
+   <xsd:element name="ReminderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReminderLine" type="ReminderLineType"/>
+   <xsd:element name="ReminderPeriod" type="PeriodType"/>
+   <xsd:element name="RemittanceAdviceLine" type="RemittanceAdviceLineType"/>
+   <xsd:element name="Renewal" type="RenewalType"/>
+   <xsd:element name="ReplacedNoticeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReplacedRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="ReplacementRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="ReportedShipment" type="ShipmentType"/>
+   <xsd:element name="ReportingPerson" type="PersonType"/>
+   <xsd:element name="RequestForQuotationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="RequestForQuotationLine" type="RequestForQuotationLineType"/>
+   <xsd:element name="RequestForTenderLine" type="RequestForTenderLineType"/>
+   <xsd:element name="RequestLineReference" type="LineReferenceType"/>
+   <xsd:element name="RequestedArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="RequestedClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="RequestedDeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedDespatchPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="RequestedLanguage" type="LanguageType"/>
+   <xsd:element name="RequestedMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="RequestedPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedStatusLocation" type="LocationType"/>
+   <xsd:element name="RequestedStatusPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedTenderTotal" type="RequestedTenderTotalType"/>
+   <xsd:element name="RequestedValidityPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedWaypointTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequiredBusinessClassificationScheme"
+                type="ClassificationSchemeType"/>
+   <xsd:element name="RequiredClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="RequiredFinancialGuarantee" type="FinancialGuaranteeType"/>
+   <xsd:element name="RequiredItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="RequiredRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="ResidenceAddress" type="AddressType"/>
+   <xsd:element name="ResolutionDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="Response" type="ResponseType"/>
+   <xsd:element name="ResponsibleTransportServiceProviderParty" type="PartyType"/>
+   <xsd:element name="ResultOfVerification" type="ResultOfVerificationType"/>
+   <xsd:element name="RetailPlannedImpact" type="RetailPlannedImpactType"/>
+   <xsd:element name="RetailerCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="ReturnAddress" type="AddressType"/>
+   <xsd:element name="RoadTransport" type="RoadTransportType"/>
+   <xsd:element name="SalesItem" type="SalesItemType"/>
+   <xsd:element name="ScheduledServiceFrequency" type="ServiceFrequencyType"/>
+   <xsd:element name="SecondaryHazard" type="SecondaryHazardType"/>
+   <xsd:element name="SecurityOfficerPerson" type="PersonType"/>
+   <xsd:element name="SelfBilledCreditNoteDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="SelfBilledInvoiceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="SellerContact" type="ContactType"/>
+   <xsd:element name="SellerProposedSubstituteLineItem" type="LineItemType"/>
+   <xsd:element name="SellerSubstitutedLineItem" type="LineItemType"/>
+   <xsd:element name="SellerSupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="SellersItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="SenderParty" type="PartyType"/>
+   <xsd:element name="ServiceAllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="ServiceChargePaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="ServiceEndTimePeriod" type="PeriodType"/>
+   <xsd:element name="ServiceFrequency" type="ServiceFrequencyType"/>
+   <xsd:element name="ServiceProviderParty" type="ServiceProviderPartyType"/>
+   <xsd:element name="ServiceStartTimePeriod" type="PeriodType"/>
+   <xsd:element name="SettlementPeriod" type="PeriodType"/>
+   <xsd:element name="ShareholderParty" type="ShareholderPartyType"/>
+   <xsd:element name="Shipment" type="ShipmentType"/>
+   <xsd:element name="ShipmentDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="ShipsSurgeonPerson" type="PersonType"/>
+   <xsd:element name="SignatoryContact" type="ContactType"/>
+   <xsd:element name="SignatoryParty" type="PartyType"/>
+   <xsd:element name="Signature" type="SignatureType"/>
+   <xsd:element name="SourceCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="SourceIssuerParty" type="PartyType"/>
+   <xsd:element name="SpecificTendererRequirement" type="TendererRequirementType"/>
+   <xsd:element name="StandardItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="StatementDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="StatementLine" type="StatementLineType"/>
+   <xsd:element name="StatementPeriod" type="PeriodType"/>
+   <xsd:element name="Status" type="StatusType"/>
+   <xsd:element name="StatusLocation" type="LocationType"/>
+   <xsd:element name="StatusPeriod" type="PeriodType"/>
+   <xsd:element name="StockAvailabilityReportLine"
+                type="StockAvailabilityReportLineType"/>
+   <xsd:element name="StorageLocation" type="LocationType"/>
+   <xsd:element name="StorageTransportEvent" type="TransportEventType"/>
+   <xsd:element name="Stowage" type="StowageType"/>
+   <xsd:element name="SubCreditNoteLine" type="CreditNoteLineType"/>
+   <xsd:element name="SubDebitNoteLine" type="DebitNoteLineType"/>
+   <xsd:element name="SubInvoiceLine" type="InvoiceLineType"/>
+   <xsd:element name="SubLineItem" type="LineItemType"/>
+   <xsd:element name="SubRequestForTenderLine" type="RequestForTenderLineType"/>
+   <xsd:element name="SubTenderLine" type="TenderLineType"/>
+   <xsd:element name="SubcontractTerms" type="SubcontractTermsType"/>
+   <xsd:element name="SubcontractorParty" type="PartyType"/>
+   <xsd:element name="SubordinateAwardingCriterion" type="AwardingCriterionType"/>
+   <xsd:element name="SubordinateAwardingCriterionResponse"
+                type="AwardingCriterionResponseType"/>
+   <xsd:element name="SubscriberConsumption" type="SubscriberConsumptionType"/>
+   <xsd:element name="SubscriberParty" type="PartyType"/>
+   <xsd:element name="SubsequentProcessTenderRequirement" type="TenderRequirementType"/>
+   <xsd:element name="SubsidiaryLocation" type="LocationType"/>
+   <xsd:element name="SubstituteCarrierParty" type="PartyType"/>
+   <xsd:element name="SuggestedEvidence" type="EvidenceType"/>
+   <xsd:element name="SupplierConsumption" type="SupplierConsumptionType"/>
+   <xsd:element name="SupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="SupplyChainActivityDataLine" type="ActivityDataLineType"/>
+   <xsd:element name="SupplyItem" type="ItemType"/>
+   <xsd:element name="SupportedCommodityClassification"
+                type="CommodityClassificationType"/>
+   <xsd:element name="SupportedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="SupportingDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TakeoverTransportEvent" type="TransportEventType"/>
+   <xsd:element name="TaxCategory" type="TaxCategoryType"/>
+   <xsd:element name="TaxExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="TaxExclusivePrice" type="PriceType"/>
+   <xsd:element name="TaxInclusivePrice" type="PriceType"/>
+   <xsd:element name="TaxRepresentativeParty" type="PartyType"/>
+   <xsd:element name="TaxScheme" type="TaxSchemeType"/>
+   <xsd:element name="TaxSubtotal" type="TaxSubtotalType"/>
+   <xsd:element name="TaxTotal" type="TaxTotalType"/>
+   <xsd:element name="TechnicalCapability" type="CapabilityType"/>
+   <xsd:element name="TechnicalCommitteePerson" type="PersonType"/>
+   <xsd:element name="TechnicalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TechnicalEvaluationCriterion" type="EvaluationCriterionType"/>
+   <xsd:element name="TelecommunicationsService" type="TelecommunicationsServiceType"/>
+   <xsd:element name="TelecommunicationsSupply" type="TelecommunicationsSupplyType"/>
+   <xsd:element name="TelecommunicationsSupplyLine"
+                type="TelecommunicationsSupplyLineType"/>
+   <xsd:element name="Temperature" type="TemperatureType"/>
+   <xsd:element name="TemplateDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TenderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TenderEvaluationParty" type="PartyType"/>
+   <xsd:element name="TenderLine" type="TenderLineType"/>
+   <xsd:element name="TenderPreparation" type="TenderPreparationType"/>
+   <xsd:element name="TenderRecipientParty" type="PartyType"/>
+   <xsd:element name="TenderRequirement" type="TenderRequirementType"/>
+   <xsd:element name="TenderResult" type="TenderResultType"/>
+   <xsd:element name="TenderSubmissionDeadlinePeriod" type="PeriodType"/>
+   <xsd:element name="TenderValidityPeriod" type="PeriodType"/>
+   <xsd:element name="TenderedProject" type="TenderedProjectType"/>
+   <xsd:element name="TendererParty" type="PartyType"/>
+   <xsd:element name="TendererPartyQualification" type="TendererPartyQualificationType"/>
+   <xsd:element name="TendererQualificationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TendererQualificationRequest"
+                type="TendererQualificationRequestType"/>
+   <xsd:element name="TendererRequirement" type="TendererRequirementType"/>
+   <xsd:element name="TenderingProcess" type="TenderingProcessType"/>
+   <xsd:element name="TenderingTerms" type="TenderingTermsType"/>
+   <xsd:element name="TerminalOperatorParty" type="PartyType"/>
+   <xsd:element name="TimeDuty" type="DutyType"/>
+   <xsd:element name="ToLocation" type="LocationType"/>
+   <xsd:element name="TotalCapacityDimension" type="DimensionType"/>
+   <xsd:element name="TradeFinancing" type="TradeFinancingType"/>
+   <xsd:element name="TradingTerms" type="TradingTermsType"/>
+   <xsd:element name="TransactionConditions" type="TransactionConditionsType"/>
+   <xsd:element name="TransitCountry" type="CountryType"/>
+   <xsd:element name="TransitPeriod" type="PeriodType"/>
+   <xsd:element name="TransportAdvisorParty" type="PartyType"/>
+   <xsd:element name="TransportContract" type="ContractType"/>
+   <xsd:element name="TransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="TransportEquipmentSeal" type="TransportEquipmentSealType"/>
+   <xsd:element name="TransportEvent" type="TransportEventType"/>
+   <xsd:element name="TransportExecutionPlanDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportExecutionPlanRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportExecutionTerms" type="TransportExecutionTermsType"/>
+   <xsd:element name="TransportHandlingUnit" type="TransportHandlingUnitType"/>
+   <xsd:element name="TransportMeans" type="TransportMeansType"/>
+   <xsd:element name="TransportProgressStatusRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportSchedule" type="TransportScheduleType"/>
+   <xsd:element name="TransportServiceDescriptionDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportServiceDescriptionRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportServiceProviderParty" type="PartyType"/>
+   <xsd:element name="TransportServiceProviderResponseDeadlinePeriod" type="PeriodType"/>
+   <xsd:element name="TransportServiceProviderResponseRequiredPeriod" type="PeriodType"/>
+   <xsd:element name="TransportUserParty" type="PartyType"/>
+   <xsd:element name="TransportUserResponseRequiredPeriod" type="PeriodType"/>
+   <xsd:element name="TransportationSegment" type="TransportationSegmentType"/>
+   <xsd:element name="TransportationService" type="TransportationServiceType"/>
+   <xsd:element name="TransportationStatusRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransshipPortLocation" type="LocationType"/>
+   <xsd:element name="UnloadingLocation" type="LocationType"/>
+   <xsd:element name="UnloadingPortLocation" type="LocationType"/>
+   <xsd:element name="UnstructuredPrice" type="UnstructuredPriceType"/>
+   <xsd:element name="UnsupportedCommodityClassification"
+                type="CommodityClassificationType"/>
+   <xsd:element name="UnsupportedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="UpdatedDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="UpdatedPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="UsabilityPeriod" type="PeriodType"/>
+   <xsd:element name="UtilityConsumptionPoint" type="ConsumptionPointType"/>
+   <xsd:element name="UtilityCustomerParty" type="PartyType"/>
+   <xsd:element name="UtilityItem" type="UtilityItemType"/>
+   <xsd:element name="UtilityMeter" type="MeterType"/>
+   <xsd:element name="UtilitySupplierParty" type="PartyType"/>
+   <xsd:element name="ValidityPeriod" type="PeriodType"/>
+   <xsd:element name="WarehousingTransportEvent" type="TransportEventType"/>
+   <xsd:element name="WarrantyParty" type="PartyType"/>
+   <xsd:element name="WarrantyValidityPeriod" type="PeriodType"/>
+   <xsd:element name="WebSiteAccess" type="WebSiteAccessType"/>
+   <xsd:element name="WinningParty" type="WinningPartyType"/>
+   <xsd:element name="WithholdingTaxTotal" type="TaxTotalType"/>
+   <xsd:element name="WitnessParty" type="PartyType"/>
+   <xsd:element name="WorkOrderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="WorkPhaseReference" type="WorkPhaseReferenceType"/>
+   <xsd:complexType name="ActivityDataLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityOriginLocation" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityFinalLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ActivityPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AddressType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AddressTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AddressFormatCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Postbox" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Floor" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Room" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StreetName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalStreetName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BlockName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuildingName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuildingNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InhouseMail" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Department" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkAttention" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkCare" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlotIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CitySubdivisionName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CityName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PostalZone" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CountrySubentity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CountrySubentityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Region" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:District" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimezoneOffset" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Country" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LocationCoordinate" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AddressLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Line" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AirTransportType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AircraftID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceChargeType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeIndicator" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:AllowanceChargeReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AllowanceChargeReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MultiplierFactorNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrepaidIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentMeans" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AppealTermsType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PresentationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AppealInformationParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AppealReceiverParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MediationParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AttachmentType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:EmbeddedDocumentBinaryObject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExternalReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AuctionTermsType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AuctionConstraintIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:JustificationDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProcessDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ConditionsDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ElectronicDeviceDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AuctionURI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingCriterionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:WeightNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Weight" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CalculationExpression" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CalculationExpressionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumImprovementBid" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubordinateAwardingCriterion"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionResponseType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingCriterionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingCriterionDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubordinateAwardingCriterionResponse"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingTermsType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:WeightingAlgorithmCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TechnicalCommitteeDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LowTendersDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PrizeIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrizeDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PaymentDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:FollowupContractIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BindingOnBuyerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AwardingCriterion" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TechnicalCommitteePerson"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BillingReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cac:InvoiceDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SelfBilledInvoiceDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:CreditNoteDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SelfBilledCreditNoteDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:DebitNoteDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReminderDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BillingReferenceLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BillingReferenceLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BranchType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinancialInstitution" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BudgetAccountType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BudgetYearNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequiredClassificationScheme" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BudgetAccountLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BudgetAccount" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CapabilityType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:CapabilityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CardAccountType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:PrimaryAccountNumberID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetworkID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CardTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidityStartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssuerID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueNumberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CV2ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CardChipCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChipApplicationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HolderName" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueItemSpecificationUpdateLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LifeCycleStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractSubdivision" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OrderableIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderableUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContentUnitQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderQuantityIncrementNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WarrantyInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemComparison" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ComponentRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AccessoryRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacementRelatedItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ComplementaryRelatedItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacedRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:KeywordItemProperty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallForTendersLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CallForTendersDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CataloguePricingUpdateLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RevisionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RevisionTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueRequestLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractSubdivision" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificateTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificateType" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateOfOriginApplicationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ReferenceID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificateType" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ApplicationStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OriginalJobID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousJobID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Shipment" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EndorserParty" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreparationParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ExporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ImporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuingCountry" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentDistribution" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupportingDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ClassificationCategoryType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CodeValue" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CategorizesClassificationCategory"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ClassificationSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LastRevisionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LastRevisionTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AgencyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AgencyName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SchemeURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LanguageID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ClassificationCategory"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ClauseType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Content" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CommodityClassificationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:NatureCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CargoTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CommodityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ItemClassificationCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CommunicationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ChannelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Channel" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CompletedTaskType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AnnualAverageAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaskAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartyCapacityAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RecipientCustomerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AttributeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Measure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MinimumMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsignmentType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CarrierAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsigneeAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsignorAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreightForwarderAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BrokerAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractedCarrierAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformingCarrierAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SummaryDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalInvoiceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredCustomsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TariffDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TariffCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InsurancePremiumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetNetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeableWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LoadingLengthMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AnimalFoodIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumanFoodIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LivestockIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BulkCargoIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContainerizedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GeneralCargoIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialSecurityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ThirdPartyPayerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CarrierServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CustomsClearanceServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ForwarderServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SpecialServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShippingPriorityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalGoodsItemQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTransportHandlingUnitQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:InsuranceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredForCarriageValueAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredStatisticsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOnBoardValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SplitConsignmentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeliveryInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ConsignmentQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsolidatableIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HaulageInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LoadingSequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChildConsignmentQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalPackagesQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsolidatedShipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CustomsDeclaration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedDeliveryTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedDeliveryTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Status" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ChildConsignment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ConsigneeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsignorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ImporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightForwarderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalDespatchParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinalDeliveryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PerformingCarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubstituteCarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LogisticsOperatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportAdvisorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HazardousItemNotificationParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:InsuranceParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MortgageHolderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BillOfLadingHolderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalDepartureCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinalDestinationCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransitCountry" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportContract" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginalDespatchTransportationService"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:FinalDeliveryTransportationService"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CollectPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DisbursementPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PrepaidPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExtraAllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MainCarriageShipmentStage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreCarriageShipmentStage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OnCarriageShipmentStage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportHandlingUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FirstArrivalPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LastExitPortLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:UtilityStatementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MainPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnergyWaterSupply" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TelecommunicationsSupply" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LegalMonetaryTotal" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionAverageType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AverageAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionCorrectionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:CorrectionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorrectionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GasPressureQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualTemperatureReductionQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:NormalTemperatureReductionQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DifferenceTemperatureReductionQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CorrectionUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionEnergyQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionWaterQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorrectionAmount" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionHistoryType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:MeterNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionLevel" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Period" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ParentDocumentLineReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InvoicedQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UtilityItem" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UnstructuredPrice" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionPointType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SubscriberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalDeliveredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WebSiteAccess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UtilityMeter" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionReportType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalConsumedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BasicConsumedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResidentOccupantsNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumersEnergyLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumersEnergyLevel" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResidenceType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResidenceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HeatingType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HeatingTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GuidanceDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsumptionReportReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ConsumptionHistory" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionReportReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ConsumptionReportID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalConsumedQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContactType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Telephone" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Telefax" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicMail" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OtherCommunication" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NominationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractualDelivery" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractExecutionRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExecutionRequirementCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractExtensionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:OptionsDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MinimumNumberNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumNumberNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OptionValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Renewal" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingActivityType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActivityType" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingPartyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:BuyerProfileURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractingPartyType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingActivity" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingPartyTypeType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:PartyTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartyType" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CorporateRegistrationSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorporateRegistrationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:JurisdictionRegionAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CountryType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:IdentificationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CreditAccountType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AccountID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CreditNoteLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CreditedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOfChargeIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DiscrepancyResponse" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubCreditNoteLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemPriceExtension" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomerPartyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:CustomerAssignedAccountID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplierAssignedAccountID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalAccountID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsDeclarationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DebitNoteLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DebitedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DiscrepancyResponse" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubDebitNoteLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeclarationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DeclarationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReleaseID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TrackingID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AlternativeDeliveryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedDeliveryPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PromisedDeliveryPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedDeliveryPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinimumDeliveryUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumDeliveryUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryTermsType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LossRiskResponsibilityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LossRisk" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryUnitType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:BatchQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumerUnitQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DependentPriceReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LocationAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DependentLineReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DespatchType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GuaranteedDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GuaranteedDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReleaseID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Instructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedDespatchPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedDespatchPeriod" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DespatchLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeliveredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BackorderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BackorderReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OutstandingQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OutstandingReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OversupplyQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DimensionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AttributeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Measure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MinimumMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentDistributionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:PrintQualifier" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumCopiesNumeric" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:XPath" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LanguageID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocaleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Attachment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ResultOfVerification" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentResponseType">
+      <xsd:sequence>
+         <xsd:element ref="cac:Response" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RecipientParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineResponse" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DutyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Duty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DutyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorRoleType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:RoleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleDescription" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorShortListType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:LimitationDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExpectedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PreSelectedParty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EmissionCalculationMethodType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:CalculationMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FullnessIndicationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementFromLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementToLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EndorsementType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:DocumentID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ApprovalStatus" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EndorserParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EndorserPartyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:RoleCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SignatoryContact" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EnergyTaxReportType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TaxEnergyAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEnergyOnAccountAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEnergyBalanceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxScheme" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EnergyWaterSupplyType">
+      <xsd:sequence>
+         <xsd:element ref="cac:ConsumptionReport" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnergyTaxReport" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ConsumptionAverage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnergyWaterConsumptionCorrection"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EnvironmentalEmissionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:EnvironmentalEmissionTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EmissionCalculationMethod"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EvaluationCriterionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:EvaluationCriterionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ThresholdAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ThresholdQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpressionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Expression" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DurationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SuggestedEvidence" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:IdentificationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CompletionIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CurrentStatus" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OccurenceLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventCommentType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Comment" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventLineItemType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:LineNumberNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ParticipatingLocationsLocation"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RetailPlannedImpact" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupplyItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventTacticType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Comment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EventTacticEnumeration" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventTacticEnumerationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ConsumerIncentiveTacticTypeCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DisplayTacticTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeatureTacticTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TradeItemPackingLabelingTypeCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EvidenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EvidenceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CandidateStatement" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceIssuingParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EvidenceSuppliedType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionCriteriaLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ThresholdValueComparisonCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ThresholdQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExceptionStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CollaborationPriorityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExceptionResolutionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EffectivePeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplyItem" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ForecastExceptionCriterionLine"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionNotificationLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExceptionStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CollaborationPriorityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResolutionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparedValueMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceValueMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:VarianceQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExceptionObservationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ForecastException" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplyItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExchangeRateType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:SourceCurrencyCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceCurrencyBaseRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TargetCurrencyCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TargetCurrencyBaseRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExchangeMarketID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CalculationRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MathematicOperatorCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Date" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ForeignExchangeContract" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExternalReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentHash" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HashAlgorithmMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MimeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FormatCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EncodingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CharacterSetCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FileName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FinancialAccountType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AliasName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountFormatCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentNote" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialInstitutionBranch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Country" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FinancialGuaranteeType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:GuaranteeTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LiabilityAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AmountRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConstitutionPeriod" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FinancialInstitutionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastExceptionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ForecastPurposeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DataSourceCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonDataCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonForecastIssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonForecastIssueDate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastExceptionCriterionLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ForecastPurposeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonDataSourceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DataSourceCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimeDeltaDaysQuantity" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:FrozenDocumentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ForecastPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastRevisionLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:RevisedForecastLineID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceForecastIssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceForecastIssueTime" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdjustmentReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ForecastPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FrameworkAgreementType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ExpectedOperatorQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOperatorQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Justification" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Frequency" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DurationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubsequentProcessTenderRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredCustomsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredForCarriageValueAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredStatisticsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOnBoardValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InsuranceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetNetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeableWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreferenceCriterionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredCustomsID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsTariffQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsImportClassifiedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeableQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReturnableQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:GoodsItemContainer" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:InvoiceLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Temperature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainedGoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Pickup" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainingPackage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ShipmentDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemContainerType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEquipment" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousGoodsTransitType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TransportEmergencyCardCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackingCriteriaCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRegulationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InhalationToxicityZoneCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportAuthorizationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousItemType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardNotation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardEndorsement" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UNDGCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmergencyProceduresCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MedicalFirstAidGuideCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TechnicalName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CategoryName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousCategoryCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UpperOrangeHazardPlacardID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LowerOrangeHazardPlacardID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkingID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardClassID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContactParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SecondaryHazard" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousGoodsTransit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EmergencyTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FlashpointTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalTemperature" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ImmobilizedSecurityType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ImmobilizationCertificateID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SecurityID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FaceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarketValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SharesNumberQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionForReturnsLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ManufacturerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InventoryReportLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:InventoryValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:InventoryLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InvoiceLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:InvoicedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOfChargeIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WithholdingTaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubInvoiceLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemPriceExtension" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackSizeNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CatalogueIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Keyword" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:BrandName" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ModelName" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BuyersItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellersItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ManufacturersItemIdentification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:StandardItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CatalogueItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalItemIdentification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CatalogueDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemSpecificationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransactionConditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ClassifiedTaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalItemProperty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ManufacturerParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:InformationContentProviderParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:OriginAddress" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemInstance" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Certificate" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemComparisonType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:PriceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExtendedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BarcodeSymbologyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PhysicalAttribute" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemInformationRequestLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TimeFrequencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemInstanceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ProductTraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ManufactureDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ManufactureTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BestBeforeDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SerialID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalItemProperty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LotIdentification" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemLocationQuantityType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:LeadTimeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TradingRestrictions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicableTerritoryAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicableTaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DependentPriceReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemManagementProfileType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:FrozenPeriodDaysNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumInventoryQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MultipleOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderIntervalDaysNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReplenishmentOwnerDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TargetServicePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TargetInventoryQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EffectivePeriod" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemLocationQuantity" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:NameCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TestMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQualifier" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ImportanceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ListValue" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UsabilityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemPropertyGroup" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RangeDimension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemPropertyRange" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemPropertyGroupType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ImportanceCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemPropertyRangeType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:MinimumValue" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumValue" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LanguageType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocaleCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LineItemType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalesOrderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumBackorderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumBackorderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InspectionMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartialDeliveryIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BackOrderAllowedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WarrantyInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderedShipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SubLineItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemPriceExtension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LineReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:LineID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LineResponseType">
+      <xsd:sequence>
+         <xsd:element ref="cac:LineReference" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Response" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LocationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Conditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CountrySubentity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CountrySubentityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InformationURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubsidiaryLocation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LocationCoordinate" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LocationCoordinateType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:CoordinateSystemCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatitudeDegreesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatitudeMinutesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatitudeDirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LongitudeDegreesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LongitudeMinutesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LongitudeDirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AltitudeMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LotIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:LotNumberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalItemProperty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MaritimeTransportType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:VesselID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VesselName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RadioCallSignID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShipsRequirements" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:GrossTonnageMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetTonnageMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RegistryCertificateDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RegistryPortLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MeterType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:MeterNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterConstant" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterConstantCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalDeliveredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeterReading" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeterProperty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MeterPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NameCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQualifier" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterReadingType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterReadingTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterReadingDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterReadingDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterReadingMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterReadingMethodCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterReadingMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterReadingMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterReadingComments" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DeliveredQuantity" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MiscellaneousEventType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:MiscellaneousEventTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EventLineItem" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MonetaryTotalType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxExclusiveAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AllowanceTotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeTotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrepaidAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayableRoundingAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayableAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayableAlternativeAmount" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="NotificationRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:NotificationTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PostEventNotificationDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:PreEventNotificationDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotificationPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotificationLocation" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OnAccountPaymentType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:EstimatedConsumedQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:SubstitutionStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineItem" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerProposedSubstituteLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SellerSubstitutedLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BuyerProposedSubstituteLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CatalogueLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:QuotationLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderLineReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:LineID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalesOrderLineID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalesOrderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomerReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderedShipmentType">
+      <xsd:sequence>
+         <xsd:element ref="cac:Shipment" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PackageType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReturnableMaterialIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackageLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackagingTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackingMaterial" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContainedPackage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainingTransportEquipment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Pickup" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:MarkCareIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkAttentionIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WebsiteURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LogoReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndpointID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IndustryClassificationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PartyIdentification" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PartyName" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PostalAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PhysicalLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PartyTaxScheme" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PartyLegalEntity" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Person" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AgentParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ServiceProviderParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PowerOfAttorney" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialAccount" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyLegalEntityType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:RegistrationName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationExpirationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalFormCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalForm" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SoleProprietorshipIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLiquidationStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorporateStockAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FullyPaidSharesIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RegistrationAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CorporateRegistrationScheme" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HeadOfficeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShareholderParty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyNameType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyTaxSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:RegistrationName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExemptionReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExemptionReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RegistrationAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxScheme" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaidAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaidDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaidTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstructionID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMandateType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MandateTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumPaymentInstructionsNumeric"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumPaidAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SignatureID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayerFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentReversalPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Clause" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentMeansCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentDueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentChannelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstructionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstructionNote" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PaymentID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CardAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayerFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CreditAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentMandate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TradeFinancing" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentTermsType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentMeansID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PrepaidPaymentReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReferenceEventCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SettlementDiscountPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PenaltySurchargePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SettlementDiscountAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PenaltyAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentTermsDetailsURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentDueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstallmentDueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InvoicingPartyReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SettlementPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PenaltyPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PerformanceDataLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PerformanceValueQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PeriodType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:StartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DurationMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DescriptionCode" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PersonType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FirstName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FamilyName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Title" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MiddleName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OtherName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NameSuffix" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:JobTitle" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NationalityID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GenderCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BirthDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BirthplaceName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrganizationDepartment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IdentityDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ResidenceAddress" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PhysicalAttributeType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AttributeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PositionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DescriptionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PickupType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualPickupDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualPickupTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EarliestPickupDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EarliestPickupTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestPickupDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestPickupTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PickupLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PickupParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PowerOfAttorneyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotaryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AgentParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:WitnessParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MandateDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PriceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:PriceAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceChangeReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PriceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderableUnitFactorRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PriceList" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingExchangeRate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PriceExtensionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PriceListType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreviousPriceList" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PricingReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cac:OriginalItemLocationQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AlternativeConditionPrice"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessJustificationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:PreviousCancellationReasonCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcessReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcessReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementProjectType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProcurementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcurementSubTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:QualityControlCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredFeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:RequestedDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedOverallContractQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedTenderTotal" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MainCommodityClassification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RealizedLocation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PlannedPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractExtension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestForTenderLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementProjectLotType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProject" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProjectReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WorkPhaseReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalEventType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:PromotionalEventTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubmissionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FirstShipmentAvailibilityDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestProposalAcceptanceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PromotionalSpecification"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalEventLineItemType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EventLineItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalSpecificationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:SpecificationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PromotionalEventLineItem"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EventTactic" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QualificationResolutionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AdmissionCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExclusionReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Resolution" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ResolutionDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResolutionTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QualifyingPartyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ParticipationPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PersonalSituation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OperatingYearsQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmployeeQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BusinessClassificationEvidenceID"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:BusinessIdentityEvidenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TendererRoleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BusinessClassificationScheme" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TechnicalCapability" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialCapability" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CompletedTask" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Declaration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EconomicOperatorRole" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QuotationLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestForQuotationLineID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineItem" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerProposedSubstituteLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AlternativeLineItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestLineReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RailTransportType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TrainID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:RailCarID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReceiptLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReceivedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShortQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShortageActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RejectedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RejectReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RejectReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:RejectActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:QuantityDiscrepancyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OversupplyQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimingComplaintCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimingComplaint" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RegulationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:LegalReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OntologyURI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RelatedItemType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReminderLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceBroughtForwardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DebitLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CreditLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PenaltySurchargePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReminderPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RemittanceAdviceLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DebitLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CreditLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InvoicingPartyReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RenewalType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RequestForQuotationLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OptionalLineItemIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrivacyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SecurityClassificationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RequestForTenderLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxIncludedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SubRequestForTenderLine"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedTenderTotalType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:EstimatedOverallContractAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxIncludedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MonetaryScope" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AverageSubsequentContractAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ApplicableTaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:EffectiveDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EffectiveTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Status" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ResultOfVerificationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ValidatorID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationResultCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidateProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidateTool" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidateToolVersion" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SignatoryParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RetailPlannedImpactType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastPurposeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RoadTransportType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:LicensePlateID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SalesItemType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityProperty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxExclusivePrice" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxInclusivePrice" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SecondaryHazardType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardNotation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardEndorsement" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmergencyProceduresCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Extension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceFrequencyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:WeekDayCode" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceProviderPartyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShareholderPartyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:PartecipationPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipmentType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShippingPriorityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetNetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalGoodsItemQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTransportHandlingUnitQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:InsuranceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredCustomsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredForCarriageValueAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredStatisticsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOnBoardValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DeliveryInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SplitConsignmentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsignmentQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Consignment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ShipmentStage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportHandlingUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReturnAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FirstArrivalPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LastExitPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExportCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipmentStageType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportModeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportMeansTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransitDirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreCarriageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OnCarriageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LoadingSequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SuccessiveSequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Instructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DemurrageInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CrewQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PassengerQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransitPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportMeans" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UnloadingPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransshipPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExaminationTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AvailabilityTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExportationTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DischargeTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarehousingTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TakeoverTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OptionalTakeoverTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:DropoffTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReceiptTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:StorageTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AcceptanceTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TerminalOperatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CustomsAgentParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedTransitPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FreightChargeLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DetentionTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedArrivalTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedWaypointTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PlannedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedWaypointTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ActualDepartureTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualWaypointTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EstimatedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedArrivalTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PassengerPerson" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DriverPerson" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReportingPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CrewMemberPerson" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SecurityOfficerPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MasterPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipsSurgeonPerson" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SignatureType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ValidationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidatorID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CanonicalizationMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SignatureMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SignatoryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalSignatureAttachment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalDocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StatementLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceBroughtForwardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DebitLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CreditLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentMeans" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CollectedPayment" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StatusType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ConditionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:StatusReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StatusReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Text" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:IndicationIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReliabilityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Condition" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StockAvailabilityReportLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StowageType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:LocationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Location" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SubcontractTermsType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Rate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UnknownPriceIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubcontractingConditionsCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumPercent" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberConsumptionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ConsumptionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecificationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalMeteredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubscriberParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UtilityConsumptionPoint" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:OnAccountPayment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Consumption" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplierConsumption" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SupplierConsumptionType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UtilitySupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UtilityCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Consumption" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Contract" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsumptionLine" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SupplierPartyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:CustomerAssignedAccountID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalAccountID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DataSendingCapability" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxCategoryType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseUnitMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxExemptionReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxExemptionReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TierRange" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TierRatePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxScheme" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:JurisdictionRegionAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxSubtotalType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TaxableAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CalculationSequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransactionCurrencyTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseUnitMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TierRange" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TierRatePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxTotalType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TaxAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoundingAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEvidenceIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxIncludedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxSubtotal" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CallDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CallTime" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceNumberCalled" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCategory"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCategoryCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MovieTitle" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoamingPartnerName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayPerView" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCall" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCallCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:CallBaseAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CallExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Country" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallDuty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TimeDuty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TelecommunicationsSupplyType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsSupplyTypeCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:PrivacyCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TelecommunicationsSupplyLine"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PhoneNumber" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TelecommunicationsService"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TemperatureType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AttributeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Measure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderLineType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderableUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContentUnitQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderQuantityIncrementNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WarrantyInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfferedItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacementRelatedItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubTenderLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallForTendersLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CallForTendersDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderPreparationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TenderEnvelopeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TenderEnvelopeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OpenTenderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentTenderRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TemplateDocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderResultType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TenderResultCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AdvertisementAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedTenderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LowerTenderAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HigherTenderAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedElectronicTenderQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedForeignTenderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Contract" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AwardedTenderedProject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractFormalizationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubcontractTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WinningParty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderedProjectType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:VariantID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TenderEnvelopeID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TenderEnvelopeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EvidenceDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LegalMonetaryTotal" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AwardingCriterionResponse"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TendererPartyQualificationType">
+      <xsd:sequence>
+         <xsd:element ref="cac:InterestedProcurementProjectLot"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MainQualifyingParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalQualifyingParty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TendererQualificationRequestType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:CompanyLegalFormCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalForm" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PersonalSituation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OperatingYearsQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmployeeQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredBusinessClassificationScheme"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TechnicalEvaluationCriterion"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialEvaluationCriterion"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SpecificTendererRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EconomicOperatorRole" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TendererRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TendererRequirementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LegalReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SuggestedEvidence" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingProcessType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OriginalContractingSystemID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NegotiationDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProcedureCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UrgencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpenseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartPresentationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractingSystemCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubmissionMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CandidateReductionConstraintIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:GovernmentAgreementConstraintIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentAvailabilityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderSubmissionDeadlinePeriod"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:InvitationSubmissionPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ParticipationRequestReceptionPeriod"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:NoticeDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcessJustification" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EconomicOperatorShortList" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OpenTenderEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AuctionTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FrameworkAgreement" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingTermsType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:AwardingMethodTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceEvaluationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumVariantQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VariantConstraintIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AcceptedVariantsDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PriceRevisionFormulaDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:FundingProgramCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FundingProgram" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MaximumAdvertisementAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PaymentFrequencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EconomicOperatorRegistryURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredCurriculaIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OtherConditionsIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalConditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LatestSecurityClearanceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentationFeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PenaltyClause" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredFinancialGuarantee"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcurementLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:FiscalLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EnvironmentalLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EmploymentLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ContractualDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallForTendersDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TendererQualificationRequest"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowedSubcontractTerms"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderPreparation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractExecutionRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AwardingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalInformationParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentProviderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderRecipientParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractResponsibleParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderEvaluationParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractAcceptancePeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AppealTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BudgetAccountLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacedNoticeDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TradeFinancingType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FinancingInstrumentCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancingParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:FinancingFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Clause" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TradingTermsType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Reference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ApplicableAddress" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionConditionsType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferencedConsignmentID"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportEquipmentTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProviderTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OwnerTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SizeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DispositionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FullnessIndicationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RefrigerationOnIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReturnabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LegalStatusIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AirFlowPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumidityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AnimalFoodApprovedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumanFoodApprovedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DangerousGoodsApprovedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:RefrigeratedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Characteristics" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DamageRemarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SpecialTransportRequirements"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TareWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TrackingDeviceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PowerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEquipmentSeal"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProviderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingProofParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OwnerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OperatingParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UnloadingLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:StorageLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PositioningTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:QuarantineTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PickupTransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HandlingTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LoadingTransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicableTransportMeans" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HaulageTradingTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousGoodsTransit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PackagedTransportHandlingUnit"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ServiceAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AttachedTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Pickup" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainedInTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentSealType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SealIssuerTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Condition" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SealStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SealingPartyType" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEventType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:IdentificationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportEventTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CompletionIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReportedShipment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CurrentStatus" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Location" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportExecutionTermsType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TransportUserSpecialTerms"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportServiceProviderSpecialTerms"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ChangeConditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BonusPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CommissionPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PenaltyPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EnvironmentalEmission" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotificationRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ServiceChargePaymentTerms" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportHandlingUnitType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportHandlingUnitTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalGoodsItemQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalPackageQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DamageRemarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ShippingMarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HandlingUnitDespatchLine"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ActualPackage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceivedHandlingUnitReceiptLine"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEquipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportMeans" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousGoodsTransit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FloorSpaceMeasurementDimension"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PalletSpaceMeasurementDimension"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Status" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CustomsDeclaration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReferencedShipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportMeansType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:JourneyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationNationalityID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationNationality"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportMeansTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TradeServiceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Stowage" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AirTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RoadTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RailTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaritimeTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OwnerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportScheduleType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReliabilityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:StatusLocation" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualDepartureTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedArrivalTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationSegmentType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportExecutionPlanReferenceID"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:TransportationService" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportServiceProviderParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ReferencedConsignment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentStage" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationServiceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:TransportServiceCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TariffClassCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Priority" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreightRateClassCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportationServiceDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportationServiceDetailsURI"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEquipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupportedTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UnsupportedTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupportedCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UnsupportedCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TotalCapacityDimension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentStage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ResponsibleTransportServiceProviderParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EnvironmentalEmission" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EstimatedDurationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ScheduledServiceFrequency"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="UnstructuredPriceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:PriceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimeAmount" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="UtilityItemType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackSizeNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrentChargeType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrentChargeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OneTimeChargeType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OneTimeChargeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Contract" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WebSiteAccessType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Password" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Login" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WinningPartyType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:Rank" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WorkPhaseReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WorkPhaseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WorkPhase" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProgressPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WorkOrderDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== --><!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-CommonBasicComponents-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-CommonBasicComponents-2.1.xsd
@@ -1,0 +1,5385 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            xsdrt/common/UBL-CommonBasicComponents-2.1.xsd
+  Generated on:      2013-10-31 17:17z
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+            xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.1">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+               schemaLocation="UBL-QualifiedDataTypes-2.1.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
+               schemaLocation="UBL-UnqualifiedDataTypes-2.1.xsd"/>
+   <xsd:element name="AcceptedIndicator" type="AcceptedIndicatorType"/>
+   <xsd:element name="AcceptedVariantsDescription"
+                type="AcceptedVariantsDescriptionType"/>
+   <xsd:element name="AccountFormatCode" type="AccountFormatCodeType"/>
+   <xsd:element name="AccountID" type="AccountIDType"/>
+   <xsd:element name="AccountTypeCode" type="AccountTypeCodeType"/>
+   <xsd:element name="AccountingCost" type="AccountingCostType"/>
+   <xsd:element name="AccountingCostCode" type="AccountingCostCodeType"/>
+   <xsd:element name="ActionCode" type="ActionCodeType"/>
+   <xsd:element name="ActivityType" type="ActivityTypeType"/>
+   <xsd:element name="ActivityTypeCode" type="ActivityTypeCodeType"/>
+   <xsd:element name="ActualDeliveryDate" type="ActualDeliveryDateType"/>
+   <xsd:element name="ActualDeliveryTime" type="ActualDeliveryTimeType"/>
+   <xsd:element name="ActualDespatchDate" type="ActualDespatchDateType"/>
+   <xsd:element name="ActualDespatchTime" type="ActualDespatchTimeType"/>
+   <xsd:element name="ActualPickupDate" type="ActualPickupDateType"/>
+   <xsd:element name="ActualPickupTime" type="ActualPickupTimeType"/>
+   <xsd:element name="ActualTemperatureReductionQuantity"
+                type="ActualTemperatureReductionQuantityType"/>
+   <xsd:element name="AdValoremIndicator" type="AdValoremIndicatorType"/>
+   <xsd:element name="AdditionalAccountID" type="AdditionalAccountIDType"/>
+   <xsd:element name="AdditionalConditions" type="AdditionalConditionsType"/>
+   <xsd:element name="AdditionalInformation" type="AdditionalInformationType"/>
+   <xsd:element name="AdditionalStreetName" type="AdditionalStreetNameType"/>
+   <xsd:element name="AddressFormatCode" type="AddressFormatCodeType"/>
+   <xsd:element name="AddressTypeCode" type="AddressTypeCodeType"/>
+   <xsd:element name="AdjustmentReasonCode" type="AdjustmentReasonCodeType"/>
+   <xsd:element name="AdmissionCode" type="AdmissionCodeType"/>
+   <xsd:element name="AdvertisementAmount" type="AdvertisementAmountType"/>
+   <xsd:element name="AgencyID" type="AgencyIDType"/>
+   <xsd:element name="AgencyName" type="AgencyNameType"/>
+   <xsd:element name="AirFlowPercent" type="AirFlowPercentType"/>
+   <xsd:element name="AircraftID" type="AircraftIDType"/>
+   <xsd:element name="AliasName" type="AliasNameType"/>
+   <xsd:element name="AllowanceChargeReason" type="AllowanceChargeReasonType"/>
+   <xsd:element name="AllowanceChargeReasonCode" type="AllowanceChargeReasonCodeType"/>
+   <xsd:element name="AllowanceTotalAmount" type="AllowanceTotalAmountType"/>
+   <xsd:element name="AltitudeMeasure" type="AltitudeMeasureType"/>
+   <xsd:element name="Amount" type="AmountType"/>
+   <xsd:element name="AmountRate" type="AmountRateType"/>
+   <xsd:element name="AnimalFoodApprovedIndicator"
+                type="AnimalFoodApprovedIndicatorType"/>
+   <xsd:element name="AnimalFoodIndicator" type="AnimalFoodIndicatorType"/>
+   <xsd:element name="AnnualAverageAmount" type="AnnualAverageAmountType"/>
+   <xsd:element name="ApplicationStatusCode" type="ApplicationStatusCodeType"/>
+   <xsd:element name="ApprovalDate" type="ApprovalDateType"/>
+   <xsd:element name="ApprovalStatus" type="ApprovalStatusType"/>
+   <xsd:element name="AttributeID" type="AttributeIDType"/>
+   <xsd:element name="AuctionConstraintIndicator" type="AuctionConstraintIndicatorType"/>
+   <xsd:element name="AuctionURI" type="AuctionURIType"/>
+   <xsd:element name="AvailabilityDate" type="AvailabilityDateType"/>
+   <xsd:element name="AvailabilityStatusCode" type="AvailabilityStatusCodeType"/>
+   <xsd:element name="AverageAmount" type="AverageAmountType"/>
+   <xsd:element name="AverageSubsequentContractAmount"
+                type="AverageSubsequentContractAmountType"/>
+   <xsd:element name="AwardDate" type="AwardDateType"/>
+   <xsd:element name="AwardTime" type="AwardTimeType"/>
+   <xsd:element name="AwardingCriterionDescription"
+                type="AwardingCriterionDescriptionType"/>
+   <xsd:element name="AwardingCriterionID" type="AwardingCriterionIDType"/>
+   <xsd:element name="AwardingCriterionTypeCode" type="AwardingCriterionTypeCodeType"/>
+   <xsd:element name="AwardingMethodTypeCode" type="AwardingMethodTypeCodeType"/>
+   <xsd:element name="BackOrderAllowedIndicator" type="BackOrderAllowedIndicatorType"/>
+   <xsd:element name="BackorderQuantity" type="BackorderQuantityType"/>
+   <xsd:element name="BackorderReason" type="BackorderReasonType"/>
+   <xsd:element name="BalanceAmount" type="BalanceAmountType"/>
+   <xsd:element name="BalanceBroughtForwardIndicator"
+                type="BalanceBroughtForwardIndicatorType"/>
+   <xsd:element name="BarcodeSymbologyID" type="BarcodeSymbologyIDType"/>
+   <xsd:element name="BaseAmount" type="BaseAmountType"/>
+   <xsd:element name="BaseQuantity" type="BaseQuantityType"/>
+   <xsd:element name="BaseUnitMeasure" type="BaseUnitMeasureType"/>
+   <xsd:element name="BasedOnConsensusIndicator" type="BasedOnConsensusIndicatorType"/>
+   <xsd:element name="BasicConsumedQuantity" type="BasicConsumedQuantityType"/>
+   <xsd:element name="BatchQuantity" type="BatchQuantityType"/>
+   <xsd:element name="BestBeforeDate" type="BestBeforeDateType"/>
+   <xsd:element name="BindingOnBuyerIndicator" type="BindingOnBuyerIndicatorType"/>
+   <xsd:element name="BirthDate" type="BirthDateType"/>
+   <xsd:element name="BirthplaceName" type="BirthplaceNameType"/>
+   <xsd:element name="BlockName" type="BlockNameType"/>
+   <xsd:element name="BrandName" type="BrandNameType"/>
+   <xsd:element name="BrokerAssignedID" type="BrokerAssignedIDType"/>
+   <xsd:element name="BudgetYearNumeric" type="BudgetYearNumericType"/>
+   <xsd:element name="BuildingName" type="BuildingNameType"/>
+   <xsd:element name="BuildingNumber" type="BuildingNumberType"/>
+   <xsd:element name="BulkCargoIndicator" type="BulkCargoIndicatorType"/>
+   <xsd:element name="BusinessClassificationEvidenceID"
+                type="BusinessClassificationEvidenceIDType"/>
+   <xsd:element name="BusinessIdentityEvidenceID" type="BusinessIdentityEvidenceIDType"/>
+   <xsd:element name="BuyerEventID" type="BuyerEventIDType"/>
+   <xsd:element name="BuyerProfileURI" type="BuyerProfileURIType"/>
+   <xsd:element name="BuyerReference" type="BuyerReferenceType"/>
+   <xsd:element name="CV2ID" type="CV2IDType"/>
+   <xsd:element name="CalculationExpression" type="CalculationExpressionType"/>
+   <xsd:element name="CalculationExpressionCode" type="CalculationExpressionCodeType"/>
+   <xsd:element name="CalculationMethodCode" type="CalculationMethodCodeType"/>
+   <xsd:element name="CalculationRate" type="CalculationRateType"/>
+   <xsd:element name="CalculationSequenceNumeric" type="CalculationSequenceNumericType"/>
+   <xsd:element name="CallBaseAmount" type="CallBaseAmountType"/>
+   <xsd:element name="CallDate" type="CallDateType"/>
+   <xsd:element name="CallExtensionAmount" type="CallExtensionAmountType"/>
+   <xsd:element name="CallTime" type="CallTimeType"/>
+   <xsd:element name="CancellationNote" type="CancellationNoteType"/>
+   <xsd:element name="CandidateReductionConstraintIndicator"
+                type="CandidateReductionConstraintIndicatorType"/>
+   <xsd:element name="CandidateStatement" type="CandidateStatementType"/>
+   <xsd:element name="CanonicalizationMethod" type="CanonicalizationMethodType"/>
+   <xsd:element name="CapabilityTypeCode" type="CapabilityTypeCodeType"/>
+   <xsd:element name="CardChipCode" type="CardChipCodeType"/>
+   <xsd:element name="CardTypeCode" type="CardTypeCodeType"/>
+   <xsd:element name="CargoTypeCode" type="CargoTypeCodeType"/>
+   <xsd:element name="CarrierAssignedID" type="CarrierAssignedIDType"/>
+   <xsd:element name="CarrierServiceInstructions" type="CarrierServiceInstructionsType"/>
+   <xsd:element name="CatalogueIndicator" type="CatalogueIndicatorType"/>
+   <xsd:element name="CategoryName" type="CategoryNameType"/>
+   <xsd:element name="CertificateType" type="CertificateTypeType"/>
+   <xsd:element name="CertificateTypeCode" type="CertificateTypeCodeType"/>
+   <xsd:element name="ChangeConditions" type="ChangeConditionsType"/>
+   <xsd:element name="Channel" type="ChannelType"/>
+   <xsd:element name="ChannelCode" type="ChannelCodeType"/>
+   <xsd:element name="CharacterSetCode" type="CharacterSetCodeType"/>
+   <xsd:element name="Characteristics" type="CharacteristicsType"/>
+   <xsd:element name="ChargeIndicator" type="ChargeIndicatorType"/>
+   <xsd:element name="ChargeTotalAmount" type="ChargeTotalAmountType"/>
+   <xsd:element name="ChargeableQuantity" type="ChargeableQuantityType"/>
+   <xsd:element name="ChargeableWeightMeasure" type="ChargeableWeightMeasureType"/>
+   <xsd:element name="ChildConsignmentQuantity" type="ChildConsignmentQuantityType"/>
+   <xsd:element name="ChipApplicationID" type="ChipApplicationIDType"/>
+   <xsd:element name="CityName" type="CityNameType"/>
+   <xsd:element name="CitySubdivisionName" type="CitySubdivisionNameType"/>
+   <xsd:element name="CodeValue" type="CodeValueType"/>
+   <xsd:element name="CollaborationPriorityCode" type="CollaborationPriorityCodeType"/>
+   <xsd:element name="Comment" type="CommentType"/>
+   <xsd:element name="CommodityCode" type="CommodityCodeType"/>
+   <xsd:element name="CompanyID" type="CompanyIDType"/>
+   <xsd:element name="CompanyLegalForm" type="CompanyLegalFormType"/>
+   <xsd:element name="CompanyLegalFormCode" type="CompanyLegalFormCodeType"/>
+   <xsd:element name="CompanyLiquidationStatusCode"
+                type="CompanyLiquidationStatusCodeType"/>
+   <xsd:element name="ComparedValueMeasure" type="ComparedValueMeasureType"/>
+   <xsd:element name="ComparisonDataCode" type="ComparisonDataCodeType"/>
+   <xsd:element name="ComparisonDataSourceCode" type="ComparisonDataSourceCodeType"/>
+   <xsd:element name="ComparisonForecastIssueDate"
+                type="ComparisonForecastIssueDateType"/>
+   <xsd:element name="ComparisonForecastIssueTime"
+                type="ComparisonForecastIssueTimeType"/>
+   <xsd:element name="CompletionIndicator" type="CompletionIndicatorType"/>
+   <xsd:element name="Condition" type="ConditionType"/>
+   <xsd:element name="ConditionCode" type="ConditionCodeType"/>
+   <xsd:element name="Conditions" type="ConditionsType"/>
+   <xsd:element name="ConditionsDescription" type="ConditionsDescriptionType"/>
+   <xsd:element name="ConsigneeAssignedID" type="ConsigneeAssignedIDType"/>
+   <xsd:element name="ConsignmentQuantity" type="ConsignmentQuantityType"/>
+   <xsd:element name="ConsignorAssignedID" type="ConsignorAssignedIDType"/>
+   <xsd:element name="ConsolidatableIndicator" type="ConsolidatableIndicatorType"/>
+   <xsd:element name="ConstitutionCode" type="ConstitutionCodeType"/>
+   <xsd:element name="ConsumerIncentiveTacticTypeCode"
+                type="ConsumerIncentiveTacticTypeCodeType"/>
+   <xsd:element name="ConsumerUnitQuantity" type="ConsumerUnitQuantityType"/>
+   <xsd:element name="ConsumersEnergyLevel" type="ConsumersEnergyLevelType"/>
+   <xsd:element name="ConsumersEnergyLevelCode" type="ConsumersEnergyLevelCodeType"/>
+   <xsd:element name="ConsumptionEnergyQuantity" type="ConsumptionEnergyQuantityType"/>
+   <xsd:element name="ConsumptionID" type="ConsumptionIDType"/>
+   <xsd:element name="ConsumptionLevel" type="ConsumptionLevelType"/>
+   <xsd:element name="ConsumptionLevelCode" type="ConsumptionLevelCodeType"/>
+   <xsd:element name="ConsumptionReportID" type="ConsumptionReportIDType"/>
+   <xsd:element name="ConsumptionType" type="ConsumptionTypeType"/>
+   <xsd:element name="ConsumptionTypeCode" type="ConsumptionTypeCodeType"/>
+   <xsd:element name="ConsumptionWaterQuantity" type="ConsumptionWaterQuantityType"/>
+   <xsd:element name="ContainerizedIndicator" type="ContainerizedIndicatorType"/>
+   <xsd:element name="Content" type="ContentType"/>
+   <xsd:element name="ContentUnitQuantity" type="ContentUnitQuantityType"/>
+   <xsd:element name="ContractFolderID" type="ContractFolderIDType"/>
+   <xsd:element name="ContractName" type="ContractNameType"/>
+   <xsd:element name="ContractSubdivision" type="ContractSubdivisionType"/>
+   <xsd:element name="ContractType" type="ContractTypeType"/>
+   <xsd:element name="ContractTypeCode" type="ContractTypeCodeType"/>
+   <xsd:element name="ContractedCarrierAssignedID"
+                type="ContractedCarrierAssignedIDType"/>
+   <xsd:element name="ContractingSystemCode" type="ContractingSystemCodeType"/>
+   <xsd:element name="CoordinateSystemCode" type="CoordinateSystemCodeType"/>
+   <xsd:element name="CopyIndicator" type="CopyIndicatorType"/>
+   <xsd:element name="CorporateRegistrationTypeCode"
+                type="CorporateRegistrationTypeCodeType"/>
+   <xsd:element name="CorporateStockAmount" type="CorporateStockAmountType"/>
+   <xsd:element name="CorrectionAmount" type="CorrectionAmountType"/>
+   <xsd:element name="CorrectionType" type="CorrectionTypeType"/>
+   <xsd:element name="CorrectionTypeCode" type="CorrectionTypeCodeType"/>
+   <xsd:element name="CorrectionUnitAmount" type="CorrectionUnitAmountType"/>
+   <xsd:element name="CountrySubentity" type="CountrySubentityType"/>
+   <xsd:element name="CountrySubentityCode" type="CountrySubentityCodeType"/>
+   <xsd:element name="CreditLineAmount" type="CreditLineAmountType"/>
+   <xsd:element name="CreditNoteTypeCode" type="CreditNoteTypeCodeType"/>
+   <xsd:element name="CreditedQuantity" type="CreditedQuantityType"/>
+   <xsd:element name="CrewQuantity" type="CrewQuantityType"/>
+   <xsd:element name="CurrencyCode" type="CurrencyCodeType"/>
+   <xsd:element name="CurrentChargeType" type="CurrentChargeTypeType"/>
+   <xsd:element name="CurrentChargeTypeCode" type="CurrentChargeTypeCodeType"/>
+   <xsd:element name="CustomerAssignedAccountID" type="CustomerAssignedAccountIDType"/>
+   <xsd:element name="CustomerReference" type="CustomerReferenceType"/>
+   <xsd:element name="CustomizationID" type="CustomizationIDType"/>
+   <xsd:element name="CustomsClearanceServiceInstructions"
+                type="CustomsClearanceServiceInstructionsType"/>
+   <xsd:element name="CustomsImportClassifiedIndicator"
+                type="CustomsImportClassifiedIndicatorType"/>
+   <xsd:element name="CustomsStatusCode" type="CustomsStatusCodeType"/>
+   <xsd:element name="CustomsTariffQuantity" type="CustomsTariffQuantityType"/>
+   <xsd:element name="DamageRemarks" type="DamageRemarksType"/>
+   <xsd:element name="DangerousGoodsApprovedIndicator"
+                type="DangerousGoodsApprovedIndicatorType"/>
+   <xsd:element name="DataSendingCapability" type="DataSendingCapabilityType"/>
+   <xsd:element name="DataSourceCode" type="DataSourceCodeType"/>
+   <xsd:element name="Date" type="DateType"/>
+   <xsd:element name="DebitLineAmount" type="DebitLineAmountType"/>
+   <xsd:element name="DebitedQuantity" type="DebitedQuantityType"/>
+   <xsd:element name="DeclarationTypeCode" type="DeclarationTypeCodeType"/>
+   <xsd:element name="DeclaredCarriageValueAmount"
+                type="DeclaredCarriageValueAmountType"/>
+   <xsd:element name="DeclaredCustomsValueAmount" type="DeclaredCustomsValueAmountType"/>
+   <xsd:element name="DeclaredForCarriageValueAmount"
+                type="DeclaredForCarriageValueAmountType"/>
+   <xsd:element name="DeclaredStatisticsValueAmount"
+                type="DeclaredStatisticsValueAmountType"/>
+   <xsd:element name="DeliveredQuantity" type="DeliveredQuantityType"/>
+   <xsd:element name="DeliveryInstructions" type="DeliveryInstructionsType"/>
+   <xsd:element name="DemurrageInstructions" type="DemurrageInstructionsType"/>
+   <xsd:element name="Department" type="DepartmentType"/>
+   <xsd:element name="Description" type="DescriptionType"/>
+   <xsd:element name="DescriptionCode" type="DescriptionCodeType"/>
+   <xsd:element name="DespatchAdviceTypeCode" type="DespatchAdviceTypeCodeType"/>
+   <xsd:element name="DifferenceTemperatureReductionQuantity"
+                type="DifferenceTemperatureReductionQuantityType"/>
+   <xsd:element name="DirectionCode" type="DirectionCodeType"/>
+   <xsd:element name="DisplayTacticTypeCode" type="DisplayTacticTypeCodeType"/>
+   <xsd:element name="DispositionCode" type="DispositionCodeType"/>
+   <xsd:element name="District" type="DistrictType"/>
+   <xsd:element name="DocumentCurrencyCode" type="DocumentCurrencyCodeType"/>
+   <xsd:element name="DocumentDescription" type="DocumentDescriptionType"/>
+   <xsd:element name="DocumentHash" type="DocumentHashType"/>
+   <xsd:element name="DocumentID" type="DocumentIDType"/>
+   <xsd:element name="DocumentStatusCode" type="DocumentStatusCodeType"/>
+   <xsd:element name="DocumentStatusReasonCode" type="DocumentStatusReasonCodeType"/>
+   <xsd:element name="DocumentStatusReasonDescription"
+                type="DocumentStatusReasonDescriptionType"/>
+   <xsd:element name="DocumentType" type="DocumentTypeType"/>
+   <xsd:element name="DocumentTypeCode" type="DocumentTypeCodeType"/>
+   <xsd:element name="DocumentationFeeAmount" type="DocumentationFeeAmountType"/>
+   <xsd:element name="DueDate" type="DueDateType"/>
+   <xsd:element name="DurationMeasure" type="DurationMeasureType"/>
+   <xsd:element name="Duty" type="DutyType"/>
+   <xsd:element name="DutyCode" type="DutyCodeType"/>
+   <xsd:element name="EarliestPickupDate" type="EarliestPickupDateType"/>
+   <xsd:element name="EarliestPickupTime" type="EarliestPickupTimeType"/>
+   <xsd:element name="EconomicOperatorRegistryURI"
+                type="EconomicOperatorRegistryURIType"/>
+   <xsd:element name="EffectiveDate" type="EffectiveDateType"/>
+   <xsd:element name="EffectiveTime" type="EffectiveTimeType"/>
+   <xsd:element name="ElectronicDeviceDescription"
+                type="ElectronicDeviceDescriptionType"/>
+   <xsd:element name="ElectronicMail" type="ElectronicMailType"/>
+   <xsd:element name="EmbeddedDocumentBinaryObject"
+                type="EmbeddedDocumentBinaryObjectType"/>
+   <xsd:element name="EmergencyProceduresCode" type="EmergencyProceduresCodeType"/>
+   <xsd:element name="EmployeeQuantity" type="EmployeeQuantityType"/>
+   <xsd:element name="EncodingCode" type="EncodingCodeType"/>
+   <xsd:element name="EndDate" type="EndDateType"/>
+   <xsd:element name="EndTime" type="EndTimeType"/>
+   <xsd:element name="EndpointID" type="EndpointIDType"/>
+   <xsd:element name="EnvironmentalEmissionTypeCode"
+                type="EnvironmentalEmissionTypeCodeType"/>
+   <xsd:element name="EstimatedAmount" type="EstimatedAmountType"/>
+   <xsd:element name="EstimatedConsumedQuantity" type="EstimatedConsumedQuantityType"/>
+   <xsd:element name="EstimatedDeliveryDate" type="EstimatedDeliveryDateType"/>
+   <xsd:element name="EstimatedDeliveryTime" type="EstimatedDeliveryTimeType"/>
+   <xsd:element name="EstimatedDespatchDate" type="EstimatedDespatchDateType"/>
+   <xsd:element name="EstimatedDespatchTime" type="EstimatedDespatchTimeType"/>
+   <xsd:element name="EstimatedOverallContractAmount"
+                type="EstimatedOverallContractAmountType"/>
+   <xsd:element name="EstimatedOverallContractQuantity"
+                type="EstimatedOverallContractQuantityType"/>
+   <xsd:element name="EvaluationCriterionTypeCode"
+                type="EvaluationCriterionTypeCodeType"/>
+   <xsd:element name="EvidenceTypeCode" type="EvidenceTypeCodeType"/>
+   <xsd:element name="ExceptionResolutionCode" type="ExceptionResolutionCodeType"/>
+   <xsd:element name="ExceptionStatusCode" type="ExceptionStatusCodeType"/>
+   <xsd:element name="ExchangeMarketID" type="ExchangeMarketIDType"/>
+   <xsd:element name="ExclusionReason" type="ExclusionReasonType"/>
+   <xsd:element name="ExecutionRequirementCode" type="ExecutionRequirementCodeType"/>
+   <xsd:element name="ExemptionReason" type="ExemptionReasonType"/>
+   <xsd:element name="ExemptionReasonCode" type="ExemptionReasonCodeType"/>
+   <xsd:element name="ExpectedOperatorQuantity" type="ExpectedOperatorQuantityType"/>
+   <xsd:element name="ExpectedQuantity" type="ExpectedQuantityType"/>
+   <xsd:element name="ExpenseCode" type="ExpenseCodeType"/>
+   <xsd:element name="ExpiryDate" type="ExpiryDateType"/>
+   <xsd:element name="ExpiryTime" type="ExpiryTimeType"/>
+   <xsd:element name="Expression" type="ExpressionType"/>
+   <xsd:element name="ExpressionCode" type="ExpressionCodeType"/>
+   <xsd:element name="ExtendedID" type="ExtendedIDType"/>
+   <xsd:element name="Extension" type="ExtensionType"/>
+   <xsd:element name="FaceValueAmount" type="FaceValueAmountType"/>
+   <xsd:element name="FamilyName" type="FamilyNameType"/>
+   <xsd:element name="FeatureTacticTypeCode" type="FeatureTacticTypeCodeType"/>
+   <xsd:element name="FeeAmount" type="FeeAmountType"/>
+   <xsd:element name="FeeDescription" type="FeeDescriptionType"/>
+   <xsd:element name="FileName" type="FileNameType"/>
+   <xsd:element name="FinancingInstrumentCode" type="FinancingInstrumentCodeType"/>
+   <xsd:element name="FirstName" type="FirstNameType"/>
+   <xsd:element name="FirstShipmentAvailibilityDate"
+                type="FirstShipmentAvailibilityDateType"/>
+   <xsd:element name="Floor" type="FloorType"/>
+   <xsd:element name="FollowupContractIndicator" type="FollowupContractIndicatorType"/>
+   <xsd:element name="ForecastPurposeCode" type="ForecastPurposeCodeType"/>
+   <xsd:element name="ForecastTypeCode" type="ForecastTypeCodeType"/>
+   <xsd:element name="FormatCode" type="FormatCodeType"/>
+   <xsd:element name="ForwarderServiceInstructions"
+                type="ForwarderServiceInstructionsType"/>
+   <xsd:element name="FreeOfChargeIndicator" type="FreeOfChargeIndicatorType"/>
+   <xsd:element name="FreeOnBoardValueAmount" type="FreeOnBoardValueAmountType"/>
+   <xsd:element name="FreightForwarderAssignedID" type="FreightForwarderAssignedIDType"/>
+   <xsd:element name="FreightRateClassCode" type="FreightRateClassCodeType"/>
+   <xsd:element name="Frequency" type="FrequencyType"/>
+   <xsd:element name="FrozenDocumentIndicator" type="FrozenDocumentIndicatorType"/>
+   <xsd:element name="FrozenPeriodDaysNumeric" type="FrozenPeriodDaysNumericType"/>
+   <xsd:element name="FullnessIndicationCode" type="FullnessIndicationCodeType"/>
+   <xsd:element name="FullyPaidSharesIndicator" type="FullyPaidSharesIndicatorType"/>
+   <xsd:element name="FundingProgram" type="FundingProgramType"/>
+   <xsd:element name="FundingProgramCode" type="FundingProgramCodeType"/>
+   <xsd:element name="GasPressureQuantity" type="GasPressureQuantityType"/>
+   <xsd:element name="GenderCode" type="GenderCodeType"/>
+   <xsd:element name="GeneralCargoIndicator" type="GeneralCargoIndicatorType"/>
+   <xsd:element name="GovernmentAgreementConstraintIndicator"
+                type="GovernmentAgreementConstraintIndicatorType"/>
+   <xsd:element name="GrossTonnageMeasure" type="GrossTonnageMeasureType"/>
+   <xsd:element name="GrossVolumeMeasure" type="GrossVolumeMeasureType"/>
+   <xsd:element name="GrossWeightMeasure" type="GrossWeightMeasureType"/>
+   <xsd:element name="GuaranteeTypeCode" type="GuaranteeTypeCodeType"/>
+   <xsd:element name="GuaranteedDespatchDate" type="GuaranteedDespatchDateType"/>
+   <xsd:element name="GuaranteedDespatchTime" type="GuaranteedDespatchTimeType"/>
+   <xsd:element name="HandlingCode" type="HandlingCodeType"/>
+   <xsd:element name="HandlingInstructions" type="HandlingInstructionsType"/>
+   <xsd:element name="HashAlgorithmMethod" type="HashAlgorithmMethodType"/>
+   <xsd:element name="HaulageInstructions" type="HaulageInstructionsType"/>
+   <xsd:element name="HazardClassID" type="HazardClassIDType"/>
+   <xsd:element name="HazardousCategoryCode" type="HazardousCategoryCodeType"/>
+   <xsd:element name="HazardousRegulationCode" type="HazardousRegulationCodeType"/>
+   <xsd:element name="HazardousRiskIndicator" type="HazardousRiskIndicatorType"/>
+   <xsd:element name="HeatingType" type="HeatingTypeType"/>
+   <xsd:element name="HeatingTypeCode" type="HeatingTypeCodeType"/>
+   <xsd:element name="HigherTenderAmount" type="HigherTenderAmountType"/>
+   <xsd:element name="HolderName" type="HolderNameType"/>
+   <xsd:element name="HumanFoodApprovedIndicator" type="HumanFoodApprovedIndicatorType"/>
+   <xsd:element name="HumanFoodIndicator" type="HumanFoodIndicatorType"/>
+   <xsd:element name="HumidityPercent" type="HumidityPercentType"/>
+   <xsd:element name="ID" type="IDType"/>
+   <xsd:element name="IdentificationCode" type="IdentificationCodeType"/>
+   <xsd:element name="IdentificationID" type="IdentificationIDType"/>
+   <xsd:element name="ImmobilizationCertificateID"
+                type="ImmobilizationCertificateIDType"/>
+   <xsd:element name="ImportanceCode" type="ImportanceCodeType"/>
+   <xsd:element name="IndicationIndicator" type="IndicationIndicatorType"/>
+   <xsd:element name="IndustryClassificationCode" type="IndustryClassificationCodeType"/>
+   <xsd:element name="Information" type="InformationType"/>
+   <xsd:element name="InformationURI" type="InformationURIType"/>
+   <xsd:element name="InhalationToxicityZoneCode" type="InhalationToxicityZoneCodeType"/>
+   <xsd:element name="InhouseMail" type="InhouseMailType"/>
+   <xsd:element name="InspectionMethodCode" type="InspectionMethodCodeType"/>
+   <xsd:element name="InstallmentDueDate" type="InstallmentDueDateType"/>
+   <xsd:element name="InstructionID" type="InstructionIDType"/>
+   <xsd:element name="InstructionNote" type="InstructionNoteType"/>
+   <xsd:element name="Instructions" type="InstructionsType"/>
+   <xsd:element name="InsurancePremiumAmount" type="InsurancePremiumAmountType"/>
+   <xsd:element name="InsuranceValueAmount" type="InsuranceValueAmountType"/>
+   <xsd:element name="InventoryValueAmount" type="InventoryValueAmountType"/>
+   <xsd:element name="InvoiceTypeCode" type="InvoiceTypeCodeType"/>
+   <xsd:element name="InvoicedQuantity" type="InvoicedQuantityType"/>
+   <xsd:element name="InvoicingPartyReference" type="InvoicingPartyReferenceType"/>
+   <xsd:element name="IssueDate" type="IssueDateType"/>
+   <xsd:element name="IssueNumberID" type="IssueNumberIDType"/>
+   <xsd:element name="IssueTime" type="IssueTimeType"/>
+   <xsd:element name="IssuerID" type="IssuerIDType"/>
+   <xsd:element name="ItemClassificationCode" type="ItemClassificationCodeType"/>
+   <xsd:element name="ItemUpdateRequestIndicator" type="ItemUpdateRequestIndicatorType"/>
+   <xsd:element name="JobTitle" type="JobTitleType"/>
+   <xsd:element name="JourneyID" type="JourneyIDType"/>
+   <xsd:element name="Justification" type="JustificationType"/>
+   <xsd:element name="JustificationDescription" type="JustificationDescriptionType"/>
+   <xsd:element name="Keyword" type="KeywordType"/>
+   <xsd:element name="LanguageID" type="LanguageIDType"/>
+   <xsd:element name="LastRevisionDate" type="LastRevisionDateType"/>
+   <xsd:element name="LastRevisionTime" type="LastRevisionTimeType"/>
+   <xsd:element name="LatestDeliveryDate" type="LatestDeliveryDateType"/>
+   <xsd:element name="LatestDeliveryTime" type="LatestDeliveryTimeType"/>
+   <xsd:element name="LatestMeterQuantity" type="LatestMeterQuantityType"/>
+   <xsd:element name="LatestMeterReadingDate" type="LatestMeterReadingDateType"/>
+   <xsd:element name="LatestMeterReadingMethod" type="LatestMeterReadingMethodType"/>
+   <xsd:element name="LatestMeterReadingMethodCode"
+                type="LatestMeterReadingMethodCodeType"/>
+   <xsd:element name="LatestPickupDate" type="LatestPickupDateType"/>
+   <xsd:element name="LatestPickupTime" type="LatestPickupTimeType"/>
+   <xsd:element name="LatestProposalAcceptanceDate"
+                type="LatestProposalAcceptanceDateType"/>
+   <xsd:element name="LatestSecurityClearanceDate"
+                type="LatestSecurityClearanceDateType"/>
+   <xsd:element name="LatitudeDegreesMeasure" type="LatitudeDegreesMeasureType"/>
+   <xsd:element name="LatitudeDirectionCode" type="LatitudeDirectionCodeType"/>
+   <xsd:element name="LatitudeMinutesMeasure" type="LatitudeMinutesMeasureType"/>
+   <xsd:element name="LeadTimeMeasure" type="LeadTimeMeasureType"/>
+   <xsd:element name="LegalReference" type="LegalReferenceType"/>
+   <xsd:element name="LegalStatusIndicator" type="LegalStatusIndicatorType"/>
+   <xsd:element name="LiabilityAmount" type="LiabilityAmountType"/>
+   <xsd:element name="LicensePlateID" type="LicensePlateIDType"/>
+   <xsd:element name="LifeCycleStatusCode" type="LifeCycleStatusCodeType"/>
+   <xsd:element name="LimitationDescription" type="LimitationDescriptionType"/>
+   <xsd:element name="Line" type="LineType"/>
+   <xsd:element name="LineCountNumeric" type="LineCountNumericType"/>
+   <xsd:element name="LineExtensionAmount" type="LineExtensionAmountType"/>
+   <xsd:element name="LineID" type="LineIDType"/>
+   <xsd:element name="LineNumberNumeric" type="LineNumberNumericType"/>
+   <xsd:element name="LineStatusCode" type="LineStatusCodeType"/>
+   <xsd:element name="ListValue" type="ListValueType"/>
+   <xsd:element name="LivestockIndicator" type="LivestockIndicatorType"/>
+   <xsd:element name="LoadingLengthMeasure" type="LoadingLengthMeasureType"/>
+   <xsd:element name="LoadingSequenceID" type="LoadingSequenceIDType"/>
+   <xsd:element name="LocaleCode" type="LocaleCodeType"/>
+   <xsd:element name="Location" type="LocationType"/>
+   <xsd:element name="LocationID" type="LocationIDType"/>
+   <xsd:element name="LocationTypeCode" type="LocationTypeCodeType"/>
+   <xsd:element name="Login" type="LoginType"/>
+   <xsd:element name="LogoReferenceID" type="LogoReferenceIDType"/>
+   <xsd:element name="LongitudeDegreesMeasure" type="LongitudeDegreesMeasureType"/>
+   <xsd:element name="LongitudeDirectionCode" type="LongitudeDirectionCodeType"/>
+   <xsd:element name="LongitudeMinutesMeasure" type="LongitudeMinutesMeasureType"/>
+   <xsd:element name="LossRisk" type="LossRiskType"/>
+   <xsd:element name="LossRiskResponsibilityCode" type="LossRiskResponsibilityCodeType"/>
+   <xsd:element name="LotNumberID" type="LotNumberIDType"/>
+   <xsd:element name="LowTendersDescription" type="LowTendersDescriptionType"/>
+   <xsd:element name="LowerOrangeHazardPlacardID" type="LowerOrangeHazardPlacardIDType"/>
+   <xsd:element name="LowerTenderAmount" type="LowerTenderAmountType"/>
+   <xsd:element name="MandateTypeCode" type="MandateTypeCodeType"/>
+   <xsd:element name="ManufactureDate" type="ManufactureDateType"/>
+   <xsd:element name="ManufactureTime" type="ManufactureTimeType"/>
+   <xsd:element name="MarkAttention" type="MarkAttentionType"/>
+   <xsd:element name="MarkAttentionIndicator" type="MarkAttentionIndicatorType"/>
+   <xsd:element name="MarkCare" type="MarkCareType"/>
+   <xsd:element name="MarkCareIndicator" type="MarkCareIndicatorType"/>
+   <xsd:element name="MarketValueAmount" type="MarketValueAmountType"/>
+   <xsd:element name="MarkingID" type="MarkingIDType"/>
+   <xsd:element name="MathematicOperatorCode" type="MathematicOperatorCodeType"/>
+   <xsd:element name="MaximumAdvertisementAmount" type="MaximumAdvertisementAmountType"/>
+   <xsd:element name="MaximumAmount" type="MaximumAmountType"/>
+   <xsd:element name="MaximumBackorderQuantity" type="MaximumBackorderQuantityType"/>
+   <xsd:element name="MaximumCopiesNumeric" type="MaximumCopiesNumericType"/>
+   <xsd:element name="MaximumMeasure" type="MaximumMeasureType"/>
+   <xsd:element name="MaximumNumberNumeric" type="MaximumNumberNumericType"/>
+   <xsd:element name="MaximumOperatorQuantity" type="MaximumOperatorQuantityType"/>
+   <xsd:element name="MaximumOrderQuantity" type="MaximumOrderQuantityType"/>
+   <xsd:element name="MaximumPaidAmount" type="MaximumPaidAmountType"/>
+   <xsd:element name="MaximumPaymentInstructionsNumeric"
+                type="MaximumPaymentInstructionsNumericType"/>
+   <xsd:element name="MaximumPercent" type="MaximumPercentType"/>
+   <xsd:element name="MaximumQuantity" type="MaximumQuantityType"/>
+   <xsd:element name="MaximumValue" type="MaximumValueType"/>
+   <xsd:element name="MaximumVariantQuantity" type="MaximumVariantQuantityType"/>
+   <xsd:element name="Measure" type="MeasureType"/>
+   <xsd:element name="MedicalFirstAidGuideCode" type="MedicalFirstAidGuideCodeType"/>
+   <xsd:element name="MeterConstant" type="MeterConstantType"/>
+   <xsd:element name="MeterConstantCode" type="MeterConstantCodeType"/>
+   <xsd:element name="MeterName" type="MeterNameType"/>
+   <xsd:element name="MeterNumber" type="MeterNumberType"/>
+   <xsd:element name="MeterReadingComments" type="MeterReadingCommentsType"/>
+   <xsd:element name="MeterReadingType" type="MeterReadingTypeType"/>
+   <xsd:element name="MeterReadingTypeCode" type="MeterReadingTypeCodeType"/>
+   <xsd:element name="MiddleName" type="MiddleNameType"/>
+   <xsd:element name="MimeCode" type="MimeCodeType"/>
+   <xsd:element name="MinimumAmount" type="MinimumAmountType"/>
+   <xsd:element name="MinimumBackorderQuantity" type="MinimumBackorderQuantityType"/>
+   <xsd:element name="MinimumImprovementBid" type="MinimumImprovementBidType"/>
+   <xsd:element name="MinimumInventoryQuantity" type="MinimumInventoryQuantityType"/>
+   <xsd:element name="MinimumMeasure" type="MinimumMeasureType"/>
+   <xsd:element name="MinimumNumberNumeric" type="MinimumNumberNumericType"/>
+   <xsd:element name="MinimumOrderQuantity" type="MinimumOrderQuantityType"/>
+   <xsd:element name="MinimumPercent" type="MinimumPercentType"/>
+   <xsd:element name="MinimumQuantity" type="MinimumQuantityType"/>
+   <xsd:element name="MinimumValue" type="MinimumValueType"/>
+   <xsd:element name="MiscellaneousEventTypeCode" type="MiscellaneousEventTypeCodeType"/>
+   <xsd:element name="ModelName" type="ModelNameType"/>
+   <xsd:element name="MonetaryScope" type="MonetaryScopeType"/>
+   <xsd:element name="MovieTitle" type="MovieTitleType"/>
+   <xsd:element name="MultipleOrderQuantity" type="MultipleOrderQuantityType"/>
+   <xsd:element name="MultiplierFactorNumeric" type="MultiplierFactorNumericType"/>
+   <xsd:element name="Name" type="NameType"/>
+   <xsd:element name="NameCode" type="NameCodeType"/>
+   <xsd:element name="NameSuffix" type="NameSuffixType"/>
+   <xsd:element name="NationalityID" type="NationalityIDType"/>
+   <xsd:element name="NatureCode" type="NatureCodeType"/>
+   <xsd:element name="NegotiationDescription" type="NegotiationDescriptionType"/>
+   <xsd:element name="NetNetWeightMeasure" type="NetNetWeightMeasureType"/>
+   <xsd:element name="NetTonnageMeasure" type="NetTonnageMeasureType"/>
+   <xsd:element name="NetVolumeMeasure" type="NetVolumeMeasureType"/>
+   <xsd:element name="NetWeightMeasure" type="NetWeightMeasureType"/>
+   <xsd:element name="NetworkID" type="NetworkIDType"/>
+   <xsd:element name="NominationDate" type="NominationDateType"/>
+   <xsd:element name="NominationTime" type="NominationTimeType"/>
+   <xsd:element name="NormalTemperatureReductionQuantity"
+                type="NormalTemperatureReductionQuantityType"/>
+   <xsd:element name="Note" type="NoteType"/>
+   <xsd:element name="NotificationTypeCode" type="NotificationTypeCodeType"/>
+   <xsd:element name="OccurrenceDate" type="OccurrenceDateType"/>
+   <xsd:element name="OccurrenceTime" type="OccurrenceTimeType"/>
+   <xsd:element name="OnCarriageIndicator" type="OnCarriageIndicatorType"/>
+   <xsd:element name="OneTimeChargeType" type="OneTimeChargeTypeType"/>
+   <xsd:element name="OneTimeChargeTypeCode" type="OneTimeChargeTypeCodeType"/>
+   <xsd:element name="OntologyURI" type="OntologyURIType"/>
+   <xsd:element name="OpenTenderID" type="OpenTenderIDType"/>
+   <xsd:element name="OperatingYearsQuantity" type="OperatingYearsQuantityType"/>
+   <xsd:element name="OptionalLineItemIndicator" type="OptionalLineItemIndicatorType"/>
+   <xsd:element name="OptionsDescription" type="OptionsDescriptionType"/>
+   <xsd:element name="OrderIntervalDaysNumeric" type="OrderIntervalDaysNumericType"/>
+   <xsd:element name="OrderQuantityIncrementNumeric"
+                type="OrderQuantityIncrementNumericType"/>
+   <xsd:element name="OrderResponseCode" type="OrderResponseCodeType"/>
+   <xsd:element name="OrderTypeCode" type="OrderTypeCodeType"/>
+   <xsd:element name="OrderableIndicator" type="OrderableIndicatorType"/>
+   <xsd:element name="OrderableUnit" type="OrderableUnitType"/>
+   <xsd:element name="OrderableUnitFactorRate" type="OrderableUnitFactorRateType"/>
+   <xsd:element name="OrganizationDepartment" type="OrganizationDepartmentType"/>
+   <xsd:element name="OriginalContractingSystemID"
+                type="OriginalContractingSystemIDType"/>
+   <xsd:element name="OriginalJobID" type="OriginalJobIDType"/>
+   <xsd:element name="OtherConditionsIndicator" type="OtherConditionsIndicatorType"/>
+   <xsd:element name="OtherInstruction" type="OtherInstructionType"/>
+   <xsd:element name="OtherName" type="OtherNameType"/>
+   <xsd:element name="OutstandingQuantity" type="OutstandingQuantityType"/>
+   <xsd:element name="OutstandingReason" type="OutstandingReasonType"/>
+   <xsd:element name="OversupplyQuantity" type="OversupplyQuantityType"/>
+   <xsd:element name="OwnerTypeCode" type="OwnerTypeCodeType"/>
+   <xsd:element name="PackLevelCode" type="PackLevelCodeType"/>
+   <xsd:element name="PackQuantity" type="PackQuantityType"/>
+   <xsd:element name="PackSizeNumeric" type="PackSizeNumericType"/>
+   <xsd:element name="PackageLevelCode" type="PackageLevelCodeType"/>
+   <xsd:element name="PackagingTypeCode" type="PackagingTypeCodeType"/>
+   <xsd:element name="PackingCriteriaCode" type="PackingCriteriaCodeType"/>
+   <xsd:element name="PackingMaterial" type="PackingMaterialType"/>
+   <xsd:element name="PaidAmount" type="PaidAmountType"/>
+   <xsd:element name="PaidDate" type="PaidDateType"/>
+   <xsd:element name="PaidTime" type="PaidTimeType"/>
+   <xsd:element name="ParentDocumentID" type="ParentDocumentIDType"/>
+   <xsd:element name="ParentDocumentLineReferenceID"
+                type="ParentDocumentLineReferenceIDType"/>
+   <xsd:element name="ParentDocumentTypeCode" type="ParentDocumentTypeCodeType"/>
+   <xsd:element name="ParentDocumentVersionID" type="ParentDocumentVersionIDType"/>
+   <xsd:element name="PartPresentationCode" type="PartPresentationCodeType"/>
+   <xsd:element name="PartecipationPercent" type="PartecipationPercentType"/>
+   <xsd:element name="PartialDeliveryIndicator" type="PartialDeliveryIndicatorType"/>
+   <xsd:element name="ParticipationPercent" type="ParticipationPercentType"/>
+   <xsd:element name="PartyCapacityAmount" type="PartyCapacityAmountType"/>
+   <xsd:element name="PartyType" type="PartyTypeType"/>
+   <xsd:element name="PartyTypeCode" type="PartyTypeCodeType"/>
+   <xsd:element name="PassengerQuantity" type="PassengerQuantityType"/>
+   <xsd:element name="Password" type="PasswordType"/>
+   <xsd:element name="PayPerView" type="PayPerViewType"/>
+   <xsd:element name="PayableAlternativeAmount" type="PayableAlternativeAmountType"/>
+   <xsd:element name="PayableAmount" type="PayableAmountType"/>
+   <xsd:element name="PayableRoundingAmount" type="PayableRoundingAmountType"/>
+   <xsd:element name="PayerReference" type="PayerReferenceType"/>
+   <xsd:element name="PaymentAlternativeCurrencyCode"
+                type="PaymentAlternativeCurrencyCodeType"/>
+   <xsd:element name="PaymentChannelCode" type="PaymentChannelCodeType"/>
+   <xsd:element name="PaymentCurrencyCode" type="PaymentCurrencyCodeType"/>
+   <xsd:element name="PaymentDescription" type="PaymentDescriptionType"/>
+   <xsd:element name="PaymentDueDate" type="PaymentDueDateType"/>
+   <xsd:element name="PaymentFrequencyCode" type="PaymentFrequencyCodeType"/>
+   <xsd:element name="PaymentID" type="PaymentIDType"/>
+   <xsd:element name="PaymentMeansCode" type="PaymentMeansCodeType"/>
+   <xsd:element name="PaymentMeansID" type="PaymentMeansIDType"/>
+   <xsd:element name="PaymentNote" type="PaymentNoteType"/>
+   <xsd:element name="PaymentOrderReference" type="PaymentOrderReferenceType"/>
+   <xsd:element name="PaymentPercent" type="PaymentPercentType"/>
+   <xsd:element name="PaymentPurposeCode" type="PaymentPurposeCodeType"/>
+   <xsd:element name="PaymentTermsDetailsURI" type="PaymentTermsDetailsURIType"/>
+   <xsd:element name="PenaltyAmount" type="PenaltyAmountType"/>
+   <xsd:element name="PenaltySurchargePercent" type="PenaltySurchargePercentType"/>
+   <xsd:element name="PerUnitAmount" type="PerUnitAmountType"/>
+   <xsd:element name="Percent" type="PercentType"/>
+   <xsd:element name="PerformanceMetricTypeCode" type="PerformanceMetricTypeCodeType"/>
+   <xsd:element name="PerformanceValueQuantity" type="PerformanceValueQuantityType"/>
+   <xsd:element name="PerformingCarrierAssignedID"
+                type="PerformingCarrierAssignedIDType"/>
+   <xsd:element name="PersonalSituation" type="PersonalSituationType"/>
+   <xsd:element name="PhoneNumber" type="PhoneNumberType"/>
+   <xsd:element name="PlacardEndorsement" type="PlacardEndorsementType"/>
+   <xsd:element name="PlacardNotation" type="PlacardNotationType"/>
+   <xsd:element name="PlannedDate" type="PlannedDateType"/>
+   <xsd:element name="PlotIdentification" type="PlotIdentificationType"/>
+   <xsd:element name="PositionCode" type="PositionCodeType"/>
+   <xsd:element name="PostEventNotificationDurationMeasure"
+                type="PostEventNotificationDurationMeasureType"/>
+   <xsd:element name="PostalZone" type="PostalZoneType"/>
+   <xsd:element name="Postbox" type="PostboxType"/>
+   <xsd:element name="PowerIndicator" type="PowerIndicatorType"/>
+   <xsd:element name="PreCarriageIndicator" type="PreCarriageIndicatorType"/>
+   <xsd:element name="PreEventNotificationDurationMeasure"
+                type="PreEventNotificationDurationMeasureType"/>
+   <xsd:element name="PreferenceCriterionCode" type="PreferenceCriterionCodeType"/>
+   <xsd:element name="PrepaidAmount" type="PrepaidAmountType"/>
+   <xsd:element name="PrepaidIndicator" type="PrepaidIndicatorType"/>
+   <xsd:element name="PrepaidPaymentReferenceID" type="PrepaidPaymentReferenceIDType"/>
+   <xsd:element name="PreviousCancellationReasonCode"
+                type="PreviousCancellationReasonCodeType"/>
+   <xsd:element name="PreviousJobID" type="PreviousJobIDType"/>
+   <xsd:element name="PreviousMeterQuantity" type="PreviousMeterQuantityType"/>
+   <xsd:element name="PreviousMeterReadingDate" type="PreviousMeterReadingDateType"/>
+   <xsd:element name="PreviousMeterReadingMethod" type="PreviousMeterReadingMethodType"/>
+   <xsd:element name="PreviousMeterReadingMethodCode"
+                type="PreviousMeterReadingMethodCodeType"/>
+   <xsd:element name="PreviousVersionID" type="PreviousVersionIDType"/>
+   <xsd:element name="PriceAmount" type="PriceAmountType"/>
+   <xsd:element name="PriceChangeReason" type="PriceChangeReasonType"/>
+   <xsd:element name="PriceEvaluationCode" type="PriceEvaluationCodeType"/>
+   <xsd:element name="PriceRevisionFormulaDescription"
+                type="PriceRevisionFormulaDescriptionType"/>
+   <xsd:element name="PriceType" type="PriceTypeType"/>
+   <xsd:element name="PriceTypeCode" type="PriceTypeCodeType"/>
+   <xsd:element name="PricingCurrencyCode" type="PricingCurrencyCodeType"/>
+   <xsd:element name="PricingUpdateRequestIndicator"
+                type="PricingUpdateRequestIndicatorType"/>
+   <xsd:element name="PrimaryAccountNumberID" type="PrimaryAccountNumberIDType"/>
+   <xsd:element name="PrintQualifier" type="PrintQualifierType"/>
+   <xsd:element name="Priority" type="PriorityType"/>
+   <xsd:element name="PrivacyCode" type="PrivacyCodeType"/>
+   <xsd:element name="PrizeDescription" type="PrizeDescriptionType"/>
+   <xsd:element name="PrizeIndicator" type="PrizeIndicatorType"/>
+   <xsd:element name="ProcedureCode" type="ProcedureCodeType"/>
+   <xsd:element name="ProcessDescription" type="ProcessDescriptionType"/>
+   <xsd:element name="ProcessReason" type="ProcessReasonType"/>
+   <xsd:element name="ProcessReasonCode" type="ProcessReasonCodeType"/>
+   <xsd:element name="ProcurementSubTypeCode" type="ProcurementSubTypeCodeType"/>
+   <xsd:element name="ProcurementTypeCode" type="ProcurementTypeCodeType"/>
+   <xsd:element name="ProductTraceID" type="ProductTraceIDType"/>
+   <xsd:element name="ProfileExecutionID" type="ProfileExecutionIDType"/>
+   <xsd:element name="ProfileID" type="ProfileIDType"/>
+   <xsd:element name="ProfileStatusCode" type="ProfileStatusCodeType"/>
+   <xsd:element name="ProgressPercent" type="ProgressPercentType"/>
+   <xsd:element name="PromotionalEventTypeCode" type="PromotionalEventTypeCodeType"/>
+   <xsd:element name="ProviderTypeCode" type="ProviderTypeCodeType"/>
+   <xsd:element name="PublishAwardIndicator" type="PublishAwardIndicatorType"/>
+   <xsd:element name="Purpose" type="PurposeType"/>
+   <xsd:element name="PurposeCode" type="PurposeCodeType"/>
+   <xsd:element name="QualityControlCode" type="QualityControlCodeType"/>
+   <xsd:element name="Quantity" type="QuantityType"/>
+   <xsd:element name="QuantityDiscrepancyCode" type="QuantityDiscrepancyCodeType"/>
+   <xsd:element name="RadioCallSignID" type="RadioCallSignIDType"/>
+   <xsd:element name="RailCarID" type="RailCarIDType"/>
+   <xsd:element name="Rank" type="RankType"/>
+   <xsd:element name="Rate" type="RateType"/>
+   <xsd:element name="ReceiptAdviceTypeCode" type="ReceiptAdviceTypeCodeType"/>
+   <xsd:element name="ReceivedDate" type="ReceivedDateType"/>
+   <xsd:element name="ReceivedElectronicTenderQuantity"
+                type="ReceivedElectronicTenderQuantityType"/>
+   <xsd:element name="ReceivedForeignTenderQuantity"
+                type="ReceivedForeignTenderQuantityType"/>
+   <xsd:element name="ReceivedQuantity" type="ReceivedQuantityType"/>
+   <xsd:element name="ReceivedTenderQuantity" type="ReceivedTenderQuantityType"/>
+   <xsd:element name="Reference" type="ReferenceType"/>
+   <xsd:element name="ReferenceDate" type="ReferenceDateType"/>
+   <xsd:element name="ReferenceEventCode" type="ReferenceEventCodeType"/>
+   <xsd:element name="ReferenceID" type="ReferenceIDType"/>
+   <xsd:element name="ReferenceTime" type="ReferenceTimeType"/>
+   <xsd:element name="ReferencedConsignmentID" type="ReferencedConsignmentIDType"/>
+   <xsd:element name="RefrigeratedIndicator" type="RefrigeratedIndicatorType"/>
+   <xsd:element name="RefrigerationOnIndicator" type="RefrigerationOnIndicatorType"/>
+   <xsd:element name="Region" type="RegionType"/>
+   <xsd:element name="RegisteredDate" type="RegisteredDateType"/>
+   <xsd:element name="RegisteredTime" type="RegisteredTimeType"/>
+   <xsd:element name="RegistrationDate" type="RegistrationDateType"/>
+   <xsd:element name="RegistrationExpirationDate" type="RegistrationExpirationDateType"/>
+   <xsd:element name="RegistrationID" type="RegistrationIDType"/>
+   <xsd:element name="RegistrationName" type="RegistrationNameType"/>
+   <xsd:element name="RegistrationNationality" type="RegistrationNationalityType"/>
+   <xsd:element name="RegistrationNationalityID" type="RegistrationNationalityIDType"/>
+   <xsd:element name="RegulatoryDomain" type="RegulatoryDomainType"/>
+   <xsd:element name="RejectActionCode" type="RejectActionCodeType"/>
+   <xsd:element name="RejectReason" type="RejectReasonType"/>
+   <xsd:element name="RejectReasonCode" type="RejectReasonCodeType"/>
+   <xsd:element name="RejectedQuantity" type="RejectedQuantityType"/>
+   <xsd:element name="RejectionNote" type="RejectionNoteType"/>
+   <xsd:element name="ReleaseID" type="ReleaseIDType"/>
+   <xsd:element name="ReliabilityPercent" type="ReliabilityPercentType"/>
+   <xsd:element name="Remarks" type="RemarksType"/>
+   <xsd:element name="ReminderSequenceNumeric" type="ReminderSequenceNumericType"/>
+   <xsd:element name="ReminderTypeCode" type="ReminderTypeCodeType"/>
+   <xsd:element name="ReplenishmentOwnerDescription"
+                type="ReplenishmentOwnerDescriptionType"/>
+   <xsd:element name="RequestForQuotationLineID" type="RequestForQuotationLineIDType"/>
+   <xsd:element name="RequestedDeliveryDate" type="RequestedDeliveryDateType"/>
+   <xsd:element name="RequestedDespatchDate" type="RequestedDespatchDateType"/>
+   <xsd:element name="RequestedDespatchTime" type="RequestedDespatchTimeType"/>
+   <xsd:element name="RequestedInvoiceCurrencyCode"
+                type="RequestedInvoiceCurrencyCodeType"/>
+   <xsd:element name="RequestedPublicationDate" type="RequestedPublicationDateType"/>
+   <xsd:element name="RequiredCurriculaIndicator" type="RequiredCurriculaIndicatorType"/>
+   <xsd:element name="RequiredCustomsID" type="RequiredCustomsIDType"/>
+   <xsd:element name="RequiredDeliveryDate" type="RequiredDeliveryDateType"/>
+   <xsd:element name="RequiredDeliveryTime" type="RequiredDeliveryTimeType"/>
+   <xsd:element name="RequiredFeeAmount" type="RequiredFeeAmountType"/>
+   <xsd:element name="ResidenceType" type="ResidenceTypeType"/>
+   <xsd:element name="ResidenceTypeCode" type="ResidenceTypeCodeType"/>
+   <xsd:element name="ResidentOccupantsNumeric" type="ResidentOccupantsNumericType"/>
+   <xsd:element name="Resolution" type="ResolutionType"/>
+   <xsd:element name="ResolutionCode" type="ResolutionCodeType"/>
+   <xsd:element name="ResolutionDate" type="ResolutionDateType"/>
+   <xsd:element name="ResolutionTime" type="ResolutionTimeType"/>
+   <xsd:element name="ResponseCode" type="ResponseCodeType"/>
+   <xsd:element name="ResponseDate" type="ResponseDateType"/>
+   <xsd:element name="ResponseTime" type="ResponseTimeType"/>
+   <xsd:element name="RetailEventName" type="RetailEventNameType"/>
+   <xsd:element name="RetailEventStatusCode" type="RetailEventStatusCodeType"/>
+   <xsd:element name="ReturnabilityIndicator" type="ReturnabilityIndicatorType"/>
+   <xsd:element name="ReturnableMaterialIndicator"
+                type="ReturnableMaterialIndicatorType"/>
+   <xsd:element name="ReturnableQuantity" type="ReturnableQuantityType"/>
+   <xsd:element name="RevisedForecastLineID" type="RevisedForecastLineIDType"/>
+   <xsd:element name="RevisionDate" type="RevisionDateType"/>
+   <xsd:element name="RevisionStatusCode" type="RevisionStatusCodeType"/>
+   <xsd:element name="RevisionTime" type="RevisionTimeType"/>
+   <xsd:element name="RoamingPartnerName" type="RoamingPartnerNameType"/>
+   <xsd:element name="RoleCode" type="RoleCodeType"/>
+   <xsd:element name="RoleDescription" type="RoleDescriptionType"/>
+   <xsd:element name="Room" type="RoomType"/>
+   <xsd:element name="RoundingAmount" type="RoundingAmountType"/>
+   <xsd:element name="SalesOrderID" type="SalesOrderIDType"/>
+   <xsd:element name="SalesOrderLineID" type="SalesOrderLineIDType"/>
+   <xsd:element name="SchemeURI" type="SchemeURIType"/>
+   <xsd:element name="SealIssuerTypeCode" type="SealIssuerTypeCodeType"/>
+   <xsd:element name="SealStatusCode" type="SealStatusCodeType"/>
+   <xsd:element name="SealingPartyType" type="SealingPartyTypeType"/>
+   <xsd:element name="SecurityClassificationCode" type="SecurityClassificationCodeType"/>
+   <xsd:element name="SecurityID" type="SecurityIDType"/>
+   <xsd:element name="SellerEventID" type="SellerEventIDType"/>
+   <xsd:element name="SequenceID" type="SequenceIDType"/>
+   <xsd:element name="SequenceNumberID" type="SequenceNumberIDType"/>
+   <xsd:element name="SequenceNumeric" type="SequenceNumericType"/>
+   <xsd:element name="SerialID" type="SerialIDType"/>
+   <xsd:element name="ServiceInformationPreferenceCode"
+                type="ServiceInformationPreferenceCodeType"/>
+   <xsd:element name="ServiceName" type="ServiceNameType"/>
+   <xsd:element name="ServiceNumberCalled" type="ServiceNumberCalledType"/>
+   <xsd:element name="ServiceType" type="ServiceTypeType"/>
+   <xsd:element name="ServiceTypeCode" type="ServiceTypeCodeType"/>
+   <xsd:element name="SettlementDiscountAmount" type="SettlementDiscountAmountType"/>
+   <xsd:element name="SettlementDiscountPercent" type="SettlementDiscountPercentType"/>
+   <xsd:element name="SharesNumberQuantity" type="SharesNumberQuantityType"/>
+   <xsd:element name="ShippingMarks" type="ShippingMarksType"/>
+   <xsd:element name="ShippingOrderID" type="ShippingOrderIDType"/>
+   <xsd:element name="ShippingPriorityLevelCode" type="ShippingPriorityLevelCodeType"/>
+   <xsd:element name="ShipsRequirements" type="ShipsRequirementsType"/>
+   <xsd:element name="ShortQuantity" type="ShortQuantityType"/>
+   <xsd:element name="ShortageActionCode" type="ShortageActionCodeType"/>
+   <xsd:element name="SignatureID" type="SignatureIDType"/>
+   <xsd:element name="SignatureMethod" type="SignatureMethodType"/>
+   <xsd:element name="SizeTypeCode" type="SizeTypeCodeType"/>
+   <xsd:element name="SoleProprietorshipIndicator"
+                type="SoleProprietorshipIndicatorType"/>
+   <xsd:element name="SourceCurrencyBaseRate" type="SourceCurrencyBaseRateType"/>
+   <xsd:element name="SourceCurrencyCode" type="SourceCurrencyCodeType"/>
+   <xsd:element name="SourceForecastIssueDate" type="SourceForecastIssueDateType"/>
+   <xsd:element name="SourceForecastIssueTime" type="SourceForecastIssueTimeType"/>
+   <xsd:element name="SourceValueMeasure" type="SourceValueMeasureType"/>
+   <xsd:element name="SpecialInstructions" type="SpecialInstructionsType"/>
+   <xsd:element name="SpecialSecurityIndicator" type="SpecialSecurityIndicatorType"/>
+   <xsd:element name="SpecialServiceInstructions" type="SpecialServiceInstructionsType"/>
+   <xsd:element name="SpecialTerms" type="SpecialTermsType"/>
+   <xsd:element name="SpecialTransportRequirements"
+                type="SpecialTransportRequirementsType"/>
+   <xsd:element name="SpecificationID" type="SpecificationIDType"/>
+   <xsd:element name="SpecificationTypeCode" type="SpecificationTypeCodeType"/>
+   <xsd:element name="SplitConsignmentIndicator" type="SplitConsignmentIndicatorType"/>
+   <xsd:element name="StartDate" type="StartDateType"/>
+   <xsd:element name="StartTime" type="StartTimeType"/>
+   <xsd:element name="StatementTypeCode" type="StatementTypeCodeType"/>
+   <xsd:element name="StatusAvailableIndicator" type="StatusAvailableIndicatorType"/>
+   <xsd:element name="StatusCode" type="StatusCodeType"/>
+   <xsd:element name="StatusReason" type="StatusReasonType"/>
+   <xsd:element name="StatusReasonCode" type="StatusReasonCodeType"/>
+   <xsd:element name="StreetName" type="StreetNameType"/>
+   <xsd:element name="SubcontractingConditionsCode"
+                type="SubcontractingConditionsCodeType"/>
+   <xsd:element name="SubmissionDate" type="SubmissionDateType"/>
+   <xsd:element name="SubmissionDueDate" type="SubmissionDueDateType"/>
+   <xsd:element name="SubmissionMethodCode" type="SubmissionMethodCodeType"/>
+   <xsd:element name="SubscriberID" type="SubscriberIDType"/>
+   <xsd:element name="SubscriberType" type="SubscriberTypeType"/>
+   <xsd:element name="SubscriberTypeCode" type="SubscriberTypeCodeType"/>
+   <xsd:element name="SubstitutionStatusCode" type="SubstitutionStatusCodeType"/>
+   <xsd:element name="SuccessiveSequenceID" type="SuccessiveSequenceIDType"/>
+   <xsd:element name="SummaryDescription" type="SummaryDescriptionType"/>
+   <xsd:element name="SupplierAssignedAccountID" type="SupplierAssignedAccountIDType"/>
+   <xsd:element name="SupplyChainActivityTypeCode"
+                type="SupplyChainActivityTypeCodeType"/>
+   <xsd:element name="TareWeightMeasure" type="TareWeightMeasureType"/>
+   <xsd:element name="TargetCurrencyBaseRate" type="TargetCurrencyBaseRateType"/>
+   <xsd:element name="TargetCurrencyCode" type="TargetCurrencyCodeType"/>
+   <xsd:element name="TargetInventoryQuantity" type="TargetInventoryQuantityType"/>
+   <xsd:element name="TargetServicePercent" type="TargetServicePercentType"/>
+   <xsd:element name="TariffClassCode" type="TariffClassCodeType"/>
+   <xsd:element name="TariffCode" type="TariffCodeType"/>
+   <xsd:element name="TariffDescription" type="TariffDescriptionType"/>
+   <xsd:element name="TaxAmount" type="TaxAmountType"/>
+   <xsd:element name="TaxCurrencyCode" type="TaxCurrencyCodeType"/>
+   <xsd:element name="TaxEnergyAmount" type="TaxEnergyAmountType"/>
+   <xsd:element name="TaxEnergyBalanceAmount" type="TaxEnergyBalanceAmountType"/>
+   <xsd:element name="TaxEnergyOnAccountAmount" type="TaxEnergyOnAccountAmountType"/>
+   <xsd:element name="TaxEvidenceIndicator" type="TaxEvidenceIndicatorType"/>
+   <xsd:element name="TaxExclusiveAmount" type="TaxExclusiveAmountType"/>
+   <xsd:element name="TaxExemptionReason" type="TaxExemptionReasonType"/>
+   <xsd:element name="TaxExemptionReasonCode" type="TaxExemptionReasonCodeType"/>
+   <xsd:element name="TaxIncludedIndicator" type="TaxIncludedIndicatorType"/>
+   <xsd:element name="TaxInclusiveAmount" type="TaxInclusiveAmountType"/>
+   <xsd:element name="TaxLevelCode" type="TaxLevelCodeType"/>
+   <xsd:element name="TaxPointDate" type="TaxPointDateType"/>
+   <xsd:element name="TaxTypeCode" type="TaxTypeCodeType"/>
+   <xsd:element name="TaxableAmount" type="TaxableAmountType"/>
+   <xsd:element name="TechnicalCommitteeDescription"
+                type="TechnicalCommitteeDescriptionType"/>
+   <xsd:element name="TechnicalName" type="TechnicalNameType"/>
+   <xsd:element name="TelecommunicationsServiceCall"
+                type="TelecommunicationsServiceCallType"/>
+   <xsd:element name="TelecommunicationsServiceCallCode"
+                type="TelecommunicationsServiceCallCodeType"/>
+   <xsd:element name="TelecommunicationsServiceCategory"
+                type="TelecommunicationsServiceCategoryType"/>
+   <xsd:element name="TelecommunicationsServiceCategoryCode"
+                type="TelecommunicationsServiceCategoryCodeType"/>
+   <xsd:element name="TelecommunicationsSupplyType"
+                type="TelecommunicationsSupplyTypeType"/>
+   <xsd:element name="TelecommunicationsSupplyTypeCode"
+                type="TelecommunicationsSupplyTypeCodeType"/>
+   <xsd:element name="Telefax" type="TelefaxType"/>
+   <xsd:element name="Telephone" type="TelephoneType"/>
+   <xsd:element name="TenderEnvelopeID" type="TenderEnvelopeIDType"/>
+   <xsd:element name="TenderEnvelopeTypeCode" type="TenderEnvelopeTypeCodeType"/>
+   <xsd:element name="TenderResultCode" type="TenderResultCodeType"/>
+   <xsd:element name="TenderTypeCode" type="TenderTypeCodeType"/>
+   <xsd:element name="TendererRequirementTypeCode"
+                type="TendererRequirementTypeCodeType"/>
+   <xsd:element name="TendererRoleCode" type="TendererRoleCodeType"/>
+   <xsd:element name="TestMethod" type="TestMethodType"/>
+   <xsd:element name="Text" type="TextType"/>
+   <xsd:element name="ThirdPartyPayerIndicator" type="ThirdPartyPayerIndicatorType"/>
+   <xsd:element name="ThresholdAmount" type="ThresholdAmountType"/>
+   <xsd:element name="ThresholdQuantity" type="ThresholdQuantityType"/>
+   <xsd:element name="ThresholdValueComparisonCode"
+                type="ThresholdValueComparisonCodeType"/>
+   <xsd:element name="TierRange" type="TierRangeType"/>
+   <xsd:element name="TierRatePercent" type="TierRatePercentType"/>
+   <xsd:element name="TimeAmount" type="TimeAmountType"/>
+   <xsd:element name="TimeDeltaDaysQuantity" type="TimeDeltaDaysQuantityType"/>
+   <xsd:element name="TimeFrequencyCode" type="TimeFrequencyCodeType"/>
+   <xsd:element name="TimezoneOffset" type="TimezoneOffsetType"/>
+   <xsd:element name="TimingComplaint" type="TimingComplaintType"/>
+   <xsd:element name="TimingComplaintCode" type="TimingComplaintCodeType"/>
+   <xsd:element name="Title" type="TitleType"/>
+   <xsd:element name="ToOrderIndicator" type="ToOrderIndicatorType"/>
+   <xsd:element name="TotalAmount" type="TotalAmountType"/>
+   <xsd:element name="TotalBalanceAmount" type="TotalBalanceAmountType"/>
+   <xsd:element name="TotalConsumedQuantity" type="TotalConsumedQuantityType"/>
+   <xsd:element name="TotalCreditAmount" type="TotalCreditAmountType"/>
+   <xsd:element name="TotalDebitAmount" type="TotalDebitAmountType"/>
+   <xsd:element name="TotalDeliveredQuantity" type="TotalDeliveredQuantityType"/>
+   <xsd:element name="TotalGoodsItemQuantity" type="TotalGoodsItemQuantityType"/>
+   <xsd:element name="TotalInvoiceAmount" type="TotalInvoiceAmountType"/>
+   <xsd:element name="TotalMeteredQuantity" type="TotalMeteredQuantityType"/>
+   <xsd:element name="TotalPackageQuantity" type="TotalPackageQuantityType"/>
+   <xsd:element name="TotalPackagesQuantity" type="TotalPackagesQuantityType"/>
+   <xsd:element name="TotalPaymentAmount" type="TotalPaymentAmountType"/>
+   <xsd:element name="TotalTaskAmount" type="TotalTaskAmountType"/>
+   <xsd:element name="TotalTaxAmount" type="TotalTaxAmountType"/>
+   <xsd:element name="TotalTransportHandlingUnitQuantity"
+                type="TotalTransportHandlingUnitQuantityType"/>
+   <xsd:element name="TraceID" type="TraceIDType"/>
+   <xsd:element name="TrackingDeviceCode" type="TrackingDeviceCodeType"/>
+   <xsd:element name="TrackingID" type="TrackingIDType"/>
+   <xsd:element name="TradeItemPackingLabelingTypeCode"
+                type="TradeItemPackingLabelingTypeCodeType"/>
+   <xsd:element name="TradeServiceCode" type="TradeServiceCodeType"/>
+   <xsd:element name="TradingRestrictions" type="TradingRestrictionsType"/>
+   <xsd:element name="TrainID" type="TrainIDType"/>
+   <xsd:element name="TransactionCurrencyTaxAmount"
+                type="TransactionCurrencyTaxAmountType"/>
+   <xsd:element name="TransitDirectionCode" type="TransitDirectionCodeType"/>
+   <xsd:element name="TransportAuthorizationCode" type="TransportAuthorizationCodeType"/>
+   <xsd:element name="TransportEmergencyCardCode" type="TransportEmergencyCardCodeType"/>
+   <xsd:element name="TransportEquipmentTypeCode" type="TransportEquipmentTypeCodeType"/>
+   <xsd:element name="TransportEventTypeCode" type="TransportEventTypeCodeType"/>
+   <xsd:element name="TransportExecutionPlanReferenceID"
+                type="TransportExecutionPlanReferenceIDType"/>
+   <xsd:element name="TransportExecutionStatusCode"
+                type="TransportExecutionStatusCodeType"/>
+   <xsd:element name="TransportHandlingUnitTypeCode"
+                type="TransportHandlingUnitTypeCodeType"/>
+   <xsd:element name="TransportMeansTypeCode" type="TransportMeansTypeCodeType"/>
+   <xsd:element name="TransportModeCode" type="TransportModeCodeType"/>
+   <xsd:element name="TransportServiceCode" type="TransportServiceCodeType"/>
+   <xsd:element name="TransportServiceProviderRemarks"
+                type="TransportServiceProviderRemarksType"/>
+   <xsd:element name="TransportServiceProviderSpecialTerms"
+                type="TransportServiceProviderSpecialTermsType"/>
+   <xsd:element name="TransportUserRemarks" type="TransportUserRemarksType"/>
+   <xsd:element name="TransportUserSpecialTerms" type="TransportUserSpecialTermsType"/>
+   <xsd:element name="TransportationServiceDescription"
+                type="TransportationServiceDescriptionType"/>
+   <xsd:element name="TransportationServiceDetailsURI"
+                type="TransportationServiceDetailsURIType"/>
+   <xsd:element name="TransportationStatusTypeCode"
+                type="TransportationStatusTypeCodeType"/>
+   <xsd:element name="TypeCode" type="TypeCodeType"/>
+   <xsd:element name="UBLVersionID" type="UBLVersionIDType"/>
+   <xsd:element name="UNDGCode" type="UNDGCodeType"/>
+   <xsd:element name="URI" type="URIType"/>
+   <xsd:element name="UUID" type="UUIDType"/>
+   <xsd:element name="UnknownPriceIndicator" type="UnknownPriceIndicatorType"/>
+   <xsd:element name="UpperOrangeHazardPlacardID" type="UpperOrangeHazardPlacardIDType"/>
+   <xsd:element name="UrgencyCode" type="UrgencyCodeType"/>
+   <xsd:element name="UtilityStatementTypeCode" type="UtilityStatementTypeCodeType"/>
+   <xsd:element name="ValidateProcess" type="ValidateProcessType"/>
+   <xsd:element name="ValidateTool" type="ValidateToolType"/>
+   <xsd:element name="ValidateToolVersion" type="ValidateToolVersionType"/>
+   <xsd:element name="ValidationDate" type="ValidationDateType"/>
+   <xsd:element name="ValidationResultCode" type="ValidationResultCodeType"/>
+   <xsd:element name="ValidationTime" type="ValidationTimeType"/>
+   <xsd:element name="ValidatorID" type="ValidatorIDType"/>
+   <xsd:element name="ValidityStartDate" type="ValidityStartDateType"/>
+   <xsd:element name="Value" type="ValueType"/>
+   <xsd:element name="ValueAmount" type="ValueAmountType"/>
+   <xsd:element name="ValueMeasure" type="ValueMeasureType"/>
+   <xsd:element name="ValueQualifier" type="ValueQualifierType"/>
+   <xsd:element name="ValueQuantity" type="ValueQuantityType"/>
+   <xsd:element name="VarianceQuantity" type="VarianceQuantityType"/>
+   <xsd:element name="VariantConstraintIndicator" type="VariantConstraintIndicatorType"/>
+   <xsd:element name="VariantID" type="VariantIDType"/>
+   <xsd:element name="VersionID" type="VersionIDType"/>
+   <xsd:element name="VesselID" type="VesselIDType"/>
+   <xsd:element name="VesselName" type="VesselNameType"/>
+   <xsd:element name="WarrantyInformation" type="WarrantyInformationType"/>
+   <xsd:element name="WebsiteURI" type="WebsiteURIType"/>
+   <xsd:element name="WeekDayCode" type="WeekDayCodeType"/>
+   <xsd:element name="Weight" type="WeightType"/>
+   <xsd:element name="WeightNumeric" type="WeightNumericType"/>
+   <xsd:element name="WeightingAlgorithmCode" type="WeightingAlgorithmCodeType"/>
+   <xsd:element name="WorkPhase" type="WorkPhaseType"/>
+   <xsd:element name="WorkPhaseCode" type="WorkPhaseCodeType"/>
+   <xsd:element name="XPath" type="XPathType"/>
+   <xsd:complexType name="AcceptedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AcceptedVariantsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountFormatCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountingCostCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountingCostType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActivityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActivityTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualPickupDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualPickupTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualTemperatureReductionQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdValoremIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalAccountIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalConditionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalInformationType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalStreetNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressFormatCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdjustmentReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdmissionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdvertisementAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AgencyIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AgencyNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AirFlowPercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AircraftIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AliasNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceChargeReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceChargeReasonType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceTotalAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AltitudeMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AmountRateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AnimalFoodApprovedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AnimalFoodIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AnnualAverageAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApplicationStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApprovalDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApprovalStatusType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AttributeIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AuctionConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AuctionURIType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AvailabilityDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AvailabilityStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AverageAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AverageSubsequentContractAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingMethodTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BackOrderAllowedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BackorderQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BackorderReasonType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BalanceAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BalanceBroughtForwardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BarcodeSymbologyIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BaseAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BaseQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BaseUnitMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BasedOnConsensusIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BasicConsumedQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BatchQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BestBeforeDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BindingOnBuyerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BirthDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BirthplaceNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BlockNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BrandNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BrokerAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BudgetYearNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuildingNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuildingNumberType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BulkCargoIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BusinessClassificationEvidenceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BusinessIdentityEvidenceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuyerEventIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuyerProfileURIType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuyerReferenceType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CV2IDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationExpressionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationExpressionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationRateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationSequenceNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallBaseAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallExtensionAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CancellationNoteType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CandidateReductionConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CandidateStatementType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CanonicalizationMethodType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CapabilityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CardChipCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CardTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CargoTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CarrierAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CarrierServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CategoryNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChangeConditionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CharacterSetCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CharacteristicsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeTotalAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeableQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeableWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChildConsignmentQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChipApplicationIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CityNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CitySubdivisionNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CodeValueType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CollaborationPriorityCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CommentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CommodityCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyLegalFormCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyLegalFormType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyLiquidationStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparedValueMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonDataCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonDataSourceCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonForecastIssueDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonForecastIssueTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompletionIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsigneeAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsignmentQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsignorAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsolidatableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConstitutionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumerIncentiveTacticTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumerUnitQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumersEnergyLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumersEnergyLevelType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionEnergyQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionLevelType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionReportIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionWaterQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContainerizedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContentUnitQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractFolderIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractSubdivisionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractedCarrierAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingSystemCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CoordinateSystemCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CopyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorporateRegistrationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorporateStockAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionUnitAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CountrySubentityCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CountrySubentityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CreditLineAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CreditNoteTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CreditedQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CrewQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrentChargeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrentChargeTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomerAssignedAccountIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomerReferenceType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomizationIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsClearanceServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsImportClassifiedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsTariffQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DamageRemarksType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DangerousGoodsApprovedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DataSendingCapabilityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DataSourceCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DebitLineAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DebitedQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclarationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredCarriageValueAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredCustomsValueAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredForCarriageValueAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredStatisticsValueAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveredQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryInstructionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DemurrageInstructionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DepartmentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DescriptionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DespatchAdviceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DifferenceTemperatureReductionQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DisplayTacticTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DispositionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DistrictType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentHashType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusReasonDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentationFeeAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DueDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DutyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DutyType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EarliestPickupDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EarliestPickupTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorRegistryURIType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EffectiveDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EffectiveTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicDeviceDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicMailType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmbeddedDocumentBinaryObjectType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:BinaryObjectType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmergencyProceduresCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmployeeQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EncodingCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndpointIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EnvironmentalEmissionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedConsumedQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedOverallContractAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedOverallContractQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EvaluationCriterionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EvidenceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionResolutionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExchangeMarketIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExclusionReasonType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExecutionRequirementCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExemptionReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExemptionReasonType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedOperatorQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpenseCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpiryDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpiryTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpressionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpressionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExtendedIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExtensionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FaceValueAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FamilyNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeatureTacticTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeeAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeeDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FileNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FinancingInstrumentCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FirstNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FirstShipmentAvailibilityDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FloorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FollowupContractIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastPurposeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FormatCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ForwarderServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreeOfChargeIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreeOnBoardValueAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreightForwarderAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreightRateClassCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FrequencyType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FrozenDocumentIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FrozenPeriodDaysNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FullnessIndicationCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FullyPaidSharesIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FundingProgramCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FundingProgramType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GasPressureQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GenderCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GeneralCargoIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GovernmentAgreementConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossTonnageMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossVolumeMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GuaranteeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GuaranteedDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GuaranteedDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HandlingCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HandlingInstructionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HashAlgorithmMethodType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HaulageInstructionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardClassIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousCategoryCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousRegulationCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousRiskIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HeatingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HeatingTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HigherTenderAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HolderNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HumanFoodApprovedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HumanFoodIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HumidityPercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IdentificationCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IdentificationIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ImmobilizationCertificateIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ImportanceCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IndicationIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IndustryClassificationCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InformationType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InformationURIType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InhalationToxicityZoneCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InhouseMailType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InspectionMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstallmentDueDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionNoteType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InsurancePremiumAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InsuranceValueAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InventoryValueAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InvoiceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InvoicedQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InvoicingPartyReferenceType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssueDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssueNumberIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssueTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssuerIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ItemClassificationCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ItemUpdateRequestIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JobTitleType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JourneyIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JustificationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JustificationType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="KeywordType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LanguageIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LastRevisionDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LastRevisionTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterReadingDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterReadingMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterReadingMethodType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestPickupDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestPickupTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestProposalAcceptanceDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestSecurityClearanceDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeDegreesMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeMinutesMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LeadTimeMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalReferenceType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalStatusIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LiabilityAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LicensePlateIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LifeCycleStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LimitationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineCountNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineExtensionAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineNumberNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ListValueType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LivestockIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LoadingLengthMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LoadingSequenceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocaleCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LoginType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LogoReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeDegreesMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeMinutesMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LossRiskResponsibilityCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LossRiskType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LotNumberIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LowTendersDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LowerOrangeHazardPlacardIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LowerTenderAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MandateTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManufactureDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManufactureTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkAttentionIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkAttentionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkCareIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkCareType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarketValueAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkingIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MathematicOperatorCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumAdvertisementAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumBackorderQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumCopiesNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumNumberNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumOperatorQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumOrderQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumPaidAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumPaymentInstructionsNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumPercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumValueType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumVariantQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MedicalFirstAidGuideCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterConstantCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterConstantType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterNumberType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingCommentsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MiddleNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MimeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumBackorderQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumImprovementBidType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumInventoryQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumNumberNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumOrderQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumPercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumValueType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MiscellaneousEventTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ModelNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MonetaryScopeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MovieTitleType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MultipleOrderQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MultiplierFactorNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NameCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NameSuffixType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NationalityIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NatureCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NegotiationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetNetWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetTonnageMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetVolumeMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetworkIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NominationDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NominationTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NormalTemperatureReductionQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoteType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NotificationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OccurrenceDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OccurrenceTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OnCarriageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OneTimeChargeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OneTimeChargeTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OntologyURIType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OpenTenderIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OperatingYearsQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OptionalLineItemIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OptionsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderIntervalDaysNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderQuantityIncrementNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderResponseCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderableUnitFactorRateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderableUnitType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrganizationDepartmentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OriginalContractingSystemIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OriginalJobIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherConditionsIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherInstructionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OutstandingQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OutstandingReasonType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OversupplyQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OwnerTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackSizeNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackageLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackagingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackingCriteriaCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackingMaterialType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaidAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaidDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaidTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentLineReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentVersionIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartPresentationCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartecipationPercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartialDeliveryIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParticipationPercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartyCapacityAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartyTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartyTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PassengerQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PasswordType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayPerViewType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayableAlternativeAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayableAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayableRoundingAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayerReferenceType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentAlternativeCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentChannelCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentDueDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentFrequencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentNoteType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentOrderReferenceType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentPercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentPurposeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentTermsDetailsURIType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PenaltyAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PenaltySurchargePercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerUnitAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerformanceMetricTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerformanceValueQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerformingCarrierAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonalSituationType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PhoneNumberType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlacardEndorsementType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlacardNotationType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlannedDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlotIdentificationType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PositionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PostEventNotificationDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PostalZoneType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PostboxType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PowerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreCarriageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreEventNotificationDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreferenceCriterionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrepaidAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrepaidIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrepaidPaymentReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousCancellationReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousJobIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterReadingDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterReadingMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterReadingMethodType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousVersionIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceChangeReasonType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceEvaluationCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceRevisionFormulaDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PricingCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PricingUpdateRequestIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrimaryAccountNumberIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrintQualifierType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriorityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrivacyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrizeDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrizeIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcedureCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessReasonType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementSubTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProductTraceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileExecutionIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProgressPercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalEventTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProviderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PublishAwardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PurposeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PurposeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QualityControlCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QuantityDiscrepancyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RadioCallSignIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RailCarIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RankType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceiptAdviceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedElectronicTenderQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedForeignTenderQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedTenderQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceEventCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferencedConsignmentIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RefrigeratedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RefrigerationOnIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegisteredDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegisteredTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationExpirationDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationNationalityIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationNationalityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegulatoryDomainType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectActionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectReasonType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectedQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectionNoteType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReleaseIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReliabilityPercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RemarksType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReminderSequenceNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReminderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReplenishmentOwnerDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestForQuotationLineIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedInvoiceCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedPublicationDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredCurriculaIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredCustomsIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredFeeAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResidenceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResidenceTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResidentOccupantsNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RetailEventNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RetailEventStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReturnabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReturnableMaterialIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReturnableQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisedForecastLineIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisionDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisionTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoamingPartnerNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoleCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoleDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoomType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoundingAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SalesOrderIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SalesOrderLineIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SchemeURIType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SealIssuerTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SealStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SealingPartyTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityClassificationCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SellerEventIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SequenceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SequenceNumberIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SequenceNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SerialIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceInformationPreferenceCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceNumberCalledType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SettlementDiscountAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SettlementDiscountPercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SharesNumberQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShippingMarksType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShippingOrderIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShippingPriorityLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShipsRequirementsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShortQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShortageActionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SignatureIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SignatureMethodType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SizeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SoleProprietorshipIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceCurrencyBaseRateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceForecastIssueDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceForecastIssueTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceValueMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialInstructionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialSecurityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialTermsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialTransportRequirementsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecificationIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecificationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SplitConsignmentIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StartDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StartTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusAvailableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusReasonType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StreetNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubcontractingConditionsCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubmissionDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubmissionDueDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubmissionMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubstitutionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SuccessiveSequenceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SummaryDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SupplierAssignedAccountIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SupplyChainActivityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TareWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetCurrencyBaseRateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetInventoryQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetServicePercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TariffClassCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TariffCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TariffDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEnergyAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEnergyBalanceAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEnergyOnAccountAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEvidenceIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxExclusiveAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxExemptionReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxExemptionReasonType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxIncludedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxInclusiveAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxPointDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxableAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TechnicalCommitteeDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TechnicalNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCallCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCallType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCategoryCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCategoryType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyTypeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelefaxType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelephoneType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderEnvelopeIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderEnvelopeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderResultCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TendererRequirementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TendererRoleCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TestMethodType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TextType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThirdPartyPayerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThresholdAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThresholdQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThresholdValueComparisonCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TierRangeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TierRatePercentType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimeAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimeDeltaDaysQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimeFrequencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimezoneOffsetType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimingComplaintCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimingComplaintType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TitleType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ToOrderIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalBalanceAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalConsumedQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalCreditAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalDebitAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalDeliveredQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalGoodsItemQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalInvoiceAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalMeteredQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalPackageQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalPackagesQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalPaymentAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalTaskAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalTaxAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalTransportHandlingUnitQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TraceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TrackingDeviceCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TrackingIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TradeItemPackingLabelingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TradeServiceCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TradingRestrictionsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TrainIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionCurrencyTaxAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransitDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportAuthorizationCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEmergencyCardCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEventTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportExecutionPlanReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportExecutionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportHandlingUnitTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportMeansTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportModeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportServiceCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportServiceProviderRemarksType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportServiceProviderSpecialTermsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportUserRemarksType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportUserSpecialTermsType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationServiceDescriptionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationServiceDetailsURIType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationStatusTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UBLVersionIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UNDGCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="URIType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UUIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UnknownPriceIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UpperOrangeHazardPlacardIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UrgencyCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UtilityStatementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidateProcessType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidateToolType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidateToolVersionType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidationDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidationResultCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidationTimeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidatorIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidityStartDateType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueAmountType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueMeasureType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueQualifierType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VarianceQuantityType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VariantConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VariantIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VersionIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VesselIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VesselNameType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WarrantyInformationType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WebsiteURIType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeekDayCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightNumericType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightingAlgorithmCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkPhaseCodeType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkPhaseType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="XPathType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== --><!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-CommonExtensionComponents-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-CommonExtensionComponents-2.1.xsd
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            UBL-CommonExtensionComponents-2.1.xsd
+  Generated on:      2013-04-20 18:40(UTC)
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" 
+xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
+targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" 
+            elementFormDefault="qualified" attributeFormDefault="unqualified" 
+            version="2.1">
+<!-- ===== Imports ===== -->
+  <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" schemaLocation="UBL-UnqualifiedDataTypes-2.1.xsd"/>
+  <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" schemaLocation="UBL-CommonBasicComponents-2.1.xsd"/>
+<!-- ===== Includes ===== -->
+<xsd:include schemaLocation="UBL-ExtensionContentDataType-2.1.xsd"/>
+<!-- ===== Aggregate Element and Type Declarations ===== -->
+  <xsd:element name="UBLExtensions" type="UBLExtensionsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        A container for all extensions present in the document.
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+  <xsd:complexType name="UBLExtensionsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        A container for all extensions present in the document.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element ref="UBLExtension" minOccurs="1" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            A single extension for private use.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="UBLExtension" type="UBLExtensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        A single extension for private use.
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+  <xsd:complexType name="UBLExtensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        A single extension for private use.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            An identifier for the Extension assigned by the creator of the extension.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            A name for the Extension assigned by the creator of the extension.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element ref="ExtensionAgencyID" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            An agency that maintains one or more Extensions.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element ref="ExtensionAgencyName" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            The name of the agency that maintains the Extension.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element ref="ExtensionVersionID" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            The version of the Extension.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element ref="ExtensionAgencyURI" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            A URI for the Agency that maintains the Extension.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element ref="ExtensionURI" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            A URI for the Extension.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element ref="ExtensionReasonCode" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            A code for reason the Extension is being included.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element ref="ExtensionReason" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            A description of the reason for the Extension.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element ref="ExtensionContent" minOccurs="1" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            The definition of the extension content.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+<!-- ===== Basic Element and Type Declarations ===== -->
+  <xsd:element name="ExtensionAgencyID" type="ExtensionAgencyIDType"/>
+  <xsd:element name="ExtensionAgencyName" type="ExtensionAgencyNameType"/>
+  <xsd:element name="ExtensionAgencyURI" type="ExtensionAgencyURIType"/>
+  <xsd:element name="ExtensionContent" type="ExtensionContentType"/>
+  <xsd:element name="ExtensionReason" type="ExtensionReasonType"/>
+  <xsd:element name="ExtensionReasonCode" type="ExtensionReasonCodeType"/>
+  <xsd:element name="ExtensionURI" type="ExtensionURIType"/>
+  <xsd:element name="ExtensionVersionID" type="ExtensionVersionIDType"/>
+  <xsd:complexType name="ExtensionAgencyIDType">
+    <xsd:simpleContent>
+      <xsd:extension base="udt:IdentifierType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="ExtensionAgencyNameType">
+    <xsd:simpleContent>
+      <xsd:extension base="udt:TextType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="ExtensionAgencyURIType">
+    <xsd:simpleContent>
+      <xsd:extension base="udt:IdentifierType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="ExtensionReasonType">
+    <xsd:simpleContent>
+      <xsd:extension base="udt:TextType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="ExtensionReasonCodeType">
+    <xsd:simpleContent>
+      <xsd:extension base="udt:CodeType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="ExtensionURIType">
+    <xsd:simpleContent>
+      <xsd:extension base="udt:IdentifierType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="ExtensionVersionIDType">
+    <xsd:simpleContent>
+      <xsd:extension base="udt:IdentifierType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-CommonSignatureComponents-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-CommonSignatureComponents-2.1.xsd
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            xsdrt/common/UBL-CommonSignatureComponents-2.1.xsd
+  Generated on:      2013-10-31 17:18z
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonSignatureComponents-2"
+            xmlns:sac="urn:oasis:names:specification:ubl:schema:xsd:SignatureAggregateComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonSignatureComponents-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.1">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:SignatureAggregateComponents-2"
+               schemaLocation="UBL-SignatureAggregateComponents-2.1.xsd"/>
+   <xsd:element name="UBLDocumentSignatures" type="UBLDocumentSignaturesType"/>
+   <xsd:complexType name="UBLDocumentSignaturesType">
+      <xsd:sequence>
+         <xsd:element ref="sac:SignatureInformation" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== --><!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-CoreComponentParameters-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-CoreComponentParameters-2.1.xsd
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            UBL-CoreComponentParameters-2.1.xsd
+  Generated on:      2013-04-20 18:40(UTC)
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:un:unece:uncefact:documentation:2"
+            xmlns="urn:un:unece:uncefact:documentation:2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.1">
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-ExtensionContentDataType-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-ExtensionContentDataType-2.1.xsd
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            UBL-ExtensionContentDataType-2.1.xsd
+  Generated on:      2013-04-20 18:40(UTC)
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns=
+     "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            targetNamespace=
+     "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            elementFormDefault="qualified" 
+            attributeFormDefault="unqualified" 
+            version="2.1">
+
+  <!--import here all extension schemas-->
+  <xsd:import namespace=
+     "urn:oasis:names:specification:ubl:schema:xsd:CommonSignatureComponents-2"
+              schemaLocation="UBL-CommonSignatureComponents-2.1.xsd"/>
+
+  <!-- ===== Type Declaration ===== -->
+  <xsd:complexType name="ExtensionContentType">
+    <xsd:sequence>
+      <xsd:any namespace="##other" processContents="lax"
+               minOccurs="1" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            Any element in any namespace other than the UBL extension
+            namespace is allowed to be the apex element of an extension.
+            Only those elements found in the UBL schemas and in the
+            trees of schemas imported in this module are validated.
+            Any element for which there is no schema declaration in any
+            of the trees of schemas passes validation and is not
+            treated as a schema constraint violation.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:any>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-QualifiedDataTypes-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-QualifiedDataTypes-2.1.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            UBL-QualifiedDataTypes-2.1.xsd
+  Generated on:      2013-04-20 18:40(UTC)
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+    xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
+    xmlns:ccts="urn:un:unece:uncefact:documentation:2"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified"
+    version="2.1">
+<!-- ===== Imports ===== -->
+  <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" schemaLocation="UBL-UnqualifiedDataTypes-2.1.xsd"/>
+<!-- ===== Type Definitions ===== -->
+  <!--no qualified data types defined at this time-->
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-SignatureAggregateComponents-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-SignatureAggregateComponents-2.1.xsd
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            xsdrt/common/UBL-SignatureAggregateComponents-2.1.xsd
+  Generated on:      2013-10-31 17:18z
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:SignatureAggregateComponents-2"
+            xmlns:sac="urn:oasis:names:specification:ubl:schema:xsd:SignatureAggregateComponents-2"
+            xmlns:sbc="urn:oasis:names:specification:ubl:schema:xsd:SignatureBasicComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:SignatureAggregateComponents-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.1">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:SignatureBasicComponents-2"
+               schemaLocation="UBL-SignatureBasicComponents-2.1.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="UBL-CommonBasicComponents-2.1.xsd"/>
+
+   <!-- ===== Incorporate W3C signature specification-->
+   <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#"
+               schemaLocation="UBL-xmldsig-core-schema-2.1.xsd"/>
+
+   <!-- ===== Incorporate ETSI signature specifications-->
+   <xsd:import namespace="http://uri.etsi.org/01903/v1.3.2#"
+               schemaLocation="UBL-XAdESv132-2.1.xsd"/>
+   <xsd:import namespace="http://uri.etsi.org/01903/v1.4.1#"
+               schemaLocation="UBL-XAdESv141-2.1.xsd"/>
+          <xsd:element name="SignatureInformation" type="SignatureInformationType"/>
+   <xsd:complexType name="SignatureInformationType">
+      <xsd:sequence>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="sbc:ReferencedSignatureID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="ds:Signature" minOccurs="0" maxOccurs="1">
+           <xsd:annotation>
+               <xsd:documentation>This is a single digital signature as defined by the W3C specification.</xsd:documentation>
+           </xsd:annotation>
+         </xsd:element>
+          </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== --><!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-SignatureBasicComponents-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-SignatureBasicComponents-2.1.xsd
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            xsdrt/common/UBL-SignatureBasicComponents-2.1.xsd
+  Generated on:      2013-10-31 17:18z
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:SignatureBasicComponents-2"
+            xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+            xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:SignatureBasicComponents-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.1">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+               schemaLocation="UBL-QualifiedDataTypes-2.1.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
+               schemaLocation="UBL-UnqualifiedDataTypes-2.1.xsd"/>
+   <xsd:element name="ReferencedSignatureID" type="ReferencedSignatureIDType"/>
+   <xsd:complexType name="ReferencedSignatureIDType">
+      <xsd:simpleContent>
+         <xsd:extension base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== --><!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-UnqualifiedDataTypes-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-UnqualifiedDataTypes-2.1.xsd
@@ -1,0 +1,553 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            UBL-UnqualifiedDataTypes-2.1.xsd
+  Generated on:      2013-04-20 18:40(UTC)
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+
+  This schema fragment implements UBL unqualified datatypes using core
+  component types with all supplementary components as described in
+  CCTS 2.01 http://www.unece.org/cefact/ebxml/CCTS_V2-01_Final.pdf tables
+  8-1, 8-2 and 8-3.
+
+  Per table 8-3, the graphic, picture, sound and video types are based on
+  "Binary Object. Type" as they are secondary representation terms.
+
+  Per table 8-3, the value, rate and percentage types are based on
+  "Numeric. Type" as they are secondary representation terms.
+
+  Per table 8-3, the name type is based on "Text. Type" as it is a 
+  secondary representation term.
+
+  Per XSD lexical constraints, the following unqualified data types 
+  corresponding to core component types and secondary representation terms 
+  are based on XSD types (accordingly, the supplementary component "format" 
+  is not made available for these types):
+
+        Date Time. Type  on  xsd:dateTime
+        Date. Type       on  xsd:date
+        Time. Type       on  xsd:time
+        Indicator. Type  on  xsd:boolean
+
+  Per UBL 2.0 the following supplementary components are restricted to be
+  required rather than optional:
+
+   Amount. Currency. Identifier  as  (AmountType)/@currencyID
+   Binary Object. Mime. Code     as  (BinaryObjectType)/@mimeCode
+   Graphic. Mime. Code           as  (GraphicType)/@mimeCode
+   Picture. Mime. Code           as  (PictureType)/@mimeCode
+   Sound. Mime. Code             as  (SoundType)/@mimeCode
+   Video. Mime. Code             as  (VideoType)/@mimeCode
+   Measure. Unit. Code           as  (MeasureType)/@unitCode
+
+  All other unqualified data types inherit the core component types complete
+  with their supplementary components.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" 
+xmlns:ccts-cct="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
+            xmlns:ccts="urn:un:unece:uncefact:documentation:2" 
+            elementFormDefault="qualified" 
+            attributeFormDefault="unqualified"
+            version="2.1">
+<!-- ===== Imports ===== -->
+  <xsd:import schemaLocation="CCTS_CCT_SchemaModule-2.1.xsd"
+namespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"/>
+<!-- ===== Type Definitions ===== -->
+  <xsd:complexType name="AmountType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT000001</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Amount. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A number of monetary units specified using a given unit of currency.</ccts:Definition>
+        <ccts:RepresentationTermName>Amount</ccts:RepresentationTermName>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:AmountType">
+        <xsd:attribute name="currencyID" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000001-SC2</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Amount. Currency. Identifier</ccts:DictionaryEntryName>
+                 <ccts:Definition>The currency of the amount.</ccts:Definition>
+                 <ccts:ObjectClass>Amount Currency</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                 <ccts:UsageRule>Reference UNECE Rec 9, using 3-letter alphabetic codes.</ccts:UsageRule>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="BinaryObjectType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT000002</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Binary Object. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A set of finite-length sequences of binary octets.</ccts:Definition>
+        <ccts:RepresentationTermName>Binary Object</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000002-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Binary Object. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the binary object.</ccts:Definition>
+                 <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>string</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="GraphicType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT000003</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Graphic. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A diagram, graph, mathematical curve, or similar representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Graphic</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000003-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Graphic. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the graphic object.</ccts:Definition>
+                 <ccts:ObjectClass>Graphic</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="PictureType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT000004</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Picture. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A diagram, graph, mathematical curve, or similar representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Picture</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000004-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Picture. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the picture object.</ccts:Definition>
+                 <ccts:ObjectClass>Picture</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="SoundType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT000005</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Sound. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>An audio representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Sound</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000005-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Sound. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the sound object.</ccts:Definition>
+                 <ccts:ObjectClass>Sound</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="VideoType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT000006</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Video. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A video representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Video</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000006-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Video. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the video object.</ccts:Definition>
+                 <ccts:ObjectClass>Video</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="CodeType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT000007</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Code. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string (letters, figures, or symbols) that for brevity and/or language independence may be used to represent or replace a definitive value or text of an attribute, together with relevant supplementary information.</ccts:Definition>
+        <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+        <ccts:UsageRule>Other supplementary components in the CCT are captured as part of the token and name for the schema module containing the code list and thus, are not declared as attributes. </ccts:UsageRule>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:CodeType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  
+  <xsd:complexType name="DateTimeType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT000008</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Date Time. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A particular point in the progression of time, together with relevant supplementary information.</ccts:Definition>
+        <ccts:RepresentationTermName>Date Time</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+        <ccts:UsageRule>Can be used for a date and/or time.</ccts:UsageRule>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:dateTime"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="DateType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT000009</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Date. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>One calendar day according the Gregorian calendar.</ccts:Definition>
+        <ccts:RepresentationTermName>Date</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:date"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="TimeType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000010</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Time. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>An instance of time that occurs every day.</ccts:Definition>
+        <ccts:RepresentationTermName>Time</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:time"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="IdentifierType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000011</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Identifier. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string to identify and uniquely distinguish one instance of an object in an identification scheme from all other objects in the same scheme, together with relevant supplementary information.</ccts:Definition>
+        <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+        <ccts:UsageRule>Other supplementary components in the CCT are captured as part of the token and name for the schema module containing the identifier list and thus, are not declared as attributes. </ccts:UsageRule>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:IdentifierType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="IndicatorType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000012</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Indicator. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A list of two mutually exclusive Boolean values that express the only possible states of a property.</ccts:Definition>
+        <ccts:RepresentationTermName>Indicator</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:boolean"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="MeasureType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000013</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Measure. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A numeric value determined by measuring an object using a specified unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Measure</ccts:RepresentationTermName>
+        <ccts:PropertyTermName>Type</ccts:PropertyTermName>
+        <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:MeasureType">
+        <xsd:attribute name="unitCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000013-SC2</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Measure. Unit. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The type of unit of measure.</ccts:Definition>
+                 <ccts:ObjectClass>Measure Unit</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Code</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+                 <ccts:UsageRule>Reference UNECE Rec. 20 and X12 355</ccts:UsageRule>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  
+  <xsd:complexType name="NumericType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000014</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Numeric. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Numeric</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="ValueType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000015</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:DictionaryEntryName>Value. Type</ccts:DictionaryEntryName>
+        <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Value</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="PercentType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000016</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:DictionaryEntryName>Percent. Type</ccts:DictionaryEntryName>
+        <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing and is expressed as a percentage. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Percent</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="RateType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000017</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:DictionaryEntryName>Rate. Type</ccts:DictionaryEntryName>
+        <ccts:Definition>A numeric expression of a rate that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Rate</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="QuantityType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000018</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Quantity. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A counted number of non-monetary units, possibly including a fractional part.</ccts:Definition>
+        <ccts:RepresentationTermName>Quantity</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:QuantityType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="TextType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000019</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Text. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string (i.e. a finite set of characters), generally in the form of words of a language.</ccts:Definition>
+        <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:TextType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="NameType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>UBLUDT0000020</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Name. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string that constitutes the distinctive designation of a person, place, thing or concept.</ccts:Definition>
+        <ccts:RepresentationTermName>Name</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:TextType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+</xsd:schema><!-- ===== Copyright Notice ===== --><!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-XAdESv132-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-XAdESv132-2.1.xsd
@@ -1,0 +1,476 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            UBL-XAdESv132-2.1.xsd
+  Generated on:      2011-02-21 17:20(UTC)
+
+  This is a copy of http://uri.etsi.org/01903/v1.3.2/XAdES.xsd modified 
+  only to change the importing URI for the XML DSig schema.
+-->
+<xsd:schema targetNamespace="http://uri.etsi.org/01903/v1.3.2#" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://uri.etsi.org/01903/v1.3.2#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" elementFormDefault="qualified">
+	<xsd:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="UBL-xmldsig-core-schema-2.1.xsd"/>
+	<!-- Start auxiliary types definitions: AnyType, ObjectIdentifierType, 
+EncapsulatedPKIDataType and containers for time-stamp tokens -->
+	<!-- Start AnyType -->
+	<xsd:element name="Any" type="AnyType"/>
+	<xsd:complexType name="AnyType" mixed="true">
+		<xsd:sequence minOccurs="0" maxOccurs="unbounded">
+			<xsd:any namespace="##any" processContents="lax"/>
+		</xsd:sequence>
+		<xsd:anyAttribute namespace="##any"/>
+	</xsd:complexType>
+	<!-- End AnyType -->
+	<!-- Start ObjectIdentifierType-->
+	<xsd:element name="ObjectIdentifier" type="ObjectIdentifierType"/>
+	<xsd:complexType name="ObjectIdentifierType">
+		<xsd:sequence>
+			<xsd:element name="Identifier" type="IdentifierType"/>
+			<xsd:element name="Description" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="DocumentationReferences" type="DocumentationReferencesType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="IdentifierType">
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:anyURI">
+				<xsd:attribute name="Qualifier" type="QualifierType" use="optional"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="QualifierType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="OIDAsURI"/>
+			<xsd:enumeration value="OIDAsURN"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="DocumentationReferencesType">
+		<xsd:sequence maxOccurs="unbounded">
+			<xsd:element name="DocumentationReference" type="xsd:anyURI"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- End ObjectIdentifierType-->
+	<!-- Start EncapsulatedPKIDataType-->
+	<xsd:element name="EncapsulatedPKIData" type="EncapsulatedPKIDataType"/>
+	<xsd:complexType name="EncapsulatedPKIDataType">
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:base64Binary">
+				<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+				<xsd:attribute name="Encoding" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- End EncapsulatedPKIDataType -->
+	<!-- Start time-stamp containers types -->
+	<!-- Start GenericTimeStampType -->
+	<xsd:element name="Include" type="IncludeType"/>
+	<xsd:complexType name="IncludeType">
+		<xsd:attribute name="URI" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="referencedData" type="xsd:boolean" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="ReferenceInfo" type="ReferenceInfoType"/>
+	<xsd:complexType name="ReferenceInfoType">
+		<xsd:sequence>
+			<xsd:element ref="ds:DigestMethod"/>
+			<xsd:element ref="ds:DigestValue"/>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="GenericTimeStampType" abstract="true">
+		<xsd:sequence>
+			<xsd:choice minOccurs="0">
+				<xsd:element ref="Include" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="ReferenceInfo" maxOccurs="unbounded"/>
+			</xsd:choice>
+			<xsd:element ref="ds:CanonicalizationMethod" minOccurs="0"/>
+			<xsd:choice maxOccurs="unbounded">
+				<xsd:element name="EncapsulatedTimeStamp" type="EncapsulatedPKIDataType"/>
+				<xsd:element name="XMLTimeStamp" type="AnyType"/>
+			</xsd:choice>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End GenericTimeStampType -->
+	<!-- Start XAdESTimeStampType -->
+	<xsd:element name="XAdESTimeStamp" type="XAdESTimeStampType"/>
+	<xsd:complexType name="XAdESTimeStampType">
+		<xsd:complexContent>
+			<xsd:restriction base="GenericTimeStampType">
+				<xsd:sequence>
+					<xsd:element ref="Include" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="ds:CanonicalizationMethod" minOccurs="0"/>
+					<xsd:choice maxOccurs="unbounded">
+						<xsd:element name="EncapsulatedTimeStamp" type="EncapsulatedPKIDataType"/>
+						<xsd:element name="XMLTimeStamp" type="AnyType"/>
+					</xsd:choice>
+				</xsd:sequence>
+				<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+			</xsd:restriction>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- End XAdESTimeStampType -->
+	<!-- Start OtherTimeStampType -->
+	<xsd:element name="OtherTimeStamp" type="OtherTimeStampType"/>
+	<xsd:complexType name="OtherTimeStampType">
+		<xsd:complexContent>
+			<xsd:restriction base="GenericTimeStampType">
+				<xsd:sequence>
+					<xsd:element ref="ReferenceInfo" maxOccurs="unbounded"/>
+					<xsd:element ref="ds:CanonicalizationMethod" minOccurs="0"/>
+					<xsd:choice>
+						<xsd:element name="EncapsulatedTimeStamp" type="EncapsulatedPKIDataType"/>
+						<xsd:element name="XMLTimeStamp" type="AnyType"/>
+					</xsd:choice>
+				</xsd:sequence>
+				<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+			</xsd:restriction>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- End OtherTimeStampType -->
+	<!-- End time-stamp containers types -->
+	<!-- End auxiliary types definitions-->
+	<!-- Start container types -->
+	<!-- Start QualifyingProperties -->
+	<xsd:element name="QualifyingProperties" type="QualifyingPropertiesType"/>
+	<xsd:complexType name="QualifyingPropertiesType">
+		<xsd:sequence>
+			<xsd:element name="SignedProperties" type="SignedPropertiesType" minOccurs="0"/>
+			<xsd:element name="UnsignedProperties" type="UnsignedPropertiesType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="Target" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End QualifyingProperties -->
+	<!-- Start SignedProperties-->
+	<xsd:element name="SignedProperties" type="SignedPropertiesType"/>
+	<xsd:complexType name="SignedPropertiesType">
+		<xsd:sequence>
+			<xsd:element name="SignedSignatureProperties" type="SignedSignaturePropertiesType" minOccurs="0"/>
+			<xsd:element name="SignedDataObjectProperties" type="SignedDataObjectPropertiesType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End SignedProperties-->
+	<!-- Start UnsignedProperties-->
+	<xsd:element name="UnsignedProperties" type="UnsignedPropertiesType"/>
+	<xsd:complexType name="UnsignedPropertiesType">
+		<xsd:sequence>
+			<xsd:element name="UnsignedSignatureProperties" type="UnsignedSignaturePropertiesType" minOccurs="0"/>
+			<xsd:element name="UnsignedDataObjectProperties" type="UnsignedDataObjectPropertiesType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End UnsignedProperties-->
+	<!-- Start SignedSignatureProperties-->
+	<xsd:element name="SignedSignatureProperties" type="SignedSignaturePropertiesType"/>
+	<xsd:complexType name="SignedSignaturePropertiesType">
+		<xsd:sequence>
+			<xsd:element name="SigningTime" type="xsd:dateTime" minOccurs="0"/>
+			<xsd:element name="SigningCertificate" type="CertIDListType" minOccurs="0"/>
+			<xsd:element name="SignaturePolicyIdentifier" type="SignaturePolicyIdentifierType" minOccurs="0"/>
+			<xsd:element name="SignatureProductionPlace" type="SignatureProductionPlaceType" minOccurs="0"/>
+			<xsd:element name="SignerRole" type="SignerRoleType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End SignedSignatureProperties-->
+	<!-- Start SignedDataObjectProperties-->
+	<xsd:element name="SignedDataObjectProperties" type="SignedDataObjectPropertiesType"/>
+	<xsd:complexType name="SignedDataObjectPropertiesType">
+		<xsd:sequence>
+			<xsd:element name="DataObjectFormat" type="DataObjectFormatType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="CommitmentTypeIndication" type="CommitmentTypeIndicationType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="AllDataObjectsTimeStamp" type="XAdESTimeStampType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="IndividualDataObjectsTimeStamp" type="XAdESTimeStampType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End SignedDataObjectProperties-->
+	<!-- Start UnsignedSignatureProperties-->
+	<xsd:element name="UnsignedSignatureProperties" type="UnsignedSignaturePropertiesType"/>
+	<xsd:complexType name="UnsignedSignaturePropertiesType">
+		<xsd:choice maxOccurs="unbounded">
+			<xsd:element name="CounterSignature" type="CounterSignatureType"/>
+			<xsd:element name="SignatureTimeStamp" type="XAdESTimeStampType"/>
+			<xsd:element name="CompleteCertificateRefs" type="CompleteCertificateRefsType"/>
+			<xsd:element name="CompleteRevocationRefs" type="CompleteRevocationRefsType"/>
+			<xsd:element name="AttributeCertificateRefs" type="CompleteCertificateRefsType"/>
+			<xsd:element name="AttributeRevocationRefs" type="CompleteRevocationRefsType"/>
+			<xsd:element name="SigAndRefsTimeStamp" type="XAdESTimeStampType"/>
+			<xsd:element name="RefsOnlyTimeStamp" type="XAdESTimeStampType"/>
+			<xsd:element name="CertificateValues" type="CertificateValuesType"/>
+			<xsd:element name="RevocationValues" type="RevocationValuesType"/>
+			<xsd:element name="AttrAuthoritiesCertValues" type="CertificateValuesType"/>
+			<xsd:element name="AttributeRevocationValues" type="RevocationValuesType"/>
+			<xsd:element name="ArchiveTimeStamp" type="XAdESTimeStampType"/>
+			<xsd:any namespace="##other"/>
+		</xsd:choice>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End UnsignedSignatureProperties-->
+	<!-- Start UnsignedDataObjectProperties-->
+	<xsd:element name="UnsignedDataObjectProperties" type="UnsignedDataObjectPropertiesType"/>
+	<xsd:complexType name="UnsignedDataObjectPropertiesType">
+		<xsd:sequence>
+			<xsd:element name="UnsignedDataObjectProperty" type="AnyType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End UnsignedDataObjectProperties-->
+	<!-- Start QualifyingPropertiesReference-->
+	<xsd:element name="QualifyingPropertiesReference" type="QualifyingPropertiesReferenceType"/>
+	<xsd:complexType name="QualifyingPropertiesReferenceType">
+		<xsd:attribute name="URI" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End QualifyingPropertiesReference-->
+	<!-- End container types -->
+	<!-- Start SigningTime element -->
+	<xsd:element name="SigningTime" type="xsd:dateTime"/>
+	<!-- End SigningTime element -->
+	<!-- Start SigningCertificate -->
+	<xsd:element name="SigningCertificate" type="CertIDListType"/>
+	<xsd:complexType name="CertIDListType">
+		<xsd:sequence>
+			<xsd:element name="Cert" type="CertIDType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CertIDType">
+		<xsd:sequence>
+			<xsd:element name="CertDigest" type="DigestAlgAndValueType"/>
+			<xsd:element name="IssuerSerial" type="ds:X509IssuerSerialType"/>
+		</xsd:sequence>
+		<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="DigestAlgAndValueType">
+		<xsd:sequence>
+			<xsd:element ref="ds:DigestMethod"/>
+			<xsd:element ref="ds:DigestValue"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- End SigningCertificate -->
+	<!-- Start SignaturePolicyIdentifier -->
+	<xsd:element name="SignaturePolicyIdentifier" type="SignaturePolicyIdentifierType"/>
+	<xsd:complexType name="SignaturePolicyIdentifierType">
+		<xsd:choice>
+			<xsd:element name="SignaturePolicyId" type="SignaturePolicyIdType"/>
+			<xsd:element name="SignaturePolicyImplied"/>
+		</xsd:choice>
+	</xsd:complexType>
+	<xsd:complexType name="SignaturePolicyIdType">
+		<xsd:sequence>
+			<xsd:element name="SigPolicyId" type="ObjectIdentifierType"/>
+			<xsd:element ref="ds:Transforms" minOccurs="0"/>
+			<xsd:element name="SigPolicyHash" type="DigestAlgAndValueType"/>
+			<xsd:element name="SigPolicyQualifiers" type="SigPolicyQualifiersListType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SigPolicyQualifiersListType">
+		<xsd:sequence>
+			<xsd:element name="SigPolicyQualifier" type="AnyType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="SPURI" type="xsd:anyURI"/>
+	<xsd:element name="SPUserNotice" type="SPUserNoticeType"/>
+	<xsd:complexType name="SPUserNoticeType">
+		<xsd:sequence>
+			<xsd:element name="NoticeRef" type="NoticeReferenceType" minOccurs="0"/>
+			<xsd:element name="ExplicitText" type="xsd:string" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="NoticeReferenceType">
+		<xsd:sequence>
+			<xsd:element name="Organization" type="xsd:string"/>
+			<xsd:element name="NoticeNumbers" type="IntegerListType"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="IntegerListType">
+		<xsd:sequence>
+			<xsd:element name="int" type="xsd:integer" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- End SignaturePolicyIdentifier -->
+	<!-- Start CounterSignature -->
+	<xsd:element name="CounterSignature" type="CounterSignatureType"/>
+	<xsd:complexType name="CounterSignatureType">
+		<xsd:sequence>
+			<xsd:element ref="ds:Signature"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- End CounterSignature -->
+	<!-- Start DataObjectFormat -->
+	<xsd:element name="DataObjectFormat" type="DataObjectFormatType"/>
+	<xsd:complexType name="DataObjectFormatType">
+		<xsd:sequence>
+			<xsd:element name="Description" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="ObjectIdentifier" type="ObjectIdentifierType" minOccurs="0"/>
+			<xsd:element name="MimeType" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="Encoding" type="xsd:anyURI" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="ObjectReference" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+	<!-- End DataObjectFormat -->
+	<!-- Start CommitmentTypeIndication -->
+	<xsd:element name="CommitmentTypeIndication" type="CommitmentTypeIndicationType"/>
+	<xsd:complexType name="CommitmentTypeIndicationType">
+		<xsd:sequence>
+			<xsd:element name="CommitmentTypeId" type="ObjectIdentifierType"/>
+			<xsd:choice>
+				<xsd:element name="ObjectReference" type="xsd:anyURI" maxOccurs="unbounded"/>
+				<xsd:element name="AllSignedDataObjects"/>
+			</xsd:choice>
+			<xsd:element name="CommitmentTypeQualifiers" type="CommitmentTypeQualifiersListType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CommitmentTypeQualifiersListType">
+		<xsd:sequence>
+			<xsd:element name="CommitmentTypeQualifier" type="AnyType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- End CommitmentTypeIndication -->
+	<!-- Start SignatureProductionPlace -->
+	<xsd:element name="SignatureProductionPlace" type="SignatureProductionPlaceType"/>
+	<xsd:complexType name="SignatureProductionPlaceType">
+		<xsd:sequence>
+			<xsd:element name="City" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="StateOrProvince" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="PostalCode" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="CountryName" type="xsd:string" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- End SignatureProductionPlace -->
+	<!-- Start SignerRole -->
+	<xsd:element name="SignerRole" type="SignerRoleType"/>
+	<xsd:complexType name="SignerRoleType">
+		<xsd:sequence>
+			<xsd:element name="ClaimedRoles" type="ClaimedRolesListType" minOccurs="0"/>
+			<xsd:element name="CertifiedRoles" type="CertifiedRolesListType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ClaimedRolesListType">
+		<xsd:sequence>
+			<xsd:element name="ClaimedRole" type="AnyType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CertifiedRolesListType">
+		<xsd:sequence>
+			<xsd:element name="CertifiedRole" type="EncapsulatedPKIDataType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- End SignerRole -->
+	<xsd:element name="AllDataObjectsTimeStamp" type="XAdESTimeStampType"/>
+	<xsd:element name="IndividualDataObjectsTimeStamp" type="XAdESTimeStampType"/>
+	<xsd:element name="SignatureTimeStamp" type="XAdESTimeStampType"/>
+	<!-- Start CompleteCertificateRefs -->
+	<xsd:element name="CompleteCertificateRefs" type="CompleteCertificateRefsType"/>
+	<xsd:complexType name="CompleteCertificateRefsType">
+		<xsd:sequence>
+			<xsd:element name="CertRefs" type="CertIDListType"/>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End CompleteCertificateRefs -->
+	<!-- Start CompleteRevocationRefs-->
+	<xsd:element name="CompleteRevocationRefs" type="CompleteRevocationRefsType"/>
+	<xsd:complexType name="CompleteRevocationRefsType">
+		<xsd:sequence>
+			<xsd:element name="CRLRefs" type="CRLRefsType" minOccurs="0"/>
+			<xsd:element name="OCSPRefs" type="OCSPRefsType" minOccurs="0"/>
+			<xsd:element name="OtherRefs" type="OtherCertStatusRefsType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="CRLRefsType">
+		<xsd:sequence>
+			<xsd:element name="CRLRef" type="CRLRefType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CRLRefType">
+		<xsd:sequence>
+			<xsd:element name="DigestAlgAndValue" type="DigestAlgAndValueType"/>
+			<xsd:element name="CRLIdentifier" type="CRLIdentifierType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CRLIdentifierType">
+		<xsd:sequence>
+			<xsd:element name="Issuer" type="xsd:string"/>
+			<xsd:element name="IssueTime" type="xsd:dateTime"/>
+			<xsd:element name="Number" type="xsd:integer" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="OCSPRefsType">
+		<xsd:sequence>
+			<xsd:element name="OCSPRef" type="OCSPRefType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="OCSPRefType">
+		<xsd:sequence>
+			<xsd:element name="OCSPIdentifier" type="OCSPIdentifierType"/>
+			<xsd:element name="DigestAlgAndValue" type="DigestAlgAndValueType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ResponderIDType">
+		<xsd:choice>
+			<xsd:element name="ByName" type="xsd:string"/>
+			<xsd:element name="ByKey" type="xsd:base64Binary"/>
+		</xsd:choice>
+	</xsd:complexType>
+	<xsd:complexType name="OCSPIdentifierType">
+		<xsd:sequence>
+			<xsd:element name="ResponderID" type="ResponderIDType"/>
+			<xsd:element name="ProducedAt" type="xsd:dateTime"/>
+		</xsd:sequence>
+		<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="OtherCertStatusRefsType">
+		<xsd:sequence>
+			<xsd:element name="OtherRef" type="AnyType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- End CompleteRevocationRefs-->
+	<xsd:element name="AttributeCertificateRefs" type="CompleteCertificateRefsType"/>
+	<xsd:element name="AttributeRevocationRefs" type="CompleteRevocationRefsType"/>
+	<xsd:element name="SigAndRefsTimeStamp" type="XAdESTimeStampType"/>
+	<xsd:element name="RefsOnlyTimeStamp" type="XAdESTimeStampType"/>
+	<!-- Start CertificateValues -->
+	<xsd:element name="CertificateValues" type="CertificateValuesType"/>
+	<xsd:complexType name="CertificateValuesType">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="EncapsulatedX509Certificate" type="EncapsulatedPKIDataType"/>
+			<xsd:element name="OtherCertificate" type="AnyType"/>
+		</xsd:choice>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<!-- End CertificateValues -->
+	<!-- Start RevocationValues-->
+	<xsd:element name="RevocationValues" type="RevocationValuesType"/>
+	<xsd:complexType name="RevocationValuesType">
+		<xsd:sequence>
+			<xsd:element name="CRLValues" type="CRLValuesType" minOccurs="0"/>
+			<xsd:element name="OCSPValues" type="OCSPValuesType" minOccurs="0"/>
+			<xsd:element name="OtherValues" type="OtherCertStatusValuesType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="CRLValuesType">
+		<xsd:sequence>
+			<xsd:element name="EncapsulatedCRLValue" type="EncapsulatedPKIDataType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="OCSPValuesType">
+		<xsd:sequence>
+			<xsd:element name="EncapsulatedOCSPValue" type="EncapsulatedPKIDataType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="OtherCertStatusValuesType">
+		<xsd:sequence>
+			<xsd:element name="OtherValue" type="AnyType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- End RevocationValues-->
+	<xsd:element name="AttrAuthoritiesCertValues" type="CertificateValuesType"/>
+	<xsd:element name="AttributeRevocationValues" type="RevocationValuesType"/>
+	<xsd:element name="ArchiveTimeStamp" type="XAdESTimeStampType"/>
+</xsd:schema>

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-XAdESv141-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-XAdESv141-2.1.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            UBL-XAdESv141-2.1.xsd
+  Generated on:      2011-02-21 17:20(UTC)
+
+  This is a copy of http://uri.etsi.org/01903/v1.4.1/XAdESv141.xsd modified
+  only to change the importing URI for the XAdES v1.3.2 schema.
+-->
+<xsd:schema targetNamespace="http://uri.etsi.org/01903/v1.4.1#" xmlns="http://uri.etsi.org/01903/v1.4.1#" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" elementFormDefault="qualified">
+	<xsd:import namespace="http://uri.etsi.org/01903/v1.3.2#" schemaLocation="UBL-XAdESv132-2.1.xsd"/>
+	<!-- Start CertificateValues -->
+	<xsd:element name="TimeStampValidationData" type="ValidationDataType"/>
+	<xsd:complexType name="ValidationDataType">
+		<xsd:sequence>
+			<xsd:element ref="xades:CertificateValues" minOccurs="0" />
+			<xsd:element ref="xades:RevocationValues" minOccurs="0" />
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="UR" type="xsd:anyURI" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="ArchiveTimeStampV2" type="xades:XAdESTimeStampType"/>
+</xsd:schema>

--- a/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-xmldsig-core-schema-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/common/UBL-xmldsig-core-schema-2.1.xsd
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            UBL-xmldsig-core-schema-2.1.xsd
+  Generated on:      2010-08-13 19:10(UTC)
+
+  This is a copy of http://www.w3.org/TR/xmldsig-core/xmldsig-core-schema.xsd
+  modified only to remove these PUBLIC and SYSTEM identifiers from the DOCTYPE:
+
+        PUBLIC "-//W3C//DTD XMLSchema 200102//EN" 
+               "http://www.w3.org/2001/XMLSchema.dtd"
+-->
+<!DOCTYPE schema
+ [
+   <!ATTLIST schema 
+     xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
+   <!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
+   <!ENTITY % p ''>
+   <!ENTITY % s ''>
+  ]>
+
+<!-- Schema for XML Signatures
+    http://www.w3.org/2000/09/xmldsig#
+    $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $
+
+    Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+    of Technology, Institut National de Recherche en Informatique et en
+    Automatique, Keio University). All Rights Reserved.
+    http://www.w3.org/Consortium/Legal/
+
+    This document is governed by the W3C Software License [1] as described
+    in the FAQ [2].
+
+    [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+-->
+
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+        targetNamespace="http://www.w3.org/2000/09/xmldsig#"
+        version="0.1" elementFormDefault="qualified"> 
+
+<!-- Basic Types Defined for Signatures -->
+
+<simpleType name="CryptoBinary">
+  <restriction base="base64Binary">
+  </restriction>
+</simpleType>
+
+<!-- Start Signature -->
+
+<element name="Signature" type="ds:SignatureType"/>
+<complexType name="SignatureType">
+  <sequence> 
+    <element ref="ds:SignedInfo"/> 
+    <element ref="ds:SignatureValue"/> 
+    <element ref="ds:KeyInfo" minOccurs="0"/> 
+    <element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/> 
+  </sequence>  
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="SignatureValue" type="ds:SignatureValueType"/> 
+  <complexType name="SignatureValueType">
+    <simpleContent>
+      <extension base="base64Binary">
+        <attribute name="Id" type="ID" use="optional"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+
+<!-- Start SignedInfo -->
+
+<element name="SignedInfo" type="ds:SignedInfoType"/>
+<complexType name="SignedInfoType">
+  <sequence> 
+    <element ref="ds:CanonicalizationMethod"/> 
+    <element ref="ds:SignatureMethod"/> 
+    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+  </sequence>  
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+  <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType"/> 
+  <complexType name="CanonicalizationMethodType" mixed="true">
+    <sequence>
+      <any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+  <element name="SignatureMethod" type="ds:SignatureMethodType"/>
+  <complexType name="SignatureMethodType" mixed="true">
+    <sequence>
+      <element name="HMACOutputLength" minOccurs="0" type="ds:HMACOutputLengthType"/>
+      <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) external namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+<!-- Start Reference -->
+
+<element name="Reference" type="ds:ReferenceType"/>
+<complexType name="ReferenceType">
+  <sequence> 
+    <element ref="ds:Transforms" minOccurs="0"/> 
+    <element ref="ds:DigestMethod"/> 
+    <element ref="ds:DigestValue"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="URI" type="anyURI" use="optional"/> 
+  <attribute name="Type" type="anyURI" use="optional"/> 
+</complexType>
+
+  <element name="Transforms" type="ds:TransformsType"/>
+  <complexType name="TransformsType">
+    <sequence>
+      <element ref="ds:Transform" maxOccurs="unbounded"/>  
+    </sequence>
+  </complexType>
+
+  <element name="Transform" type="ds:TransformType"/>
+  <complexType name="TransformType" mixed="true">
+    <choice minOccurs="0" maxOccurs="unbounded"> 
+      <any namespace="##other" processContents="lax"/>
+      <!-- (1,1) elements from (0,unbounded) namespaces -->
+      <element name="XPath" type="string"/> 
+    </choice>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+<!-- End Reference -->
+
+<element name="DigestMethod" type="ds:DigestMethodType"/>
+<complexType name="DigestMethodType" mixed="true"> 
+  <sequence>
+    <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>    
+  <attribute name="Algorithm" type="anyURI" use="required"/> 
+</complexType>
+
+<element name="DigestValue" type="ds:DigestValueType"/>
+<simpleType name="DigestValueType">
+  <restriction base="base64Binary"/>
+</simpleType>
+
+<!-- End SignedInfo -->
+
+<!-- Start KeyInfo -->
+
+<element name="KeyInfo" type="ds:KeyInfoType"/> 
+<complexType name="KeyInfoType" mixed="true">
+  <choice maxOccurs="unbounded">     
+    <element ref="ds:KeyName"/> 
+    <element ref="ds:KeyValue"/> 
+    <element ref="ds:RetrievalMethod"/> 
+    <element ref="ds:X509Data"/> 
+    <element ref="ds:PGPData"/> 
+    <element ref="ds:SPKIData"/>
+    <element ref="ds:MgmtData"/>
+    <any processContents="lax" namespace="##other"/>
+    <!-- (1,1) elements from (0,unbounded) namespaces -->
+  </choice>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+  <element name="KeyName" type="string"/>
+  <element name="MgmtData" type="string"/>
+
+  <element name="KeyValue" type="ds:KeyValueType"/> 
+  <complexType name="KeyValueType" mixed="true">
+   <choice>
+     <element ref="ds:DSAKeyValue"/>
+     <element ref="ds:RSAKeyValue"/>
+     <any namespace="##other" processContents="lax"/>
+   </choice>
+  </complexType>
+
+  <element name="RetrievalMethod" type="ds:RetrievalMethodType"/> 
+  <complexType name="RetrievalMethodType">
+    <sequence>
+      <element ref="ds:Transforms" minOccurs="0"/> 
+    </sequence>  
+    <attribute name="URI" type="anyURI"/>
+    <attribute name="Type" type="anyURI" use="optional"/>
+  </complexType>
+
+<!-- Start X509Data -->
+
+<element name="X509Data" type="ds:X509DataType"/> 
+<complexType name="X509DataType">
+  <sequence maxOccurs="unbounded">
+    <choice>
+      <element name="X509IssuerSerial" type="ds:X509IssuerSerialType"/>
+      <element name="X509SKI" type="base64Binary"/>
+      <element name="X509SubjectName" type="string"/>
+      <element name="X509Certificate" type="base64Binary"/>
+      <element name="X509CRL" type="base64Binary"/>
+      <any namespace="##other" processContents="lax"/>
+    </choice>
+  </sequence>
+</complexType>
+
+<complexType name="X509IssuerSerialType"> 
+  <sequence> 
+    <element name="X509IssuerName" type="string"/> 
+    <element name="X509SerialNumber" type="integer"/> 
+  </sequence>
+</complexType>
+
+<!-- End X509Data -->
+
+<!-- Begin PGPData -->
+
+<element name="PGPData" type="ds:PGPDataType"/> 
+<complexType name="PGPDataType"> 
+  <choice>
+    <sequence>
+      <element name="PGPKeyID" type="base64Binary"/> 
+      <element name="PGPKeyPacket" type="base64Binary" minOccurs="0"/> 
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+    <sequence>
+      <element name="PGPKeyPacket" type="base64Binary"/> 
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+  </choice>
+</complexType>
+
+<!-- End PGPData -->
+
+<!-- Begin SPKIData -->
+
+<element name="SPKIData" type="ds:SPKIDataType"/> 
+<complexType name="SPKIDataType">
+  <sequence maxOccurs="unbounded">
+    <element name="SPKISexp" type="base64Binary"/>
+    <any namespace="##other" processContents="lax" minOccurs="0"/>
+  </sequence>
+</complexType> 
+
+<!-- End SPKIData -->
+
+<!-- End KeyInfo -->
+
+<!-- Start Object (Manifest, SignatureProperty) -->
+
+<element name="Object" type="ds:ObjectType"/> 
+<complexType name="ObjectType" mixed="true">
+  <sequence minOccurs="0" maxOccurs="unbounded">
+    <any namespace="##any" processContents="lax"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="MimeType" type="string" use="optional"/> <!-- add a grep facet -->
+  <attribute name="Encoding" type="anyURI" use="optional"/> 
+</complexType>
+
+<element name="Manifest" type="ds:ManifestType"/> 
+<complexType name="ManifestType">
+  <sequence>
+    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+<element name="SignatureProperties" type="ds:SignaturePropertiesType"/> 
+<complexType name="SignaturePropertiesType">
+  <sequence>
+    <element ref="ds:SignatureProperty" maxOccurs="unbounded"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+   <element name="SignatureProperty" type="ds:SignaturePropertyType"/> 
+   <complexType name="SignaturePropertyType" mixed="true">
+     <choice maxOccurs="unbounded">
+       <any namespace="##other" processContents="lax"/>
+       <!-- (1,1) elements from (1,unbounded) namespaces -->
+     </choice>
+     <attribute name="Target" type="anyURI" use="required"/> 
+     <attribute name="Id" type="ID" use="optional"/> 
+   </complexType>
+
+<!-- End Object (Manifest, SignatureProperty) -->
+
+<!-- Start Algorithm Parameters -->
+
+<simpleType name="HMACOutputLengthType">
+  <restriction base="integer"/>
+</simpleType>
+
+<!-- Start KeyValue Element-types -->
+
+<element name="DSAKeyValue" type="ds:DSAKeyValueType"/>
+<complexType name="DSAKeyValueType">
+  <sequence>
+    <sequence minOccurs="0">
+      <element name="P" type="ds:CryptoBinary"/>
+      <element name="Q" type="ds:CryptoBinary"/>
+    </sequence>
+    <element name="G" type="ds:CryptoBinary" minOccurs="0"/>
+    <element name="Y" type="ds:CryptoBinary"/>
+    <element name="J" type="ds:CryptoBinary" minOccurs="0"/>
+    <sequence minOccurs="0">
+      <element name="Seed" type="ds:CryptoBinary"/>
+      <element name="PgenCounter" type="ds:CryptoBinary"/>
+    </sequence>
+  </sequence>
+</complexType>
+
+<element name="RSAKeyValue" type="ds:RSAKeyValueType"/>
+<complexType name="RSAKeyValueType">
+  <sequence>
+    <element name="Modulus" type="ds:CryptoBinary"/> 
+    <element name="Exponent" type="ds:CryptoBinary"/> 
+  </sequence>
+</complexType> 
+
+<!-- End KeyValue Element-types -->
+
+<!-- End Signature -->
+
+</schema>

--- a/data/kosit/bis/resources/ubl/2.1/xsd/maindoc/UBL-CreditNote-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/maindoc/UBL-CreditNote-2.1.xsd
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            xsdrt/maindoc/UBL-CreditNote-2.1.xsd
+  Generated on:      2013-10-31 17:17z
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.1">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+               schemaLocation="../common/UBL-CommonAggregateComponents-2.1.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="../common/UBL-CommonBasicComponents-2.1.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+               schemaLocation="../common/UBL-CommonExtensionComponents-2.1.xsd"/>
+   <xsd:element name="CreditNote" type="CreditNoteType"/>
+   <xsd:complexType name="CreditNoteType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UBLVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileExecutionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CreditNoteTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DocumentCurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxCurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PricingCurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentCurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentAlternativeCurrencyCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineCountNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuyerReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DiscrepancyResponse" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OrderReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:StatementDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginatorDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AccountingSupplierParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingCustomerParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxRepresentativeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentMeans" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PricingExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentAlternativeExchangeRate"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LegalMonetaryTotal" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:CreditNoteLine" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== --><!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/data/kosit/bis/resources/ubl/2.1/xsd/maindoc/UBL-Invoice-2.1.xsd
+++ b/data/kosit/bis/resources/ubl/2.1/xsd/maindoc/UBL-Invoice-2.1.xsd
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.1 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.1/
+  Release Date:      04 November 2013
+  Module:            xsdrt/maindoc/UBL-Invoice-2.1.xsd
+  Generated on:      2013-10-31 17:17z
+  Copyright (c) OASIS Open 2013. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.1">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+               schemaLocation="../common/UBL-CommonAggregateComponents-2.1.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="../common/UBL-CommonBasicComponents-2.1.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+               schemaLocation="../common/UBL-CommonExtensionComponents-2.1.xsd"/>
+   <xsd:element name="Invoice" type="InvoiceType"/>
+   <xsd:complexType name="InvoiceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UBLVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileExecutionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InvoiceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentCurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxCurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PricingCurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentCurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentAlternativeCurrencyCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineCountNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuyerReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OrderReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:StatementDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginatorDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProjectReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AccountingSupplierParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingCustomerParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxRepresentativeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentMeans" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PrepaidPayment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PricingExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentAlternativeExchangeRate"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WithholdingTaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LegalMonetaryTotal" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoiceLine" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== --><!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/data/kosit/bis/resources/xrechnung-report.xsl
+++ b/data/kosit/bis/resources/xrechnung-report.xsl
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:rep="http://www.xoev.de/de/validator/varl/1"
+    xmlns:s="http://www.xoev.de/de/validator/framework/1/scenarios" 
+    xmlns:in="http://www.xoev.de/de/validator/framework/1/createreportinput"
+    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+    xmlns:html="http://www.w3.org/1999/xhtml"
+    xmlns:ubl="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" 
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+    xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+    exclude-result-prefixes="xs"
+    version="2.0">
+
+    <xsl:import href="./default-report.xsl"/>
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <!-- Überschrieben (default-report.xsl) -->
+    <xsl:template name="documentData">
+        <rep:documentData>
+            <xsl:for-each select="
+                $input-document/*/cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:RegistrationName, 
+                $input-document/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:Name">
+                <seller>
+                    <xsl:value-of select="."/>
+                </seller>
+            </xsl:for-each>
+            
+            <xsl:for-each select="
+                $input-document/*/cbc:ID,
+                $input-document/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID">
+                <id>
+                    <xsl:value-of select="."/>
+                </id>
+            </xsl:for-each>
+            
+            <xsl:for-each select="$input-document/*/cbc:IssueDate,
+                $input-document/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:IssueDateTime/udt:DateTimeString">
+                <issueDate>
+                    <xsl:value-of select="."/>
+                </issueDate>
+            </xsl:for-each>
+        </rep:documentData>
+    </xsl:template>
+
+    <!-- Overridden from default-report.xsl -->
+    <xsl:template name="html:documentData" xmlns="http://www.w3.org/1999/xhtml" >
+        <dl>
+            <xsl:for-each select="/rep:report/rep:scenarioMatched/rep:documentData/seller">
+                <dt>Erkannter Rechnungssteller:</dt>
+                <dd>
+                    <xsl:value-of select="."/>
+                </dd>
+            </xsl:for-each>
+            
+            <xsl:for-each select="/rep:report/rep:scenarioMatched/rep:documentData/id">
+                <dt>Erkannte Rechnungsnummer:</dt>
+                <dd>
+                    <xsl:value-of select="."/>
+                </dd>
+            </xsl:for-each>
+            
+            <xsl:for-each select="/rep:report/rep:scenarioMatched/rep:documentData/issueDate">
+                <dt>Erkanntes Rechnungsdatum:</dt>
+                <dd>
+                    <xsl:value-of select="."/>
+                </dd>
+            </xsl:for-each>
+        </dl>
+    </xsl:template>
+    
+    
+    
+    
+
+
+        
+</xsl:stylesheet>

--- a/data/kosit/bis/scenarios.xml
+++ b/data/kosit/bis/scenarios.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- THIS is the source file for creating scenarios.xml-->
+<scenarios xmlns="http://www.xoev.de/de/validator/framework/1/scenarios" frameworkVersion="1.0.0">
+  <name>Prüftool-Konfiguration Peppol BIS</name>
+  <author>KoSIT</author>
+  <date>2025-05-22</date>
+  <description>
+    <p>Prüfung von Dokumenten auf Konformität zum Standard Peppol BIS 3.0.19 (Mai 2025)</p>
+    <p>Diese Konfiguration enthält ausschließlich Peppol Rechnungs-Prüfungen und keine XRechnungs-Prüfungen</p>
+  </description>
+
+  <scenario>
+    <name>Peppol Billing BIS 3 - UBL Invoice</name>
+    <description>
+      <p>Validierung von UBL Invoice version 2.1</p>
+      <p>Dieses Scenario enthält:
+- XML Schema UBL v2.1 Invoice
+- Schematron-Regeln EN16931:2017
+- Schematron-Regeln Peppol Billing v3.0.19
+      </p>
+    </description>
+    <namespace prefix="cbc">urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2</namespace>
+    <namespace prefix="invoice">urn:oasis:names:specification:ubl:schema:xsd:Invoice-2</namespace>
+    <match>/invoice:Invoice[starts-with(cbc:CustomizationID,'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0')]</match>
+    <validateWithXmlSchema>
+      <resource>
+        <name>XML Schema for UBL 2.1 Invoice</name>
+        <location>resources/ubl/2.1/xsd/maindoc/UBL-Invoice-2.1.xsd</location>
+      </resource>
+    </validateWithXmlSchema>
+    <validateWithSchematron>
+      <resource>
+        <name>Schematron rules for EN16931 (UBL)</name>
+        <location>resources/peppol/billing-bis/3.0.19/CEN-EN16931-UBL.xslt</location>
+      </resource>
+    </validateWithSchematron>
+    <validateWithSchematron>
+      <resource>
+        <name>Schematron rules for Invoice - CIUS Peppol Billing BIS (UBL)</name>
+        <location>resources/peppol/billing-bis/3.0.19/PEPPOL-EN16931-UBL.xslt</location>
+      </resource>
+    </validateWithSchematron>
+    <createReport>
+      <resource>
+        <name>Validation report for Peppol Billing BIS</name>
+        <location>resources/xrechnung-report.xsl</location>
+      </resource>
+    </createReport>
+  </scenario>
+  
+  <scenario>
+    <name>Peppol Billing BIS 3 - UBL CreditNote</name>
+    <description>
+      <p>Validierung von UBL CreditNote version 2.1</p>
+      <p>Dieses Scenario enthält:
+- XML Schema UBL v2.1 CreditNote
+- Schematron-Regeln EN16931:2017
+- Schematron-Regeln Peppol Billing v3.0.19
+      </p>
+    </description>
+    <namespace prefix="cbc">urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2</namespace>
+    <namespace prefix="creditnote">urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2</namespace>
+    <match>/creditnote:CreditNote[starts-with(cbc:CustomizationID,'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0')]</match>
+    <validateWithXmlSchema>
+      <resource>
+        <name>XML Schema for UBL 2.1 CreditNote</name>
+        <location>resources/ubl/2.1/xsd/maindoc/UBL-CreditNote-2.1.xsd</location>
+      </resource>
+    </validateWithXmlSchema>
+    <validateWithSchematron>
+      <resource>
+        <name>Schematron rules for EN16931 (UBL)</name>
+        <location>resources/peppol/billing-bis/3.0.19/CEN-EN16931-UBL.xslt</location>
+      </resource>
+    </validateWithSchematron>
+    <validateWithSchematron>
+      <resource>
+        <name>Schematron rules for CreditNote - CIUS Peppol Billing BIS (UBL)</name>
+        <location>resources/peppol/billing-bis/3.0.19/PEPPOL-EN16931-UBL.xslt</location>
+      </resource>
+    </validateWithSchematron>
+    <createReport>
+      <resource>
+        <name>Prüfbericht für Peppol Billing BIS</name>
+        <location>resources/xrechnung-report.xsl</location>
+      </resource>
+    </createReport>
+  </scenario>
+	
+	<!-- end peppol billing bis -->
+  <noScenarioReport>
+    <resource>
+      <name>Default Report</name>
+      <location>resources/default-report.xsl</location>
+    </resource>
+  </noScenarioReport>
+</scenarios>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,5 @@ services:
       - APP_SECRET=${APP_SECRET}
       - DEFAULT_SCHEMA=${DEFAULT_SCHEMA}
       - DEFAULT_INVOICE=${DEFAULT_INVOICE}
+      - KOSIT_JAR=/opt/kosit/bin/validator-1.5.2-standalone.jar
+      - KOSIT_CONF_DIR=/data/kosit/bis

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,26 @@
 FROM python:3.12-slim
 
-# Add Java runtime for Schematron (Saxon-HE)
-RUN apt-get update && apt-get install -y --no-install-recommends openjdk-21-jre-headless curl unzip openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+# Java runtime + tools for downloads
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      default-jre-headless curl unzip ca-certificates openssl \
+ && rm -rf /var/lib/apt/lists/*
+
+# KoSIT validator jar will live here
+ENV KOSIT_HOME=/opt/kosit
+RUN mkdir -p $KOSIT_HOME/bin $KOSIT_HOME/conf
+
+# Optional: download a recent validator jar at build time.
+# (You can also mount it via docker-compose volume.)
+ARG KOSIT_VER=1.5.2
+RUN curl -L -o $KOSIT_HOME/bin/validator-${KOSIT_VER}-standalone.jar \
+    https://github.com/itplr-kosit/validator/releases/download/v${KOSIT_VER}/validator-${KOSIT_VER}-standalone.jar
 
 # Put Saxon-HE under /opt/saxon
 RUN mkdir -p /opt/saxon
-# (Codex: download the latest Saxon-HE jar; if you can’t fetch at build time, expect it mounted at runtime)
-# Example (adjust version if needed):
 RUN curl -L -o /opt/saxon/saxon-he.jar https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/12.4/Saxon-HE-12.4.jar
 
+# App
 WORKDIR /app
 COPY app /app
 RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 requests lxml python-dotenv python-multipart zeep


### PR DESCRIPTION
## Summary
- integrate KoSIT validator CLI with new FastAPI endpoints and HTML tab
- include Peppol BIS configuration and Docker Java runtime with validator jar
- document usage of KoSIT validator in README and compose environment

## Testing
- `python3 -m py_compile app/kosit_runner.py app/main.py`
- `pytest` *(command not found)*
- `pip install pytest` *(externally managed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fd40f0f0832b8a532a52ccf48a5a