### PR TITLE
Fix invoice page crash without reference invoice

### DIFF
--- a/app/ubl.py
+++ b/app/ubl.py
@@ -97,7 +97,12 @@ def parse_invoice_to_form(xml_bytes: bytes) -> Dict[str, Any]:
 
 def read_reference_invoice(path: str) -> Dict[str, Any]:
     if not os.path.exists(path):
-        return {}
+        minimal_invoice = (
+            b"<Invoice xmlns='urn:oasis:names:specification:ubl:schema:xsd:Invoice-2' "
+            b"xmlns:cac='urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2' "
+            b"xmlns:cbc='urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2'></Invoice>"
+        )
+        return parse_invoice_to_form(minimal_invoice)
     with open(path, "rb") as f:
         return parse_invoice_to_form(f.read())
 


### PR DESCRIPTION
## Summary
- avoid template failure when default invoice file is missing by providing a minimal invoice structure

## Testing
- `python -m py_compile app/ubl.py`
- `python - <<'PY'
import os, sys
os.environ['DEFAULT_INVOICE']='/nonexistent.xml'
os.chdir('app')
import main
from starlette.testclient import TestClient
client = TestClient(main.app)
response = client.get('/invoice')
print('status', response.status_code)
print('body_start', response.text[:80])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b99b9e26c4832b912d30e7d7039ffd