### PR TITLE
Add invoice upload and fix validator download

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 import os, logging, base64, uuid, time, json, subprocess
 from datetime import datetime
-from fastapi import FastAPI, Request, Form, Query
+from fastapi import FastAPI, Request, Form, Query, UploadFile, File
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -465,6 +465,17 @@ def fetch_schemas():
         return {"ok": True}
     except Exception as e:
         return {"ok": False, "error": str(e)}
+
+@app.post("/invoice/upload")
+async def invoice_upload(file: UploadFile = File(...)):
+    if not file.filename.lower().endswith(".xml"):
+        return JSONResponse({"ok": False, "error": "Only XML files allowed"}, status_code=400)
+    name = os.path.basename(file.filename)
+    dest = os.path.join(INVOICE_DIR, name)
+    content = await file.read()
+    with open(dest, "wb") as f:
+        f.write(content)
+    return JSONResponse({"ok": True, "path": dest})
 
 @app.get("/invoice/download")
 def invoice_download(path: str):

--- a/app/templates/invoices.html
+++ b/app/templates/invoices.html
@@ -3,6 +3,8 @@
 <h2>Invoices</h2>
 <div class="mb-3">
   <button id="fetchSchemas" class="btn btn-primary">Fetch Schemes</button>
+  <input type="file" id="uploadInput" accept=".xml" style="display:none">
+  <button id="uploadBtn" class="btn btn-secondary">Upload</button>
 </div>
 <table class="table table-striped">
   <thead><tr><th>Name</th><th>Size</th><th>Modified</th><th>Actions</th></tr></thead>
@@ -29,6 +31,21 @@ document.getElementById('fetchSchemas').addEventListener('click', async ()=>{
     alert('Schemas fetched');
   } else {
     alert('Failed: ' + (res.error || ''));
+  }
+});
+document.getElementById('uploadBtn').addEventListener('click', ()=>{
+  document.getElementById('uploadInput').click();
+});
+document.getElementById('uploadInput').addEventListener('change', async ()=>{
+  const fi = document.getElementById('uploadInput');
+  if(!fi.files.length) return;
+  const fd = new FormData();
+  fd.append('file', fi.files[0]);
+  const res = await fetch('/invoice/upload', {method:'POST', body: fd}).then(r=>r.json());
+  if(res.ok){
+    location.reload();
+  } else {
+    alert('Upload failed: ' + (res.error || ''));
   }
 });
 </script>

--- a/tools/fetch_validator.py
+++ b/tools/fetch_validator.py
@@ -6,7 +6,7 @@ By default it fetches version 1.5.2 and stores it under
 and version can be overridden via the ``KOSIT_HOME`` and
 ``KOSIT_VER`` environment variables respectively.
 """
-import os, urllib.request
+import os, urllib.request, zipfile, io
 
 KOSIT_VER = os.environ.get("KOSIT_VER", "1.5.2")
 KOSIT_HOME = os.environ.get("KOSIT_HOME", "/opt/kosit")
@@ -15,8 +15,13 @@ DEST_DIR = os.path.join(KOSIT_HOME, "bin")
 os.makedirs(DEST_DIR, exist_ok=True)
 jar_name = f"validator-{KOSIT_VER}-standalone.jar"
 jar_path = os.path.join(DEST_DIR, jar_name)
-url = f"https://github.com/itplr-kosit/validator/releases/download/v{KOSIT_VER}/{jar_name}"
+zip_name = f"validator-{KOSIT_VER}.zip"
+url = f"https://github.com/itplr-kosit/validator/releases/download/v{KOSIT_VER}/{zip_name}"
 
 print(f"Downloading KoSIT validator {KOSIT_VER} from {url}")
-urllib.request.urlretrieve(url, jar_path)
+with urllib.request.urlopen(url) as resp:
+    data = resp.read()
+with zipfile.ZipFile(io.BytesIO(data)) as z:
+    with z.open(jar_name) as src, open(jar_path, "wb") as dst:
+        dst.write(src.read())
 print("Saved to", jar_path)


### PR DESCRIPTION
## Summary
- allow uploading XML invoices from the Invoices tab and store them in the invoice folder
- fix KoSIT validator fetch script to download and extract the jar from release ZIP

## Testing
- `python -m py_compile app/main.py tools/fetch_validator.py`
- `python tools/fetch_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_68b80467a744832b9909efddc856a62d