### PR TITLE
Use shared data directory for KoSIT validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .env
 /data/config.json
 /data/logs/
+/data/kosit/bin/

--- a/README.md
+++ b/README.md
@@ -476,10 +476,11 @@ java -jar validator-<version>-standalone.jar -s <path>/scenarios.xml -r <repo-di
 ### Setup
 
 1. Ensure Java is in the container (`default-jre-headless` installed).  
-2. Provide the **KoSIT validator jar** (e.g. `validator-1.5.2-standalone.jar`) under `/opt/kosit/bin/`. You can:
-   - Run `python tools/fetch_validator.py` to download it automatically, or
-   - Download in Dockerfile, or
-   - Mount via volume and set `KOSIT_JAR=/opt/kosit/bin/validator-1.5.2-standalone.jar`.
+2. Provide the **KoSIT validator jar** (e.g. `validator-1.5.2-standalone.jar`) under
+   `data/kosit/bin/`. You can:
+   - Run `python tools/fetch_validator.py` to download it automatically (default target).
+   - Download manually and place the jar there.
+   - Override the location via `KOSIT_JAR` (defaults to `/data/kosit/bin/validator-1.5.2-standalone.jar`).
 3. Populate `data/kosit/bis/` with the **Peppol validator configuration** (contains `scenarios.xml` and `resources/**`).  
    - Point `KOSIT_CONF_DIR` to that folder if you change the path.
 

--- a/app/kosit_runner.py
+++ b/app/kosit_runner.py
@@ -1,7 +1,9 @@
 import os, subprocess, time, pathlib, shlex, zipfile
 from typing import Dict
 
-KOSIT_JAR = os.environ.get("KOSIT_JAR") or "/opt/kosit/bin/validator-1.5.2-standalone.jar"
+# Location of the KoSIT validator jar.  Defaults to the jar placed under the
+# shared /data volume so that it can be updated without rebuilding the image.
+KOSIT_JAR = os.environ.get("KOSIT_JAR") or "/data/kosit/bin/validator-1.5.2-standalone.jar"
 KOSIT_CONF_DIR = os.environ.get("KOSIT_CONF_DIR") or "/data/kosit/bis"
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -120,7 +120,9 @@ def schematron_validate(invoice_xml: str = Form(...), ruleset_path: str = Form(.
 def kosit_page():
     invoices = _list_invoices()
     conf = {
-        "jar": os.environ.get("KOSIT_JAR", "/opt/kosit/bin/validator-1.5.2-standalone.jar"),
+        # Default jar path points to the shared /data volume so the validator
+        # can be updated without rebuilding the container image.
+        "jar": os.environ.get("KOSIT_JAR", "/data/kosit/bin/validator-1.5.2-standalone.jar"),
         "conf_dir": os.environ.get("KOSIT_CONF_DIR", "/data/kosit/bis")
     }
     return env.get_template("kosit.html").render(invoices=invoices, conf=conf)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,7 @@ services:
       - APP_SECRET=${APP_SECRET}
       - DEFAULT_SCHEMA=${DEFAULT_SCHEMA}
       - DEFAULT_INVOICE=${DEFAULT_INVOICE}
-      - KOSIT_JAR=/opt/kosit/bin/validator-1.5.2-standalone.jar
+      # Validator jar lives under the /data volume so it can be updated
+      # without rebuilding the container image.
+      - KOSIT_JAR=/data/kosit/bin/validator-1.5.2-standalone.jar
       - KOSIT_CONF_DIR=/data/kosit/bis

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,15 +6,8 @@ RUN apt-get update \
       default-jre-headless curl unzip ca-certificates openssl \
  && rm -rf /var/lib/apt/lists/*
 
-# KoSIT validator jar will live here
-ENV KOSIT_HOME=/opt/kosit
-RUN mkdir -p $KOSIT_HOME/bin $KOSIT_HOME/conf
-
-# Optional: download a recent validator jar at build time.
-# (You can also mount it via docker-compose volume.)
-ARG KOSIT_VER=1.5.2
-RUN curl -L -o $KOSIT_HOME/bin/validator-${KOSIT_VER}-standalone.jar \
-    https://github.com/itplr-kosit/validator/releases/download/v${KOSIT_VER}/validator-${KOSIT_VER}-standalone.jar
+# KoSIT validator jar is expected to be provided via the /data volume at runtime
+# (see docker-compose). The image itself does not bundle the validator jar.
 
 # Put Saxon-HE under /opt/saxon
 RUN mkdir -p /opt/saxon

--- a/tools/fetch_validator.py
+++ b/tools/fetch_validator.py
@@ -2,14 +2,15 @@
 """Download the KoSIT validator jar.
 
 By default it fetches version 1.5.2 and stores it under
-``/opt/kosit/bin/validator-<version>-standalone.jar``.  The destination
-and version can be overridden via the ``KOSIT_HOME`` and
-``KOSIT_VER`` environment variables respectively.
+``data/kosit/bin/validator-<version>-standalone.jar`` relative to the
+repository root. The destination and version can be overridden via the
+``KOSIT_HOME`` and ``KOSIT_VER`` environment variables respectively.
 """
 import os, urllib.request, zipfile, io
 
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 KOSIT_VER = os.environ.get("KOSIT_VER", "1.5.2")
-KOSIT_HOME = os.environ.get("KOSIT_HOME", "/opt/kosit")
+KOSIT_HOME = os.environ.get("KOSIT_HOME", os.path.join(BASE_DIR, "data", "kosit"))
 DEST_DIR = os.path.join(KOSIT_HOME, "bin")
 
 os.makedirs(DEST_DIR, exist_ok=True)


### PR DESCRIPTION
## Summary
- Store KoSIT validator jar under `data/kosit/bin` so it can be managed via the shared volume.
- Point application and docker-compose to the new jar path and drop bundling the jar in the Docker image.
- Document the new setup and ignore downloaded validator jars.

## Testing
- `python3 -m py_compile app/kosit_runner.py app/main.py tools/fetch_validator.py`
- `python3 tools/fetch_validator.py`
- `KOSIT_JAR=$(pwd)/data/kosit/bin/validator-1.5.2-standalone.jar KOSIT_CONF_DIR=$(pwd)/data/kosit/bis python3 -c "from app.kosit_runner import run_kosit; import json; print(json.dumps(run_kosit('data/samples/einvoice_reference.xml', '/tmp/out'), indent=2))"`

------
https://chatgpt.com/codex/tasks/task_e_68b80bc31f80832b8bc233b9b93620da