### PR TITLE
Add validator download script and jar integrity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ java -jar validator-<version>-standalone.jar -s <path>/scenarios.xml -r <repo-di
 
 1. Ensure Java is in the container (`default-jre-headless` installed).  
 2. Provide the **KoSIT validator jar** (e.g. `validator-1.5.2-standalone.jar`) under `/opt/kosit/bin/`. You can:
+   - Run `python tools/fetch_validator.py` to download it automatically, or
    - Download in Dockerfile, or
    - Mount via volume and set `KOSIT_JAR=/opt/kosit/bin/validator-1.5.2-standalone.jar`.
 3. Populate `data/kosit/bis/` with the **Peppol validator configuration** (contains `scenarios.xml` and `resources/**`).  

--- a/app/kosit_runner.py
+++ b/app/kosit_runner.py
@@ -1,4 +1,4 @@
-import os, subprocess, time, pathlib, shlex
+import os, subprocess, time, pathlib, shlex, zipfile
 from typing import Dict
 
 KOSIT_JAR = os.environ.get("KOSIT_JAR") or "/opt/kosit/bin/validator-1.5.2-standalone.jar"
@@ -14,6 +14,8 @@ def run_kosit(invoice_path: str, out_dir: str, html_report: bool = True) -> Dict
 
     if not os.path.exists(KOSIT_JAR):
         return {"ok": False, "error": f"KoSIT jar not found: {KOSIT_JAR}"}
+    if not zipfile.is_zipfile(KOSIT_JAR):
+        return {"ok": False, "error": f"KoSIT jar is corrupt: {KOSIT_JAR}. Re-download using tools/fetch_validator.py"}
     if not os.path.exists(scenarios):
         return {"ok": False, "error": f"scenarios.xml not found at: {scenarios}"}
     if not os.path.exists(invoice_path):

--- a/tools/fetch_validator.py
+++ b/tools/fetch_validator.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Download the KoSIT validator jar.
+
+By default it fetches version 1.5.2 and stores it under
+``/opt/kosit/bin/validator-<version>-standalone.jar``.  The destination
+and version can be overridden via the ``KOSIT_HOME`` and
+``KOSIT_VER`` environment variables respectively.
+"""
+import os, urllib.request
+
+KOSIT_VER = os.environ.get("KOSIT_VER", "1.5.2")
+KOSIT_HOME = os.environ.get("KOSIT_HOME", "/opt/kosit")
+DEST_DIR = os.path.join(KOSIT_HOME, "bin")
+
+os.makedirs(DEST_DIR, exist_ok=True)
+jar_name = f"validator-{KOSIT_VER}-standalone.jar"
+jar_path = os.path.join(DEST_DIR, jar_name)
+url = f"https://github.com/itplr-kosit/validator/releases/download/v{KOSIT_VER}/{jar_name}"
+
+print(f"Downloading KoSIT validator {KOSIT_VER} from {url}")
+urllib.request.urlretrieve(url, jar_path)
+print("Saved to", jar_path)


### PR DESCRIPTION
## Summary
- add script to download KoSIT validator jar
- verify jar is a valid archive before running validation
- document download helper in README

## Testing
- ✅ `python -m py_compile app/kosit_runner.py tools/fetch_validator.py`
- ⚠️ `python tools/fetch_validator.py` (HTTP 404)

------
https://chatgpt.com/codex/tasks/task_e_68b8019ee098832babc9a7f18025e978